### PR TITLE
[error] make error unignorable

### DIFF
--- a/include/commissioner/defines.hpp
+++ b/include/commissioner/defines.hpp
@@ -39,6 +39,12 @@
 #include <cstddef>
 #include <vector>
 
+#if defined(__clang__)
+#define OT_COMM_MUST_USE_RESULT __attribute__((warn_unused_result))
+#else
+#define OT_COMM_MUST_USE_RESULT
+#endif
+
 namespace ot {
 
 namespace commissioner {

--- a/include/commissioner/error.hpp
+++ b/include/commissioner/error.hpp
@@ -36,11 +36,13 @@
 
 #include <string>
 
+#include <commissioner/defines.hpp>
+
 namespace ot {
 
 namespace commissioner {
 
-enum class Error : int
+enum class OT_COMM_MUST_USE_RESULT Error : int
 {
     kNone = 0,        ///< No error.
     kAbort,           ///< A request is aborted.

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -155,7 +155,7 @@ exit:
 
 void CommissionerApp::Stop()
 {
-    mCommissioner->Resign();
+    IgnoreError(mCommissioner->Resign());
 }
 
 void CommissionerApp::AbortRequests()
@@ -1340,18 +1340,19 @@ void CommissionerApp::HandleEnergyReport(const std::string *aPeerAddr,
                                          const ByteArray *  aEnergyList,
                                          Error              aError)
 {
-    if (aError != Error::kNone)
-    {
-        return;
-    }
-
+    Error   error;
     Address addr;
-    addr.Set(*aPeerAddr);
-    ASSERT(addr.IsValid());
+
+    SuccessOrExit(error = aError);
+
+    SuccessOrExit(error = addr.Set(*aPeerAddr));
 
     // Main thread will wait for updates to mPanIdConflicts,
     // which guarantees no concurrent access to it.
     mEnergyReports[addr] = {*aChannelMask, *aEnergyList};
+
+exit:
+    return;
 }
 
 void CommissionerApp::HandleDatasetChanged(Error error)

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -1340,12 +1340,10 @@ void CommissionerApp::HandleEnergyReport(const std::string *aPeerAddr,
                                          const ByteArray *  aEnergyList,
                                          Error              aError)
 {
-    Error   error;
     Address addr;
 
-    SuccessOrExit(error = aError);
-
-    SuccessOrExit(error = addr.Set(*aPeerAddr));
+    SuccessOrExit(aError);
+    SuccessOrExit(addr.Set(*aPeerAddr));
 
     // Main thread will wait for updates to mPanIdConflicts,
     // which guarantees no concurrent access to it.

--- a/src/app/etc/commissioner/non-ccm-config.json
+++ b/src/app/etc/commissioner/non-ccm-config.json
@@ -42,7 +42,8 @@
     // The pre-shared key used to connect to the border agent.
     // The maximum length is 16 bytes.
     // Must be provided if 'EnableCcm' == false.
-    "PSKc" : "3aa55f91ca47d1e4e71a08cb35e91591"
+    // "PSKc" : "3aa55f91ca47d1e4e71a08cb35e91591",
+    "PSKc" :    "00112233445566778899001122334455"
 
     // The private key file in PEM format.
     // Must be provided if 'EnableCcm' == true.

--- a/src/app/etc/commissioner/non-ccm-config.json
+++ b/src/app/etc/commissioner/non-ccm-config.json
@@ -42,8 +42,7 @@
     // The pre-shared key used to connect to the border agent.
     // The maximum length is 16 bytes.
     // Must be provided if 'EnableCcm' == false.
-    // "PSKc" : "3aa55f91ca47d1e4e71a08cb35e91591",
-    "PSKc" :    "00112233445566778899001122334455"
+    "PSKc" : "3aa55f91ca47d1e4e71a08cb35e91591"
 
     // The private key file in PEM format.
     // Must be provided if 'EnableCcm' == true.

--- a/src/app/json.cpp
+++ b/src/app/json.cpp
@@ -55,7 +55,7 @@ template <> struct adl_serializer<ot::commissioner::ByteArray>
     static void from_json(const json &aJson, ot::commissioner::ByteArray &aBuf)
     {
         // FIXME(wgtdkp): handle the failure
-        ot::commissioner::utils::Hex(aBuf, aJson.get<std::string>());
+        IgnoreError(::ot::commissioner::utils::Hex(aBuf, aJson.get<std::string>()));
     }
 };
 } // namespace nlohmann

--- a/src/common/address.cpp
+++ b/src/common/address.cpp
@@ -105,7 +105,8 @@ exit:
 Address Address::FromString(const std::string &aAddr)
 {
     Address ret;
-    ret.Set(aAddr);
+    auto    error = ret.Set(aAddr);
+    ASSERT(error == Error::kNone);
     return ret;
 }
 

--- a/src/common/address.hpp
+++ b/src/common/address.hpp
@@ -77,6 +77,7 @@ public:
 
     Error ToString(std::string &aAddr) const;
 
+    // Invalid address string is not acceptable.
     static Address FromString(const std::string &aAddr);
 
 private:

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -50,13 +50,13 @@
         }                                   \
     } while (false)
 
-#define SuccessOrExit(aError)         \
-    do                                \
-    {                                 \
-        if ((aError) != Error::kNone) \
-        {                             \
-            goto exit;                \
-        }                             \
+#define SuccessOrExit(aError)                             \
+    do                                                    \
+    {                                                     \
+        if ((aError) != ::ot::commissioner::Error::kNone) \
+        {                                                 \
+            goto exit;                                    \
+        }                                                 \
     } while (false)
 
 #define VerifyOrExit(aCondition, ...) \
@@ -74,6 +74,14 @@
     {                \
         __VA_ARGS__; \
         goto exit;   \
+    } while (false)
+
+#define IgnoreError(aError)                               \
+    do                                                    \
+    {                                                     \
+        if ((aError) != ::ot::commissioner::Error::kNone) \
+        {                                                 \
+        }                                                 \
     } while (false)
 
 namespace ot {

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -76,13 +76,10 @@
         goto exit;   \
     } while (false)
 
-#define IgnoreError(aError)                               \
-    do                                                    \
-    {                                                     \
-        if ((aError) != ::ot::commissioner::Error::kNone) \
-        {                                                 \
-        }                                                 \
-    } while (false)
+static inline void IgnoreError(ot::commissioner::Error aError)
+{
+    (void)aError;
+}
 
 namespace ot {
 

--- a/src/library/coap.cpp
+++ b/src/library/coap.cpp
@@ -82,8 +82,6 @@ Error Message::AppendOption(OptionType aNumber, const OptionValue &aValue)
 {
     Error error = Error::kNone;
 
-    // This will silently ignore options with unrecognized
-    // option number and elective options with bad value.
     VerifyOrExit(IsValidOption(aNumber, aValue), error = Error::kInvalidArgs);
 
     if (aNumber == OptionType::kUriPath)
@@ -514,7 +512,7 @@ void Coap::HandleRequest(const Request &aRequest)
     }
     else
     {
-        SendNotFound(aRequest);
+        IgnoreError(SendNotFound(aRequest));
         ExitNow(error = Error::kNotFound);
     }
 
@@ -535,7 +533,7 @@ void Coap::HandleResponse(const Response &aResponse)
     {
         if (aResponse.IsConfirmable() || aResponse.IsNonConfirmable())
         {
-            SendReset(aResponse);
+            IgnoreError(SendReset(aResponse));
         }
         ExitNow();
     }
@@ -578,7 +576,7 @@ void Coap::HandleResponse(const Response &aResponse)
 
     case Type::kConfirmable:
         // Send empty ACK if it is a CON message.
-        SendAck(aResponse);
+        IgnoreError(SendAck(aResponse));
 
         // fall through
 
@@ -996,11 +994,30 @@ std::shared_ptr<Message> Message::Deserialize(Error &aError, const ByteArray &aB
 
         SuccessOrExit(error = Deserialize(number, value, lastOptionNumber, aBuf, offset));
 
-        // Stop if any unrecognized option is critical.
-        // Otherwise, we need to proceed to decoding following options.
-        VerifyOrExit(IsValidOption(number, value) || !IsCriticalOption(number), error = Error::kBadOption);
+        if (IsValidOption(number, value))
+        {
+            // AppendOption will do further validation before adding the option.
+            error = message->AppendOption(number, value);
+        }
+        else
+        {
+            error = Error::kBadFormat;
+        }
 
-        message->AppendOption(number, value);
+        if (error != Error::kNone)
+        {
+            if (IsCriticalOption(number))
+            {
+                // Stop if any unrecognized option is critical.
+                ExitNow(error = Error::kBadOption);
+            }
+            else
+            {
+                // Ignore non-critical option error.
+                error = Error::kNone;
+            }
+        }
+
         lastOptionNumber = utils::to_underlying(number);
     }
 

--- a/src/library/coap.cpp
+++ b/src/library/coap.cpp
@@ -610,7 +610,7 @@ void Coap::Retransmit(Timer &)
             mRequestsCache.Put(requestHolder);
 
             std::string uri;
-            requestHolder.mRequest->GetUriPath(uri);
+            IgnoreError(requestHolder.mRequest->GetUriPath(uri));
 
             // Retransmit
             if (!requestHolder.mAcknowledged)

--- a/src/library/commissioner_safe.cpp
+++ b/src/library/commissioner_safe.cpp
@@ -99,7 +99,7 @@ Error CommissionerSafe::Start()
 
     VerifyOrExit(mEventThread == nullptr, error = Error::kAlready);
 
-    mEventThread = std::make_shared<std::thread>([this]() { mImpl.Start(); });
+    mEventThread = std::make_shared<std::thread>([this]() { IgnoreError(mImpl.Start()); });
 
 exit:
     return error;

--- a/src/library/commissioning_session.cpp
+++ b/src/library/commissioning_session.cpp
@@ -64,7 +64,7 @@ CommissioningSession::CommissioningSession(CommissionerImpl &aCommImpl,
 
     ASSERT(mJoinerSocket->Connect(mSocket) == 0);
     ASSERT(mSocket->Connect(mJoinerSocket) == 0);
-    mCoap.AddResource(mResourceJoinFin);
+    ASSERT(mCoap.AddResource(mResourceJoinFin) == Error::kNone);
 }
 
 Error CommissioningSession::Start(ConnectHandler aOnConnected)
@@ -216,7 +216,7 @@ exit:
         LOG_WARN("handle JOIN_FIN.req failed: {}", ErrorToString(error));
     }
 
-    SendJoinFinResponse(aJoinFin, accepted);
+    IgnoreError(SendJoinFinResponse(aJoinFin, accepted));
     LOG_INFO("sent JOIN_FIN.rsp: accepted={}", accepted);
 }
 
@@ -226,7 +226,7 @@ Error CommissioningSession::SendJoinFinResponse(const coap::Request &aJoinFinReq
     coap::Response joinFin{coap::Type::kAcknowledgment, coap::Code::kChanged};
     SuccessOrExit(error = AppendTlv(joinFin, {tlv::Type::kState, aAccept ? tlv::kStateAccept : tlv::kStateReject}));
 
-    mCoap.SendResponse(aJoinFinReq, joinFin);
+    SuccessOrExit(error = mCoap.SendResponse(aJoinFinReq, joinFin));
 
 exit:
     return error;

--- a/src/library/socket.cpp
+++ b/src/library/socket.cpp
@@ -184,7 +184,7 @@ Address UdpSocket::GetLocalAddr() const
     ASSERT(getsockname(mNetCtx.fd, reinterpret_cast<sockaddr *>(&addr), &len) == 0);
 
     Address ret;
-    ret.Set(addr);
+    ASSERT(ret.Set(addr) == Error::kNone);
     return ret;
 }
 
@@ -209,7 +209,7 @@ Address UdpSocket::GetPeerAddr() const
     ASSERT(getpeername(mNetCtx.fd, reinterpret_cast<sockaddr *>(&addr), &len) == 0);
 
     Address ret;
-    ret.Set(addr);
+    ASSERT(ret.Set(addr) == Error::kNone);
     return ret;
 }
 

--- a/src/library/socket.hpp
+++ b/src/library/socket.hpp
@@ -63,10 +63,10 @@ public:
     virtual Address GetLocalAddr() const = 0;
 
     // Must only be called when the socket has been connect to a valid peer.
-    virtual uint16_t GetPeerPort() const  = 0;
+    virtual uint16_t GetPeerPort() const = 0;
 
     // Must only be called when the socket has been connect to a valid peer.
-    virtual Address GetPeerAddr() const  = 0;
+    virtual Address GetPeerAddr() const = 0;
 
     bool IsConnected() const { return mIsConnected; }
 

--- a/src/library/socket.hpp
+++ b/src/library/socket.hpp
@@ -55,10 +55,18 @@ public:
     Socket &operator=(const Socket &aOther) = delete;
     virtual ~Socket();
 
+    // Must only be called when the socket has valid local port.
+    // For example, it has been bind to a local address and port.
     virtual uint16_t GetLocalPort() const = 0;
-    virtual Address  GetLocalAddr() const = 0;
+
+    // Must only be called when the socket has valid local address.
+    virtual Address GetLocalAddr() const = 0;
+
+    // Must only be called when the socket has been connect to a valid peer.
     virtual uint16_t GetPeerPort() const  = 0;
-    virtual Address  GetPeerAddr() const  = 0;
+
+    // Must only be called when the socket has been connect to a valid peer.
+    virtual Address GetPeerAddr() const  = 0;
 
     bool IsConnected() const { return mIsConnected; }
 

--- a/src/library/udp_proxy.cpp
+++ b/src/library/udp_proxy.cpp
@@ -86,7 +86,7 @@ void ProxyClient::SendEmptyChanged(const coap::Request &aRequest)
     mEndpoint.SetPeerAddr(aRequest.GetEndpoint()->GetPeerAddr());
     mEndpoint.SetPeerPort(aRequest.GetEndpoint()->GetPeerPort());
 
-    mCoap.SendEmptyChanged(aRequest);
+    IgnoreError(mCoap.SendEmptyChanged(aRequest));
 }
 
 /**

--- a/tests/unit/test_coap.cpp
+++ b/tests/unit/test_coap.cpp
@@ -166,7 +166,7 @@ TEST_CASE("coap-message-options", "[coap]")
         ByteArray buffer;
         Error     error = Error::kNone;
 
-        message->SetContentFormat(ContentFormat::kCBOR);
+        REQUIRE(message->SetContentFormat(ContentFormat::kCBOR) == Error::kNone);
         REQUIRE(message->Serialize(buffer) == Error::kNone);
 
         REQUIRE(buffer.size() == 4 + 2);
@@ -344,27 +344,27 @@ TEST_CASE("coap-message-confirmable", "[coap]")
     Coap coap0{eventBase, peer0};
     Coap coap1{eventBase, peer1};
 
-    coap1.AddResource(
-        {"/hello", [&coap1](const Request &aRequest) {
-             REQUIRE(aRequest.IsRequest());
-             REQUIRE(aRequest.GetType() == Type::kConfirmable);
-             REQUIRE(aRequest.GetCode() == Code::kGet);
+    REQUIRE(coap1.AddResource(
+                {"/hello", [&coap1](const Request &aRequest) {
+                     REQUIRE(aRequest.IsRequest());
+                     REQUIRE(aRequest.GetType() == Type::kConfirmable);
+                     REQUIRE(aRequest.GetCode() == Code::kGet);
 
-             ContentFormat contentFormat;
-             REQUIRE(aRequest.GetContentFormat(contentFormat) == Error::kNone);
-             REQUIRE(contentFormat == ContentFormat::kTextPlain);
+                     ContentFormat contentFormat;
+                     REQUIRE(aRequest.GetContentFormat(contentFormat) == Error::kNone);
+                     REQUIRE(contentFormat == ContentFormat::kTextPlain);
 
-             std::string uriPath;
-             REQUIRE(aRequest.GetUriPath(uriPath) == Error::kNone);
-             REQUIRE(uriPath == "/hello");
+                     std::string uriPath;
+                     REQUIRE(aRequest.GetUriPath(uriPath) == Error::kNone);
+                     REQUIRE(uriPath == "/hello");
 
-             REQUIRE(aRequest.GetPayload() == ByteArray{'h', 'e', 'l', 'l', 'o', ',', ' ', 'C', 'o', 'A', 'P'});
+                     REQUIRE(aRequest.GetPayload() == ByteArray{'h', 'e', 'l', 'l', 'o', ',', ' ', 'C', 'o', 'A', 'P'});
 
-             Response response{Type::kAcknowledgment, Code::kContent};
-             REQUIRE(response.SetContentFormat(ContentFormat::kTextPlain) == Error::kNone);
-             response.Append("Ack...");
-             REQUIRE(coap1.SendResponse(aRequest, response) == Error::kNone);
-         }});
+                     Response response{Type::kAcknowledgment, Code::kContent};
+                     REQUIRE(response.SetContentFormat(ContentFormat::kTextPlain) == Error::kNone);
+                     response.Append("Ack...");
+                     REQUIRE(coap1.SendResponse(aRequest, response) == Error::kNone);
+                 }}) == Error::kNone);
 
     SECTION("basic confirmable message send/recv")
     {

--- a/tests/unit/test_coap_secure.cpp
+++ b/tests/unit/test_coap_secure.cpp
@@ -131,7 +131,7 @@ TEST_CASE("coap-secure-basic", "[coaps]")
                           response.Append("world");
                           REQUIRE(coapsServer.SendResponse(aRequest, response) == Error::kNone);
                       }};
-    coapsServer.AddResource(resHello);
+    REQUIRE(coapsServer.AddResource(resHello) == Error::kNone);
 
     auto onServerConnected = [&coapsServer](const DtlsSession &aSession, Error aError) {
         REQUIRE(aError == Error::kNone);

--- a/tests/unit/test_cose.cpp
+++ b/tests/unit/test_cose.cpp
@@ -112,7 +112,7 @@ TEST_CASE("cose-sign-and-verify", "[cose]")
         msg.Free();
 
         REQUIRE(Sign1Message::Deserialize(msg, signature) == Error::kNone);
-        msg.SetExternalData(externalData);
+        REQUIRE(msg.SetExternalData(externalData) == Error::kNone);
         REQUIRE(msg.Validate(publicKey) == Error::kNone);
     }
 


### PR DESCRIPTION
This PR makes error unignorable by applying `warn_unused_result` attribute. 

When a type is annotated with `warn_unused_result` attribute, any function returns the object of this type must explicitly check(or ignore) the return value to get rid of the warning/error.

OT mimics exception with two error handling macros: `verifyOrExit` and `SuccessorExit`. But it is easy for a function calling to ignore the return error silently, resulting in escaped errors. And, when looking at a calling without checking the return error, the reader doesn't know if ignoring error is intentional or because of careless.

I think it is crutial to always explicitly handle (check or ignore) a return error, as Google's famous `Status` class (something like `Error` class here) is not ignorable.

We achieve this by:
- annotate `Error` class with the `warn_unused_result` attribute.
- provide macro `IgnoreError` to explicitly ignore an error when ignoring it is the desired behavior.

This approach can also be migrated to openthread and ot-br-posix.