### PR TITLE
[build] add cmake option to disable building CLI App

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ endif()
 
 option(OT_COMM_COVERAGE "Enable coverage reporting" OFF)
 option(OT_COMM_TEST     "Build tests" ON)
-
+option(OT_COMM_APP      "Build the CLI App" ON)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -48,6 +48,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMBEDTLS_USER_CONFIG_FILE='<${MBEDTLS_U
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMBEDTLS_USER_CONFIG_FILE='<${MBEDTLS_USER_CONFIG}>'")
 
 add_subdirectory(src)
-add_subdirectory(tests)
+
+if (OT_COMM_TEST)
+    add_subdirectory(tests)
+endif()
 add_subdirectory(tools)
 add_subdirectory(third_party EXCLUDE_FROM_ALL)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,8 @@ if (CMAKE_BUILD_TYPE AND OT_COMM_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU
     add_link_options(--coverage)
 endif()
 
-add_subdirectory(app)
+if (OT_COMM_APP)
+    add_subdirectory(app)
+endif()
 add_subdirectory(common)
 add_subdirectory(library)


### PR DESCRIPTION
This PR adds a `OT_COMM_APP`  CMake option to control building of the CLI App. This could be useful when including OT Commissioner in a project as a library.

This PR also fixes the `OT_COMM_TEST` option.