### PR TITLE
[api] add commissioning handler

### DIFF
--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -216,14 +216,29 @@ public:
     using JoinerInfoRequester = std::function<const JoinerInfo *(JoinerType aType, const ByteArray &aId)>;
 
     /**
-     * The callback indicates a joiner has been successfully commissioned (or not).
+     * The callback provided by vendor (application) to commission a joiner.
      *
-     * @param[in]  aJoinerInfo    A joiner info.
-     * @param[in]  aError         An error indicates whether the commissioning has succeeded.
-     *
-     * @note This will be called when A JOIN_FIN.req has been received.
+     * @param[in]  aJoinerInfo         A joiner info indexing the commissioning joiner.
+     * @param[in]  aVendorName         A human-readable product vendor name string in utf-8 format.
+     * @param[in]  aVendorModel        A human-readable product model string.
+     * @param[in]  aVendorSwVersion    A utf-8 string that specifies the product software version.
+     * @param[in]  aVendorStackVersion A vendor stack version of fixed length (5 bytes). See section
+     *                                 8.10.3.6 of Thread spec for detail.
+     * @param[in]  aProvisioningUrl    A URL encoded as a utf-8 string provided by the Joiner
+     *                                 to communicate to the user which Commissioning application
+     *                                 is best suited to properly provision it to the appropriate
+     *                                 service. Empty if the joiner doesn't provide it.
+     * @param[in]  aVendorData         A product vendor-defined data structure to guide
+     *                                 vendor-specific provisioning. Empty if the joiner doesn't provide it.
+     * @note This will be called when A well-formed JOIN_FIN.req has been received.
      */
-    using CommissioningHandler = std::function<void(const JoinerInfo &aJoinerInfo, Error aError)>;
+    using CommissioningHandler = std::function<bool(const JoinerInfo & aJoinerInfo,
+                                                    const std::string &aVendorName,
+                                                    const std::string &aVendorModel,
+                                                    const std::string &aVendorSwVersion,
+                                                    const ByteArray &  aVendorStackVersion,
+                                                    const std::string &aProvisioningUrl,
+                                                    const ByteArray &  aVendorData)>;
 
     /**
      * @brief Create an instance of the commissioner.
@@ -261,6 +276,8 @@ public:
      * @brief Set the joiner commissioning handler.
      *
      * @param[in] aCommissioningHandler  A joiner commissioning handler. nullable.
+     *
+     * @note The default behavior of not providing this handler is always accepting.
      *
      */
     virtual void SetCommissioningHandler(CommissioningHandler aCommissioningHandler) = 0;

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -208,13 +208,22 @@ public:
     /**
      * The function request user information of given joiner.
      *
-     * @param[out] aInfo    A information of given joiner.
      * @param[in]  aType    A joiner type.
      * @param[in]  aId      A joiner ID.
      *
      * @return the associated joiner info.
      */
     using JoinerInfoRequester = std::function<const JoinerInfo *(JoinerType aType, const ByteArray &aId)>;
+
+    /**
+     * The callback indicates a joiner has been successfully commissioned (or not).
+     *
+     * @param[in]  aJoinerInfo    A joiner info.
+     * @param[in]  aError         An error indicates whether the commissioning has succeeded.
+     *
+     * @note This will be called when A JOIN_FIN.req has been received.
+     */
+    using CommissioningHandler = std::function<void(const JoinerInfo &aJoinerInfo, Error aError)>;
 
     /**
      * @brief Create an instance of the commissioner.
@@ -247,6 +256,14 @@ public:
      *                                  If null, it equals to always returning failure.
      */
     virtual void SetJoinerInfoRequester(JoinerInfoRequester aJoinerInfoRequester) = 0;
