### PR TITLE
[tests] enhance integration test setup for OTBR

### DIFF
--- a/tests/integration/bootstrap.sh
+++ b/tests/integration/bootstrap.sh
@@ -105,7 +105,7 @@ main() {
     set -e
     mkdir -p ${RUNTIME_DIR}
 
-    if [[ $SKIP_BUILDING_OTBR == 0 ]] && [ ! -d ${OTBR} ]; then
+    if (( $SKIP_BUILDING_OTBR == 0 )) && [ ! -d ${OTBR} ]; then
         setup_otbr
     fi
 

--- a/tests/integration/bootstrap.sh
+++ b/tests/integration/bootstrap.sh
@@ -27,11 +27,20 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+## This file bootstrap dependencies of integration tests.
+##
+## Accepted environment variables:
+##   - OT_COMM_SKIP_BUILDING_OTBR  Control if skip building ot-br-posix from source,
+##                                 This is useful when ot-br-posix is pre-installed.
+##
+
 [ -z ${TEST_ROOT_DIR} ] && . $(dirname $0)/common.sh
+
+readonly SKIP_BUILDING_OTBR=${OT_COMM_SKIP_BUILDING_OTBR:=0}
 
 setup_otbr() {
     set -e
-    git clone ${OTBR_REPO} ${OTBR} --branch ${OTBR_BRANCH}
+    git clone ${OTBR_REPO} ${OTBR} --branch ${OTBR_BRANCH} --depth=1
 
     cd ${OTBR}
 
@@ -47,7 +56,7 @@ setup_otbr() {
 
 setup_openthread() {
     set -e
-    git clone ${OPENTHREAD_REPO} ${OPENTHREAD} --branch ${OPENTHREAD_BRANCH}
+    git clone ${OPENTHREAD_REPO} ${OPENTHREAD} --branch ${OPENTHREAD_BRANCH} --depth=1
 
     cd ${OPENTHREAD}
 
@@ -96,7 +105,7 @@ main() {
     set -e
     mkdir -p ${RUNTIME_DIR}
 
-    if [ ! -d ${OTBR} ]; then
+    if [[ $SKIP_BUILDING_OTBR == 0 ]] && [ ! -d ${OTBR} ]; then
         setup_otbr
     fi
 

--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -27,18 +27,20 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+## This file defines constants and common functions for test cases.
+
 readonly CUR_DIR=$(dirname "$(realpath -s $0)")
 readonly TEST_ROOT_DIR=${CUR_DIR}
 
+readonly RUNTIME_DIR=/tmp/test-ot-commissioner
+
 readonly OTBR_REPO=https://github.com/openthread/ot-br-posix
 readonly OTBR_BRANCH=master
-readonly OTBR=${TEST_ROOT_DIR}/ot-br-posix
+readonly OTBR=${RUNTIME_DIR}/ot-br-posix
 
 readonly OPENTHREAD_REPO=https://github.com/openthread/openthread
 readonly OPENTHREAD_BRANCH=master
-readonly OPENTHREAD=${TEST_ROOT_DIR}/openthread
-
-readonly RUNTIME_DIR=${TEST_ROOT_DIR}/tmp
+readonly OPENTHREAD=${RUNTIME_DIR}/openthread
 
 readonly NON_CCM_CLI=${RUNTIME_DIR}/ot-cli-ftd-non-ccm
 readonly NON_CCM_NCP=${RUNTIME_DIR}/ot-ncp-ftd-non-ccm

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -27,6 +27,16 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+## This file is the integration tests driver.
+##
+## Usage:
+##   ./run_tests.sh                   Run all test cases.
+##   ./run_tests.sh <test-case-name>  Run only specific test case.
+##
+## Note: Test cases are functions starting with 'test_' which are located in
+##       'test_*.sh' files.
+##
+
 . $(dirname $0)/test_announce_begin.sh
 . $(dirname $0)/test_discover.sh
 . $(dirname $0)/test_energy_scan.sh


### PR DESCRIPTION
This PR enhances integration test for OTBR by
- provide an environment to skip building OTBR from source.
- reduce git clone by option `--depth=1`.
- change tmp dir to `/tmp/test-ot-commissioner` to keep current dir clean.
- Add file descriptions.

Those changes enable reusing the integration test script in ot-br-posix project.