### PR TITLE
[tools] fix Commissioner THCI dependency on pexpect

### DIFF
--- a/tools/commissioner_thci/commissioner_impl.py
+++ b/tools/commissioner_thci/commissioner_impl.py
@@ -166,13 +166,13 @@ class OTCommissioner(ICommissioner):
         else:
             self._handler.terminate(force=True)
 
-    @classmethod
+    @staticmethod
     def make_local_commissioner(config, simulator):
         import pexpect
         handler = pexpect.spawn("/bin/bash")
         return OTCommissioner(config, handler, simulator)
 
-    @classmethod
+    @staticmethod
     def make_harness_commissioner(config, serial_handler):
         if not isinstance(serial_handler, serial.Serial):
             raise commissioner.Error("expect a serial handler")

--- a/tools/commissioner_thci/commissioner_impl.py
+++ b/tools/commissioner_thci/commissioner_impl.py
@@ -45,7 +45,6 @@ import logging
 import binascii
 import sys
 import os
-import pexpect
 
 import commissioner
 
@@ -169,11 +168,12 @@ class OTCommissioner(ICommissioner):
 
     @classmethod
     def make_local_commissioner(config, simulator):
+        import pexpect
         handler = pexpect.spawn("/bin/bash")
         return OTCommissioner(config, handler, simulator)
 
     @classmethod
-    def make_remote_commissioner(config, serial_handler):
+    def make_harness_commissioner(config, serial_handler):
         if not isinstance(serial_handler, serial.Serial):
             raise commissioner.Error("expect a serial handler")
         return OTCommissioner(config, serial_handler)

--- a/tools/commissioner_thci/commissioner_impl.py
+++ b/tools/commissioner_thci/commissioner_impl.py
@@ -167,13 +167,13 @@ class OTCommissioner(ICommissioner):
             self._handler.terminate(force=True)
 
     @staticmethod
-    def make_local_commissioner(config, simulator):
+    def makeLocalCommissioner(config, simulator):
         import pexpect
         handler = pexpect.spawn("/bin/bash")
         return OTCommissioner(config, handler, simulator)
 
     @staticmethod
-    def make_harness_commissioner(config, serial_handler):
+    def makeHarnessCommissioner(config, serial_handler):
         if not isinstance(serial_handler, serial.Serial):
             raise commissioner.Error("expect a serial handler")
         return OTCommissioner(config, serial_handler)


### PR DESCRIPTION
`make_local_commissioner` is for travis tests, `make_harness_commissioner` is for test harness. We don't want to add dependency to test harness.