### PR TITLE
[config] comment out PSKc for default CCM config file

### DIFF
--- a/src/app/etc/commissioner/ccm-config.json
+++ b/src/app/etc/commissioner/ccm-config.json
@@ -41,7 +41,7 @@
     // The pre-shared key used to connect to the border agent.
     // The maximum length is 16 bytes.
     // Must be provided if 'EnableCcm' == false.
-    "PSKc" : "deadface",
+    // "PSKc" : "deadface",
 
     // The private key file in PEM format.
     // Must be provided if 'EnableCcm' == true.


### PR DESCRIPTION
The CCM Commissioner supports using `PSKc` for establishing commissioner session, but it should not be recommended by default.