### PR TITLE
[build] enable building shared libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ Makefile.in
 # build
 ._build
 build
+cmake-build-*
 
 #tools
 .vscode

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -85,8 +85,8 @@ target_link_libraries(commissioner PRIVATE
     mbedtls
     pthread
     fmt::fmt
-    event_core_static
-    event_pthreads_static
+    event_core
+    event_pthreads
     commissioner-common)
 
 target_include_directories(commissioner PUBLIC ${PROJECT_SOURCE_DIR}/include)

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -83,7 +83,6 @@ target_link_libraries(commissioner PRIVATE
     cose
     mdns
     mbedtls
-    pthread
     fmt::fmt
     event_core
     event_pthreads

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -38,5 +38,7 @@ set(EVENT__DISABLE_REGRESS ON CACHE BOOL "libevent disable regression tests" FOR
 set(EVENT__DISABLE_TESTS ON CACHE BOOL "libevent disable tests" FORCE)
 set(EVENT__DISABLE_BENCHMARK ON CACHE BOOL "libevent disable benchmark" FORCE)
 add_subdirectory(libevent/repo)
+
+set(USE_SHARED_MBEDTLS_LIBRARY ${BUILD_SHARED_LIBS})
 add_subdirectory(mbedtls/repo)
 add_subdirectory(mdns/repo)

--- a/third_party/COSE-C/CMakeLists.txt
+++ b/third_party/COSE-C/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 
 file(GLOB COSE_SRCS "repo/src/*.c")
-add_library(cose STATIC ${COSE_SRCS})
+add_library(cose ${COSE_SRCS})
 
 target_compile_definitions(cose PUBLIC USE_MBED_TLS)
 target_compile_options(cose PRIVATE -std=gnu99 -Wall -Wextra -pedantic -Wfatal-errors)


### PR DESCRIPTION
This PR enables building shared libraries with builtin CMake option `-DBUILD_SHARED_LIBS=ON`. Shared libraries are required by [Java JNI](https://en.wikipedia.org/wiki/Java_Native_Interface).