+
+    /**
+     * @brief Set the joiner commissioning handler.
+     *
+     * @param[in] aCommissioningHandler  A joiner commissioning handler. nullable.
+     *
+     */
+    virtual void SetCommissioningHandler(CommissioningHandler aCommissioningHandler) = 0;
 
     /**
      * @brief Start the commissioner event loop.

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -230,7 +230,11 @@ public:
      *                                 service. Empty if the joiner doesn't provide it.
      * @param[in]  aVendorData         A product vendor-defined data structure to guide
      *                                 vendor-specific provisioning. Empty if the joiner doesn't provide it.
+     *
+     * @return  A boolean indicates whether the joiner is accepted.
+     *
      * @note This will be called when A well-formed JOIN_FIN.req has been received.
+     *
      */
     using CommissioningHandler = std::function<bool(const JoinerInfo & aJoinerInfo,
                                                     const std::string &aVendorName,

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -281,7 +281,8 @@ public:
      *
      * @param[in] aCommissioningHandler  A joiner commissioning handler. nullable.
      *
-     * @note The default behavior of not providing this handler is always accepting.
+     * @note A joiner will be rejected if this handler is not provided
+     *       while the joiner requires vendor-specific provision.
      *
      */
     virtual void SetCommissioningHandler(CommissioningHandler aCommissioningHandler) = 0;

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -45,6 +45,28 @@ namespace ot {
 
 namespace commissioner {
 
+/**
+ * The default commissioning handler that always accepts any joiner.
+ *
+ */
+static bool DefaultCommissioningHandler(const JoinerInfo & aJoinerInfo,
+                                        const std::string &aVendorName,
+                                        const std::string &aVendorModel,
+                                        const std::string &aVendorSwVersion,
+                                        const ByteArray &  aVendorStackVersion,
+                                        const std::string &aProvisioningUrl,
+                                        const ByteArray &  aVendorData) {
+    (void)aJoinerInfo;
+    (void)aVendorName;
+    (void)aVendorModel;
+    (void)aVendorSwVersion;
+    (void)aVendorStackVersion;
+    (void)aProvisioningUrl;
+    (void)aVendorData;
+
+    return true;
+}
+
 std::shared_ptr<CommissionerApp> CommissionerApp::Create(const std::string &aConfigFile)
 {
     Error     error = Error::kNone;
@@ -83,8 +105,8 @@ Error CommissionerApp::Init(const AppConfig &aAppConfig)
     mCommissioner->SetJoinerInfoRequester(
         [this](JoinerType aType, const ByteArray &aJoinerId) { return GetJoinerInfo(aType, aJoinerId); });
 
-    // Do not provide commissioning handler to always accept a joiner.
     // This is the default behavior of OpenThread on-Mesh Commissioner.
+    mCommissioner->SetCommissioningHandler(DefaultCommissioningHandler);
 
 exit:
     return error;

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -83,6 +83,9 @@ Error CommissionerApp::Init(const AppConfig &aAppConfig)
     mCommissioner->SetJoinerInfoRequester(
         [this](JoinerType aType, const ByteArray &aJoinerId) { return GetJoinerInfo(aType, aJoinerId); });
 
+    // Do not provide commissioning handler to always accept a joiner.
+    // This is the default behavior of OpenThread on-Mesh Commissioner.
+
 exit:
     return error;
 }

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -55,7 +55,8 @@ static bool DefaultCommissioningHandler(const JoinerInfo & aJoinerInfo,
                                         const std::string &aVendorSwVersion,
                                         const ByteArray &  aVendorStackVersion,
                                         const std::string &aProvisioningUrl,
-                                        const ByteArray &  aVendorData) {
+                                        const ByteArray &  aVendorData)
+{
     (void)aJoinerInfo;
     (void)aVendorName;
     (void)aVendorModel;

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -159,6 +159,7 @@ CommissionerImpl::CommissionerImpl(struct event_base *aEventBase)
     , mPanIdConflictHandler(nullptr)
     , mEnergyReportHandler(nullptr)
     , mJoinerInfoRequester(nullptr)
+    , mCommissioningHandler(nullptr)
 {
     mBrClient.AddResource(mResourceUdpRx);
     mBrClient.AddResource(mResourceRlyRx);
@@ -268,6 +269,11 @@ const Config &CommissionerImpl::GetConfig() const
 void CommissionerImpl::SetJoinerInfoRequester(JoinerInfoRequester aJoinerInfoRequester)
 {
     mJoinerInfoRequester = aJoinerInfoRequester;
+}
+
+void CommissionerImpl::SetCommissioningHandler(CommissioningHandler aCommissioningHandler)
+{
+    mCommissioningHandler = aCommissioningHandler;
 }
 
 Error CommissionerImpl::Start()

--- a/src/library/commissioner_impl.hpp
+++ b/src/library/commissioner_impl.hpp
@@ -80,6 +80,7 @@ public:
     const Config &GetConfig() const override;
 
     void SetJoinerInfoRequester(JoinerInfoRequester aJoinerInfoRequester) override;
+    void SetCommissioningHandler(CommissioningHandler aCommissioningHandler) override;
 
     uint16_t GetSessionId() const override;
 
@@ -297,6 +298,7 @@ private:
     EnergyReportHandler  mEnergyReportHandler;
 
     JoinerInfoRequester mJoinerInfoRequester;
+    CommissioningHandler mCommissioningHandler;
 };
 
 /*

--- a/src/library/commissioner_impl.hpp
+++ b/src/library/commissioner_impl.hpp
@@ -297,7 +297,7 @@ private:
     PanIdConflictHandler mPanIdConflictHandler;
     EnergyReportHandler  mEnergyReportHandler;
 
-    JoinerInfoRequester mJoinerInfoRequester;
+    JoinerInfoRequester  mJoinerInfoRequester;
     CommissioningHandler mCommissioningHandler;
 };
 

--- a/src/library/commissioner_safe.cpp
+++ b/src/library/commissioner_safe.cpp
@@ -537,6 +537,12 @@ void CommissionerSafe::SetJoinerInfoRequester(JoinerInfoRequester aJoinerInfoReq
 }
 
 // It is not safe to call this after starting the commissioner.
+void CommissionerSafe::SetCommissioningHandler(CommissioningHandler aCommissioningHandler)
+{
+    mImpl.SetCommissioningHandler(aCommissioningHandler);
+}
+
+// It is not safe to call this after starting the commissioner.
 void CommissionerSafe::SetDatasetChangedHandler(ErrorHandler aHandler)
 {
     mImpl.SetDatasetChangedHandler(aHandler);

--- a/src/library/commissioner_safe.hpp
+++ b/src/library/commissioner_safe.hpp
@@ -76,6 +76,7 @@ public:
     const Config &GetConfig() const override;
 
     void SetJoinerInfoRequester(JoinerInfoRequester aJoinerInfoRequester) override;
+    void SetCommissioningHandler(CommissioningHandler aCommissioningHandler) override;
 
     uint16_t GetSessionId() const override;
 

--- a/src/library/commissioning_session.cpp
+++ b/src/library/commissioning_session.cpp
@@ -206,8 +206,8 @@ void CommissioningSession::HandleJoinFin(const coap::Request &aJoinFin)
     }
     else
     {
-        // Accepts a joiner if there is no vendor-specific provisioning.
-        accepted = true;
+        // Accepts a joiner if requirement on vendor-specific provisioning.
+        accepted = provisioningUrl.empty();
     }
 
 exit:

--- a/src/library/commissioning_session.cpp
+++ b/src/library/commissioning_session.cpp
@@ -206,6 +206,7 @@ void CommissioningSession::HandleJoinFin(const coap::Request &aJoinFin)
     }
     else
     {
+        // Accepts a joiner if there is no vendor-specific provisioning.
         accepted = true;
     }
 

--- a/src/library/commissioning_session.cpp
+++ b/src/library/commissioning_session.cpp
@@ -152,13 +152,17 @@ exit:
 
 void CommissioningSession::HandleJoinFin(const coap::Request &aJoinFin)
 {
-    Error       error = Error::kNone;
+    bool        accepted = false;
+    Error       error    = Error::kNone;
     tlv::TlvSet tlvSet;
     tlv::TlvPtr stateTlv              = nullptr;
     tlv::TlvPtr vendorNameTlv         = nullptr;
     tlv::TlvPtr vendorModelTlv        = nullptr;
     tlv::TlvPtr vendorSwVersionTlv    = nullptr;
     tlv::TlvPtr vendorStackVersionTlv = nullptr;
+
+    std::string provisioningUrl{};
+    ByteArray   vendorData{};
 
     SuccessOrExit(error = GetTlvSet(tlvSet, aJoinFin));
 
@@ -188,6 +192,21 @@ void CommissioningSession::HandleJoinFin(const coap::Request &aJoinFin)
         VerifyOrExit(vendorDataTlv != nullptr, error = Error::kNotFound);
         VerifyOrExit(vendorDataTlv->IsValid(), error = Error::kBadFormat);
         VerifyOrExit(provisioningUrlTlv->GetValueAsString() == mJoinerInfo.mProvisioningUrl, error = Error::kReject);
+
+        provisioningUrl = provisioningUrlTlv->GetValueAsString();
+        vendorData      = vendorDataTlv->GetValue();
+    }
+
+    // Validation done, request commissioning by user.
+    if (mCommImpl.mCommissioningHandler != nullptr)
+    {
+        accepted = mCommImpl.mCommissioningHandler(
+            mJoinerInfo, vendorNameTlv->GetValueAsString(), vendorModelTlv->GetValueAsString(),
+            vendorSwVersionTlv->GetValueAsString(), vendorStackVersionTlv->GetValue(), provisioningUrl, vendorData);
+    }
+    else
+    {
+        accepted = true;
     }
 
 exit:
@@ -196,13 +215,8 @@ exit:
         LOG_WARN("handle JOIN_FIN.req failed: {}", ErrorToString(error));
     }
 
-    SendJoinFinResponse(aJoinFin, error == Error::kNone);
-    LOG_INFO("sent JOIN_FIN.rsp: accepted={}", error == Error::kNone);
-
-    if (mCommImpl.mCommissioningHandler != nullptr)
-    {
-        mCommImpl.mCommissioningHandler(mJoinerInfo, error);
-    }
+    SendJoinFinResponse(aJoinFin, accepted);
+    LOG_INFO("sent JOIN_FIN.rsp: accepted={}", accepted);
 }
 
 Error CommissioningSession::SendJoinFinResponse(const coap::Request &aJoinFinReq, bool aAccept)

--- a/src/library/commissioning_session.cpp
+++ b/src/library/commissioning_session.cpp
@@ -198,6 +198,11 @@ exit:
 
     SendJoinFinResponse(aJoinFin, error == Error::kNone);
     LOG_INFO("sent JOIN_FIN.rsp: accepted={}", error == Error::kNone);
+
+    if (mCommImpl.mCommissioningHandler != nullptr)
+    {
+        mCommImpl.mCommissioningHandler(mJoinerInfo, error);
+    }
 }
 
 Error CommissioningSession::SendJoinFinResponse(const coap::Request &aJoinFinReq, bool aAccept)


### PR DESCRIPTION
This PR adds a new API to notify application that a joiner has been successfully commissioned:
```c++
using CommissioningHandler = std::function<void(const JoinerInfo &aJoinerInfo, Error aError)>;
virtual SetCommissionerHandler(CommissioningHandler aCommissioningHandler) = 0;
```

This addresses issue https://github.com/openthread/ot-commissioner/issues/9.