### PR TITLE
[code] avoid static objects with non-trivial destructor

### DIFF
--- a/src/app/cli/interpreter.cpp
+++ b/src/app/cli/interpreter.cpp
@@ -57,7 +57,7 @@ namespace ot {
 
 namespace commissioner {
 
-const auto &Interpreter::mEvaluatorMap = *new std::map<std::string, Evaluator>{
+const std::map<std::string, Interpreter::Evaluator> &Interpreter::mEvaluatorMap = *new std::map<std::string, Evaluator>{
     {"start", &Interpreter::ProcessStart},
     {"stop", &Interpreter::ProcessStop},
     {"active", &Interpreter::ProcessActive},
@@ -80,7 +80,7 @@ const auto &Interpreter::mEvaluatorMap = *new std::map<std::string, Evaluator>{
     {"help", &Interpreter::ProcessHelp},
 };
 
-const auto &Interpreter::mUsageMap = *new std::map<std::string, std::string>{
+const std::map<std::string, std::string> &Interpreter::mUsageMap = *new std::map<std::string, std::string>{
     {"start", "start <border-agent-addr> <border-agent-port>"},
     {"stop", "stop"},
     {"active", "active"},

--- a/src/app/cli/interpreter.cpp
+++ b/src/app/cli/interpreter.cpp
@@ -57,7 +57,7 @@ namespace ot {
 
 namespace commissioner {
 
-const std::map<std::string, Interpreter::Evaluator> Interpreter::mEvaluatorMap{
+const auto &Interpreter::mEvaluatorMap = *new std::map<std::string, Evaluator>{
     {"start", &Interpreter::ProcessStart},
     {"stop", &Interpreter::ProcessStop},
     {"active", &Interpreter::ProcessActive},
@@ -80,7 +80,7 @@ const std::map<std::string, Interpreter::Evaluator> Interpreter::mEvaluatorMap{
     {"help", &Interpreter::ProcessHelp},
 };
 
-const std::map<std::string, std::string> Interpreter::mUsageMap{
+const auto &Interpreter::mUsageMap = *new std::map<std::string, std::string>{
     {"start", "start <border-agent-addr> <border-agent-port>"},
     {"stop", "stop"},
     {"active", "active"},
@@ -226,8 +226,8 @@ Interpreter::Expression Interpreter::Read()
 
 Interpreter::Value Interpreter::Eval(const Expression &aExpr)
 {
-    Value                                   value;
-    decltype(mEvaluatorMap)::const_iterator evaluator;
+    Value                                            value;
+    std::map<std::string, Evaluator>::const_iterator evaluator;
 
     VerifyOrExit(!aExpr.empty(), value = Error::kNone);
 

--- a/src/app/cli/interpreter.hpp
+++ b/src/app/cli/interpreter.hpp
@@ -122,8 +122,8 @@ private:
 
     bool mShouldExit = false;
 
-    static const std::map<std::string, std::string> mUsageMap;
-    static const std::map<std::string, Evaluator>   mEvaluatorMap;
+    static const std::map<std::string, std::string> &mUsageMap;
+    static const std::map<std::string, Evaluator> &  mEvaluatorMap;
 };
 
 std::string ToLower(const std::string &aStr);

--- a/src/library/uri.hpp
+++ b/src/library/uri.hpp
@@ -45,45 +45,45 @@ namespace uri {
 /*
  * Thread MeshCoP URIs
  */
-static const char *kPetitioning         = "/c/cp";
-static const char *kKeepAlive           = "/c/ca";
-static const char *kUdpRx               = "/c/ur";
-static const char *kUdpTx               = "/c/ut";
-static const char *kRelayRx             = "/c/rx";
-static const char *kRelayTx             = "/c/tx";
-static const char *kMgmtGet             = "/c/mg";
-static const char *kMgmtSet             = "/c/ms";
-static const char *kMgmtCommissionerGet = "/c/cg";
-static const char *kMgmtCommissionerSet = "/c/cs";
-static const char *kMgmtBbrGet          = "/c/bg";
-static const char *kMgmtBbrSet          = "/c/bs";
-static const char *kMgmtActiveGet       = "/c/ag";
-static const char *kMgmtActiveSet       = "/c/as";
-static const char *kMgmtPendingGet      = "/c/pg";
-static const char *kMgmtPendingSet      = "/c/ps";
-static const char *kMgmtDatasetChanged  = "/c/dc";
-static const char *kMgmtAnnounceBegin   = "/c/ab";
-static const char *kMgmtPanidQuery      = "/c/pq";
-static const char *kMgmtPanidConflict   = "/c/pc";
-static const char *kMgmtEdScan          = "/c/es";
-static const char *kMgmtEdReport        = "/c/er";
-static const char *kMgmtReenroll        = "/c/re";
-static const char *kMgmtDomainReset     = "/c/rt";
-static const char *kMgmtNetMigrate      = "/c/nm";
-static const char *kMgmtSecPendingSet   = "/c/sp";
-static const char *kJoinEnt             = "/c/je";
-static const char *kJoinFin             = "/c/jf";
-static const char *kJoinApp             = "/c/ja";
+static const char *const kPetitioning         = "/c/cp";
+static const char *const kKeepAlive           = "/c/ca";
+static const char *const kUdpRx               = "/c/ur";
+static const char *const kUdpTx               = "/c/ut";
+static const char *const kRelayRx             = "/c/rx";
+static const char *const kRelayTx             = "/c/tx";
+static const char *const kMgmtGet             = "/c/mg";
+static const char *const kMgmtSet             = "/c/ms";
+static const char *const kMgmtCommissionerGet = "/c/cg";
+static const char *const kMgmtCommissionerSet = "/c/cs";
+static const char *const kMgmtBbrGet          = "/c/bg";
+static const char *const kMgmtBbrSet          = "/c/bs";
+static const char *const kMgmtActiveGet       = "/c/ag";
+static const char *const kMgmtActiveSet       = "/c/as";
+static const char *const kMgmtPendingGet      = "/c/pg";
+static const char *const kMgmtPendingSet      = "/c/ps";
+static const char *const kMgmtDatasetChanged  = "/c/dc";
+static const char *const kMgmtAnnounceBegin   = "/c/ab";
+static const char *const kMgmtPanidQuery      = "/c/pq";
+static const char *const kMgmtPanidConflict   = "/c/pc";
+static const char *const kMgmtEdScan          = "/c/es";
+static const char *const kMgmtEdReport        = "/c/er";
+static const char *const kMgmtReenroll        = "/c/re";
+static const char *const kMgmtDomainReset     = "/c/rt";
+static const char *const kMgmtNetMigrate      = "/c/nm";
+static const char *const kMgmtSecPendingSet   = "/c/sp";
+static const char *const kJoinEnt             = "/c/je";
+static const char *const kJoinFin             = "/c/jf";
+static const char *const kJoinApp             = "/c/ja";
 
 /*
  * Thread Network Layer URIs
  */
-static const char *kMlr = "/n/mr";
+static const char *const kMlr = "/n/mr";
 
 /*
  * COM_TOK URI
  */
-static const char *kComToken = "/.well-known/ccm";
+static const char *const kComToken = "/.well-known/ccm";
 
 } // namespace uri
 

--- a/src/library/uri.hpp
+++ b/src/library/uri.hpp
@@ -45,45 +45,45 @@ namespace uri {
 /*
  * Thread MeshCoP URIs
  */
-static const std::string kPetitioning         = "/c/cp";
-static const std::string kKeepAlive           = "/c/ca";
-static const std::string kUdpRx               = "/c/ur";
-static const std::string kUdpTx               = "/c/ut";
-static const std::string kRelayRx             = "/c/rx";
-static const std::string kRelayTx             = "/c/tx";
-static const std::string kMgmtGet             = "/c/mg";
-static const std::string kMgmtSet             = "/c/ms";
-static const std::string kMgmtCommissionerGet = "/c/cg";
-static const std::string kMgmtCommissionerSet = "/c/cs";
-static const std::string kMgmtBbrGet          = "/c/bg";
-static const std::string kMgmtBbrSet          = "/c/bs";
-static const std::string kMgmtActiveGet       = "/c/ag";
-static const std::string kMgmtActiveSet       = "/c/as";
-static const std::string kMgmtPendingGet      = "/c/pg";
-static const std::string kMgmtPendingSet      = "/c/ps";
-static const std::string kMgmtDatasetChanged  = "/c/dc";
-static const std::string kMgmtAnnounceBegin   = "/c/ab";
-static const std::string kMgmtPanidQuery      = "/c/pq";
-static const std::string kMgmtPanidConflict   = "/c/pc";
-static const std::string kMgmtEdScan          = "/c/es";
-static const std::string kMgmtEdReport        = "/c/er";
-static const std::string kMgmtReenroll        = "/c/re";
-static const std::string kMgmtDomainReset     = "/c/rt";
-static const std::string kMgmtNetMigrate      = "/c/nm";
-static const std::string kMgmtSecPendingSet   = "/c/sp";
-static const std::string kJoinEnt             = "/c/je";
-static const std::string kJoinFin             = "/c/jf";
-static const std::string kJoinApp             = "/c/ja";
+static const char *kPetitioning         = "/c/cp";
+static const char *kKeepAlive           = "/c/ca";
+static const char *kUdpRx               = "/c/ur";
+static const char *kUdpTx               = "/c/ut";
+static const char *kRelayRx             = "/c/rx";
+static const char *kRelayTx             = "/c/tx";
+static const char *kMgmtGet             = "/c/mg";
+static const char *kMgmtSet             = "/c/ms";
+static const char *kMgmtCommissionerGet = "/c/cg";
+static const char *kMgmtCommissionerSet = "/c/cs";
+static const char *kMgmtBbrGet          = "/c/bg";
+static const char *kMgmtBbrSet          = "/c/bs";
+static const char *kMgmtActiveGet       = "/c/ag";
+static const char *kMgmtActiveSet       = "/c/as";
+static const char *kMgmtPendingGet      = "/c/pg";
+static const char *kMgmtPendingSet      = "/c/ps";
+static const char *kMgmtDatasetChanged  = "/c/dc";
+static const char *kMgmtAnnounceBegin   = "/c/ab";
+static const char *kMgmtPanidQuery      = "/c/pq";
+static const char *kMgmtPanidConflict   = "/c/pc";
+static const char *kMgmtEdScan          = "/c/es";
+static const char *kMgmtEdReport        = "/c/er";
+static const char *kMgmtReenroll        = "/c/re";
+static const char *kMgmtDomainReset     = "/c/rt";
+static const char *kMgmtNetMigrate      = "/c/nm";
+static const char *kMgmtSecPendingSet   = "/c/sp";
+static const char *kJoinEnt             = "/c/je";
+static const char *kJoinFin             = "/c/jf";
+static const char *kJoinApp             = "/c/ja";
 
 /*
  * Thread Network Layer URIs
  */
-static const std::string kMlr = "/n/mr";
+static const char *kMlr = "/n/mr";
 
 /*
  * COM_TOK URI
  */
-static const std::string kComToken = "/.well-known/ccm";
+static const char *kComToken = "/.well-known/ccm";
 
 } // namespace uri
 


### PR DESCRIPTION
This PR removes eliminates static objects with non-trivial destructor. This is to resolve the out-of-order destruction issue of those static object which may leading to bad access to already destructed objects.