### PR TITLE
[network-data] fix bit mask

### DIFF
--- a/include/commissioner/network_data.hpp
+++ b/include/commissioner/network_data.hpp
@@ -132,7 +132,7 @@ struct CommissionerDataset
     static constexpr uint16_t kSessionIdBit          = (1 << 14);
     static constexpr uint16_t kSteeringDataBit       = (1 << 13);
     static constexpr uint16_t kAeSteeringDataBit     = (1 << 12);
-    static constexpr uint16_t kNmkpSteeringDataBit   = (1 < 11);
+    static constexpr uint16_t kNmkpSteeringDataBit   = (1 << 11);
     static constexpr uint16_t kJoinerUdpPortBit      = (1 << 10);
     static constexpr uint16_t kAeUdpPortBit          = (1 << 9);
     static constexpr uint16_t kNmkpUdpPortBit        = (1 << 8);


### PR DESCRIPTION
This PR fixes a bit mask typo. It was working because it resulted in using 0x0001 for its bit mask and 0x0001 hasn't been allocated.