### PR TITLE
[petition] return ID of existing active commissioner if one exists

### DIFF
--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -160,7 +160,7 @@ public:
     /**
      * The response handler of a general TMF request.
      *
-     * @param[in] aError  A error code.
+     * @param[in] aError  An error code.
      */
     using ErrorHandler = std::function<void(Error aError)>;
 
@@ -168,7 +168,7 @@ public:
      * The response handler of a general TMF request.
      *
      * @param[in] aResponseData  A response data. nullable.
-     * @param[in] aError         A error code.
+     * @param[in] aError         An error code.
      *
      * @note @p aResponseData is guaranteed to be not null only when @p aError == Error::kNone.
      *       Otherwise, @p aResponseData should never be accessed.
@@ -178,13 +178,13 @@ public:
     /**
      * The petition result handler.
      *
-     * @param[in] aActiveCommissionerId  A active commissioner Id. nullable.
-     * @param[in] aError                 A error code.
+     * @param[in] aExistingCommissionerId  The Existing commissioner Id. nullable.
+     * @param[in] aError                   An error code.
      *
-     * @note There is another active commissioner if @p aError != Error::kNone
-     *       and @p aActiveCommissionerId is not null.
+     * @note There is an exiting active commissioner if @p aError != Error::kNone
+     *       and @p aExistingCommissionerId is not null.
      */
-    using PetitionHandler = std::function<void(const std::string *aActiveCommissionerId, Error aError)>;
+    using PetitionHandler = std::function<void(const std::string *aExistingCommissionerId, Error aError)>;
 
     /**
      * The MGMT_PANID_CONFLICT.ans handler.
@@ -192,7 +192,7 @@ public:
      * @param[in] aPeerAddr     A peer address that sent this MGMT_PANID_CONFLICT.ans request.
      * @param[in] aChannelMask  A channel mask the peer scanned at.
      * @param[in] aPanId        A PAN ID that has a conflict.
-     * @param[in] aError        A error code.
+     * @param[in] aError        An error code.
      *
      * @note @p aPeerAddr, aChannelMask and aPanId are guaranteed to
      *       be not null only when @p aError == Error::kNone. Otherwise,
@@ -207,7 +207,7 @@ public:
      * @param[in] aPeerAddr     A peer address that sent this MGMT_PANID_CONFLICT.ans request.
      * @param[in] aChannelMask  A channel mask the peer scanned at.
      * @param[in] aEnergyList   A list of measured energy level in dBm.
-     * @param[in] aError        A error code.
+     * @param[in] aError        An error code.
      *
      * @note @p aPeerAddr, aChannelMask and aEnergyList are guaranteed to
      *       be not null only when @p aError == Error::kNone. Otherwise,
@@ -442,13 +442,18 @@ public:
      * If succeed, a keep-alive message will be periodically sent to keep itself active.
      * It will not return until errors happened, timeouted or succeed.
      *
-     * @param[out] aActiveCommissionerId  A Commissioner ID of an already active commissioner.
-     * @param[in]  aAddr                  A border agent address.
-     * @param[in]  aPort                  A border agent port.
+     * @param[out] aExistingCommissionerId  The existing active commissioner ID.
+     * @param[in]  aAddr                    A border agent address.
+     * @param[in]  aPort                    A border agent port.
      *
      * @return Error::kNone, succeed; otherwise, failed;
+     *
+     * @note @p aExistingCommissionerId is valid only when return value
+     *       is not Error::kNone and itself is not empty. Otherwise,
+     *       its content should never be accessed.
+     *
      */
-    virtual Error Petition(std::string &aActiveCommissionerId, const std::string &aAddr, uint16_t aPort) = 0;
+    virtual Error Petition(std::string &aExistingCommissionerId, const std::string &aAddr, uint16_t aPort) = 0;
 
     /**
      * @brief Asynchronously resign from the commissioner role.

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -173,7 +173,18 @@ public:
      * @note @p aResponseData is guaranteed to be not null only when @p aError == Error::kNone.
      *       Otherwise, @p aResponseData should never be accessed.
      */
