### PR TITLE
[app] fix destruction of commissioner app

### DIFF
--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -87,11 +87,6 @@ exit:
     return error;
 }
 
-CommissionerApp::~CommissionerApp()
-{
-    mCommissioner->Stop();
-}
-
 Error CommissionerApp::Discover()
 {
     return mCommissioner->Discover(mBorderAgents);

--- a/src/app/commissioner_app.hpp
+++ b/src/app/commissioner_app.hpp
@@ -70,7 +70,7 @@ public:
     using Seconds      = std::chrono::seconds;
 
     static std::shared_ptr<CommissionerApp> Create(const std::string &aConfigFile);
-    ~CommissionerApp();
+    ~CommissionerApp() = default;
 
     // Discover Border Agent on link-local network.
     Error Discover();


### PR DESCRIPTION
This PR fixes the bug that `CommissionerApp` trying to stop the internal commissioner member.

This will result in **segment fault** if creating the `CommissionerApp` instance failed (`mCommissioner` is null), just as reported in issue https://github.com/openthread/ot-commissioner/issues/7.