### PR TITLE
[dtls] refine DTLS state and error handling

### DIFF
--- a/src/library/coap_secure.hpp
+++ b/src/library/coap_secure.hpp
@@ -84,7 +84,7 @@ public:
 
     void Disconnect()
     {
-        mDtlsSession.Disconnect();
+        mDtlsSession.Disconnect(Error::kAbort);
         mCoap.ClearRequestsAndResponses();
     }
 

--- a/src/library/commissioning_session.cpp
+++ b/src/library/commissioning_session.cpp
@@ -89,7 +89,7 @@ exit:
 
 void CommissioningSession::Stop()
 {
-    mDtlsSession->Disconnect();
+    mDtlsSession->Disconnect(Error::kAbort);
 }
 
 Error CommissioningSession::RecvJoinerDtlsRecords(const ByteArray &aRecords)

--- a/src/library/dtls.cpp
+++ b/src/library/dtls.cpp
@@ -99,10 +99,8 @@ static Error ErrorFromMbedtlsError(int mbedtlsError)
     {
         error = Error::kNone;
     }
-    else if (mbedtlsError == MBEDTLS_ERR_SSL_WANT_READ ||
-             mbedtlsError == MBEDTLS_ERR_SSL_WANT_WRITE ||
-             mbedtlsError == MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS ||
-             mbedtlsError == MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS)
+    else if (mbedtlsError == MBEDTLS_ERR_SSL_WANT_READ || mbedtlsError == MBEDTLS_ERR_SSL_WANT_WRITE ||
+             mbedtlsError == MBEDTLS_ERR_SSL_ASYNC_IN_PROGRESS || mbedtlsError == MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS)
     {
         error = Error::kTransportBusy;
     }
@@ -110,10 +108,14 @@ static Error ErrorFromMbedtlsError(int mbedtlsError)
     {
         // Low-level NET error.
         error = Error::kTransportFailed;
-    } else if (highLevelModuleId == 6 || highLevelModuleId == 7) {
+    }
+    else if (highLevelModuleId == 6 || highLevelModuleId == 7)
+    {
         // High-level SSL or CIPHER error.
         error = Error::kSecurity;
-    } else {
+    }
+    else
+    {
         error = Error::kFailed;
     }
 
@@ -413,8 +415,8 @@ exit:
 Error DtlsSession::SetClientTransportId()
 {
     ASSERT(mIsServer && !mIsClientIdSet);
-    Error error = Error::kNone;
-    int   rval = 0;
+    Error error    = Error::kNone;
+    int   rval     = 0;
     auto  peerAddr = GetPeerAddr();
 
     VerifyOrExit(peerAddr.IsValid(), error = Error::kInvalidAddr);

--- a/src/library/dtls.hpp
+++ b/src/library/dtls.hpp
@@ -84,7 +84,6 @@ public:
         kOpen,
         kConnecting,
         kConnected,
-        kDisconnecting,
         kDisconnected,
     };
 
@@ -103,7 +102,7 @@ public:
 
     void  Connect(ConnectHandler aOnConnected);
     Error Bind(const std::string &aBindIp, uint16_t aPort);
-    void  Disconnect();
+    void  Disconnect(Error aError);
 
     State GetState() const { return mState; }
 
@@ -166,6 +165,9 @@ private:
     Error Handshake();
 
     Error SetClientTransportId();
+
+    // Decide if we should stop processing this session by given error.
+    static bool ShouldStop(Error aError);
 
     static int HandleMbedtlsExportKeys(void *               aDtlsSession,
                                        const unsigned char *aMasterSecret,


### PR DESCRIPTION
This PR refines DTLS state and error handling:

- return `Error::kSecurity` for DTLS errors (return `Error::kTransportFailed` for net error)
- unify error casting from mbedtls result
- remove `State::kDisconnecting` state to simplify state transition

This PR addresses [issue#27](https://github.com/openthread/ot-commissioner/issues/27).