-    template <class T> using Handler = std::function<void(const T *aResponseData, Error aError)>;
+    template <typename T> using Handler = std::function<void(const T *aResponseData, Error aError)>;
+
+    /**
+     * The petition result handler.
+     *
+     * @param[in] aActiveCommissionerId  A active commissioner Id. nullable.
+     * @param[in] aError                 A error code.
+     *
+     * @note There is another active commissioner if @p aError != Error::kNone
+     *       and @p aActiveCommissionerId is not null.
+     */
+    using PetitionHandler = std::function<void(const std::string *aActiveCommissionerId, Error aError)>;
 
     /**
      * The MGMT_PANID_CONFLICT.ans handler.
@@ -422,7 +433,7 @@ public:
      *
      * @note The commissioner will be first connected to the network if it is not.
      */
-    virtual void Petition(ErrorHandler aHandler, const std::string &aAddr, uint16_t aPort) = 0;
+    virtual void Petition(PetitionHandler aHandler, const std::string &aAddr, uint16_t aPort) = 0;
 
     /**
      * @brief Synchronously petition to a Thread network.
@@ -431,12 +442,13 @@ public:
      * If succeed, a keep-alive message will be periodically sent to keep itself active.
      * It will not return until errors happened, timeouted or succeed.
      *
-     * @param[in] aAddr  A border agent address.
-     * @param[in] aPort  A border agent port.
+     * @param[out] aActiveCommissionerId  A Commissioner ID of an already active commissioner.
+     * @param[in]  aAddr                  A border agent address.
+     * @param[in]  aPort                  A border agent port.
      *
      * @return Error::kNone, succeed; otherwise, failed;
      */
-    virtual Error Petition(const std::string &aAddr, uint16_t aPort) = 0;
+    virtual Error Petition(std::string &aActiveCommissionerId, const std::string &aAddr, uint16_t aPort) = 0;
 
     /**
      * @brief Asynchronously resign from the commissioner role.

--- a/include/commissioner/error.hpp
+++ b/include/commissioner/error.hpp
@@ -65,7 +65,7 @@ enum class Error : int
 /**
  * @brief Convert Error to printable string.
  *
- * @param aError  A error code.
+ * @param aError  An error code.
  *
  * @return The printable string of the error.
  */

--- a/src/app/cli/interpreter.cpp
+++ b/src/app/cli/interpreter.cpp
@@ -316,17 +316,17 @@ Interpreter::Value Interpreter::ProcessStart(const Expression &aExpr)
 {
     Error       error = Error::kInvalidArgs;
     std::string msg;
-    std::string activeCommissionerId;
+    std::string existingCommissionerId;
     uint16_t    port;
 
     VerifyOrExit(aExpr.size() >= 3, msg = Usage(aExpr));
     SuccessOrExit(ParseInteger(port, aExpr[2]), msg = aExpr[2]);
-    SuccessOrExit(error = mCommissioner->Start(activeCommissionerId, aExpr[1], port));
+    SuccessOrExit(error = mCommissioner->Start(existingCommissionerId, aExpr[1], port));
 
 exit:
-    if (!activeCommissionerId.empty())
+    if (!existingCommissionerId.empty())
     {
-        msg = "there is already an active commissioner: " + activeCommissionerId;
+        msg = "there is an existing active commissioner: " + existingCommissionerId;
     }
     return {error, msg};
 }

--- a/src/app/cli/interpreter.cpp
+++ b/src/app/cli/interpreter.cpp
@@ -316,13 +316,18 @@ Interpreter::Value Interpreter::ProcessStart(const Expression &aExpr)
 {
     Error       error = Error::kInvalidArgs;
     std::string msg;
+    std::string activeCommissionerId;
     uint16_t    port;
 
     VerifyOrExit(aExpr.size() >= 3, msg = Usage(aExpr));
     SuccessOrExit(ParseInteger(port, aExpr[2]), msg = aExpr[2]);
-    SuccessOrExit(error = mCommissioner->Start(aExpr[1], port));
+    SuccessOrExit(error = mCommissioner->Start(activeCommissionerId, aExpr[1], port));
 
 exit:
+    if (!activeCommissionerId.empty())
+    {
+        msg = "there is already an active commissioner: " + activeCommissionerId;
+    }
     return {error, msg};
 }
 

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -135,7 +135,9 @@ const BorderAgent *CommissionerApp::GetBorderAgent(const std::string &aNetworkNa
     return nullptr;
 }
 
-Error CommissionerApp::Start(std::string &aActiveCommissionerId, const std::string &aBorderAgentAddr, uint16_t aBorderAgentPort)
+Error CommissionerApp::Start(std::string &      aActiveCommissionerId,
+                             const std::string &aBorderAgentAddr,
+                             uint16_t           aBorderAgentPort)
 {
     Error error = Error::kNone;
 

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -141,7 +141,7 @@ Error CommissionerApp::Start(std::string &      aExistingCommissionerId,
 {
     Error error = Error::kNone;
 
-    // We need to report the active commissioner ID even when pulling network data failed.
+    // We need to report the already active commissioner ID if one exists.
     SuccessOrExit(error = mCommissioner->Petition(aExistingCommissionerId, aBorderAgentAddr, aBorderAgentPort));
     SuccessOrExit(error = PullNetworkData());
 

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -135,11 +135,12 @@ const BorderAgent *CommissionerApp::GetBorderAgent(const std::string &aNetworkNa
     return nullptr;
 }
 
-Error CommissionerApp::Start(const std::string &aBorderAgentAddr, uint16_t aBorderAgentPort)
+Error CommissionerApp::Start(std::string &aActiveCommissionerId, const std::string &aBorderAgentAddr, uint16_t aBorderAgentPort)
 {
     Error error = Error::kNone;
 
-    SuccessOrExit(error = mCommissioner->Petition(aBorderAgentAddr, aBorderAgentPort));
+    // We need to report the active commissioner ID even when pulling network data failed.
+    SuccessOrExit(error = mCommissioner->Petition(aActiveCommissionerId, aBorderAgentAddr, aBorderAgentPort));
     SuccessOrExit(error = PullNetworkData());
 
 exit:

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -135,14 +135,14 @@ const BorderAgent *CommissionerApp::GetBorderAgent(const std::string &aNetworkNa
     return nullptr;
 }
 
-Error CommissionerApp::Start(std::string &      aActiveCommissionerId,
+Error CommissionerApp::Start(std::string &      aExistingCommissionerId,
                              const std::string &aBorderAgentAddr,
                              uint16_t           aBorderAgentPort)
 {
     Error error = Error::kNone;
 
     // We need to report the active commissioner ID even when pulling network data failed.
-    SuccessOrExit(error = mCommissioner->Petition(aActiveCommissionerId, aBorderAgentAddr, aBorderAgentPort));
+    SuccessOrExit(error = mCommissioner->Petition(aExistingCommissionerId, aBorderAgentAddr, aBorderAgentPort));
     SuccessOrExit(error = PullNetworkData());
 
 exit:

--- a/src/app/commissioner_app.hpp
+++ b/src/app/commissioner_app.hpp
@@ -82,7 +82,7 @@ public:
     // Set @p aNetworkName to empty to match any network name.
     const BorderAgent *GetBorderAgent(const std::string &aNetworkName);
 
-    Error Start(std::string &aActiveCommissionerId, const std::string &aBorderAgentAddr, uint16_t aBorderAgentPort);
+    Error Start(std::string &aExistingCommissionerId, const std::string &aBorderAgentAddr, uint16_t aBorderAgentPort);
     void  Stop();
 
     void AbortRequests();

--- a/src/app/commissioner_app.hpp
+++ b/src/app/commissioner_app.hpp
@@ -82,7 +82,7 @@ public:
     // Set @p aNetworkName to empty to match any network name.
     const BorderAgent *GetBorderAgent(const std::string &aNetworkName);
 
-    Error Start(const std::string &aBorderAgentAddr, uint16_t aBorderAgentPort);
+    Error Start(std::string &aActiveCommissionerId, const std::string &aBorderAgentAddr, uint16_t aBorderAgentPort);
     void  Stop();
 
     void AbortRequests();

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1109,8 +1109,8 @@ void CommissionerImpl::SendPetition(PetitionHandler aHandler)
     auto onResponse = [this, aHandler](const coap::Response *aResponse, Error aError) {
         Error       error = Error::kNone;
         tlv::TlvSet tlvSet;
-        tlv::TlvPtr stateTlv     = nullptr;
-        tlv::TlvPtr sessionIdTlv = nullptr;
+        tlv::TlvPtr stateTlv          = nullptr;
+        tlv::TlvPtr sessionIdTlv      = nullptr;
         tlv::TlvPtr commissionerIdTlv = nullptr;
         std::string anotherCommissionerId;
 
@@ -1123,9 +1123,11 @@ void CommissionerImpl::SendPetition(PetitionHandler aHandler)
         VerifyOrExit(stateTlv != nullptr, error = Error::kNotFound);
         VerifyOrExit(stateTlv->IsValid(), error = Error::kBadFormat);
 
-        if (stateTlv->GetValueAsInt8() != tlv::kStateAccept) {
+        if (stateTlv->GetValueAsInt8() != tlv::kStateAccept)
+        {
             commissionerIdTlv = tlvSet[tlv::Type::kCommissionerId];
-            if (commissionerIdTlv != nullptr && commissionerIdTlv->IsValid()) {
+            if (commissionerIdTlv != nullptr && commissionerIdTlv->IsValid())
+            {
                 anotherCommissionerId = commissionerIdTlv->GetValueAsString();
             }
             ExitNow(error = Error::kReject);

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1112,7 +1112,7 @@ void CommissionerImpl::SendPetition(PetitionHandler aHandler)
         tlv::TlvPtr stateTlv          = nullptr;
         tlv::TlvPtr sessionIdTlv      = nullptr;
         tlv::TlvPtr commissionerIdTlv = nullptr;
-        std::string anotherCommissionerId;
+        std::string existingCommissionerId;
 
         SuccessOrExit(error = aError);
 
@@ -1128,7 +1128,7 @@ void CommissionerImpl::SendPetition(PetitionHandler aHandler)
             commissionerIdTlv = tlvSet[tlv::Type::kCommissionerId];
             if (commissionerIdTlv != nullptr && commissionerIdTlv->IsValid())
             {
-                anotherCommissionerId = commissionerIdTlv->GetValueAsString();
+                existingCommissionerId = commissionerIdTlv->GetValueAsString();
             }
             ExitNow(error = Error::kReject);
         }
@@ -1151,7 +1151,7 @@ void CommissionerImpl::SendPetition(PetitionHandler aHandler)
         {
             mState = State::kDisabled;
         }
-        aHandler(anotherCommissionerId.empty() ? nullptr : &anotherCommissionerId, error);
+        aHandler(existingCommissionerId.empty() ? nullptr : &existingCommissionerId, error);
     };
 
     VerifyOrExit(mState == State::kDisabled, error = Error::kInvalidState);

--- a/src/library/commissioner_impl.hpp
+++ b/src/library/commissioner_impl.hpp
@@ -108,8 +108,8 @@ public:
 
     void Disconnect() override;
 
-    void  Petition(ErrorHandler aHandler, const std::string &aAddr, uint16_t aPort) override;
-    Error Petition(const std::string &, uint16_t) override { return Error::kNotImplemented; }
+    void  Petition(PetitionHandler aHandler, const std::string &aAddr, uint16_t aPort) override;
+    Error Petition(std::string &, const std::string &, uint16_t) override { return Error::kNotImplemented; }
 
     void  Resign(ErrorHandler aHandler) override;
     Error Resign() override { return Error::kNotImplemented; }
@@ -234,7 +234,7 @@ private:
     static Error     EncodeCommissionerDataset(coap::Request &aRequest, const CommissionerDataset &aDataset);
     static ByteArray GetCommissionerDatasetTlvs(uint16_t aDatasetFlags);
 
-    void SendPetition(ErrorHandler aHandler);
+    void SendPetition(PetitionHandler aHandler);
 
     // Set @p aKeepAlive to false to resign the commissioner role.
     void SendKeepAlive(Timer &aTimer, bool aKeepAlive = true);

--- a/src/library/commissioner_safe.cpp
+++ b/src/library/commissioner_safe.cpp
@@ -198,8 +198,7 @@ void CommissionerSafe::Petition(PetitionHandler aHandler, const std::string &aAd
 Error CommissionerSafe::Petition(std::string &aActiveCommissionerId, const std::string &aAddr, uint16_t aPort)
 {
     std::promise<Error> pro;
-    auto                wait = [&pro, &aActiveCommissionerId](const std::string *activeCommissionerId, Error error)
-    {
+    auto                wait = [&pro, &aActiveCommissionerId](const std::string *activeCommissionerId, Error error) {
         if (activeCommissionerId != nullptr)
         {
             aActiveCommissionerId = *activeCommissionerId;

--- a/src/library/commissioner_safe.cpp
+++ b/src/library/commissioner_safe.cpp
@@ -195,13 +195,13 @@ void CommissionerSafe::Petition(PetitionHandler aHandler, const std::string &aAd
     PushAsyncRequest([=]() { mImpl.Petition(aHandler, aAddr, aPort); });
 }
 
-Error CommissionerSafe::Petition(std::string &aActiveCommissionerId, const std::string &aAddr, uint16_t aPort)
+Error CommissionerSafe::Petition(std::string &aExistingCommissionerId, const std::string &aAddr, uint16_t aPort)
 {
     std::promise<Error> pro;
-    auto                wait = [&pro, &aActiveCommissionerId](const std::string *activeCommissionerId, Error error) {
-        if (activeCommissionerId != nullptr)
+    auto wait = [&pro, &aExistingCommissionerId](const std::string *existingCommissionerId, Error error) {
+        if (existingCommissionerId != nullptr)
         {
-            aActiveCommissionerId = *activeCommissionerId;
+            aExistingCommissionerId = *existingCommissionerId;
         }
         pro.set_value(error);
     };

--- a/src/library/commissioner_safe.hpp
+++ b/src/library/commissioner_safe.hpp
@@ -105,7 +105,7 @@ public:
     void Disconnect() override;
 
     void  Petition(PetitionHandler aHandler, const std::string &aAddr, uint16_t aPort) override;
-    Error Petition(std::string &aActiveCommissionerId, const std::string &aAddr, uint16_t aPort) override;
+    Error Petition(std::string &aExistingCommissionerId, const std::string &aAddr, uint16_t aPort) override;
 
     void  Resign(ErrorHandler aHandler) override;
     Error Resign() override;

--- a/src/library/commissioner_safe.hpp
+++ b/src/library/commissioner_safe.hpp
@@ -104,8 +104,8 @@ public:
 
     void Disconnect() override;
 
-    void  Petition(ErrorHandler aHandler, const std::string &aAddr, uint16_t aPort) override;
-    Error Petition(const std::string &aAddr, uint16_t aPort) override;
+    void  Petition(PetitionHandler aHandler, const std::string &aAddr, uint16_t aPort) override;
+    Error Petition(std::string &aActiveCommissionerId, const std::string &aAddr, uint16_t aPort) override;
 
     void  Resign(ErrorHandler aHandler) override;
     Error Resign() override;

--- a/tests/unit/test_commissioner_impl.cpp
+++ b/tests/unit/test_commissioner_impl.cpp
@@ -58,7 +58,9 @@ TEST_CASE("commissioner-impl-not-implemented-APIs", "[comm-impl]")
     std::list<BorderAgent> baList;
     REQUIRE(commImpl.Discover(baList) == Error::kNotImplemented);
     REQUIRE(commImpl.Connect("::1", 5684) == Error::kNotImplemented);
-    REQUIRE(commImpl.Petition("::1", 5684) == Error::kNotImplemented);
+
+    std::string activeCommissionerId;
+    REQUIRE(commImpl.Petition(activeCommissionerId, "::1", 5684) == Error::kNotImplemented);
     REQUIRE(commImpl.Resign() == Error::kNotImplemented);
 
     CommissionerDataset commDataset;

--- a/tests/unit/test_commissioner_impl.cpp
+++ b/tests/unit/test_commissioner_impl.cpp
@@ -59,8 +59,8 @@ TEST_CASE("commissioner-impl-not-implemented-APIs", "[comm-impl]")
     REQUIRE(commImpl.Discover(baList) == Error::kNotImplemented);
     REQUIRE(commImpl.Connect("::1", 5684) == Error::kNotImplemented);
 
-    std::string activeCommissionerId;
-    REQUIRE(commImpl.Petition(activeCommissionerId, "::1", 5684) == Error::kNotImplemented);
+    std::string existingCommissionerId;
+    REQUIRE(commImpl.Petition(existingCommissionerId, "::1", 5684) == Error::kNotImplemented);
     REQUIRE(commImpl.Resign() == Error::kNotImplemented);
 
     CommissionerDataset commDataset;


### PR DESCRIPTION
This PR returns the commissioner ID when petition failed due to an already-active commissioner in the Thread Network.