### PR TITLE
[mbedtls] remove redundant compile definitions

### DIFF
--- a/third_party/mbedtls/CMakeLists.txt
+++ b/third_party/mbedtls/CMakeLists.txt
@@ -35,9 +35,6 @@ endif()
 set(ENABLE_TESTING OFF CACHE BOOL "Disable mbedtls test")
 set(ENABLE_PROGRAMS OFF CACHE BOOL "Disable mbetls program")
 
-## We cannot use target-based functions before the targets are added.
-add_compile_definitions(MBEDTLS_USER_CONFIG_FILE="${CMAKE_CURRENT_SOURCE_DIR}/mbedtls_user_config.h")
-
 add_subdirectory(repo)
 
 ## Include the user config file by absolute path to avoid exposing current directory.


### PR DESCRIPTION
This PR removes the redundant `CMake` compile definitions in directory of `mbedtls`, which is covered by target-based commands below:
https://github.com/openthread/ot-commissioner/blob/3740b93fcf6b6220241eb8cafd6652ee2e58c991/third_party/mbedtls/CMakeLists.txt#L43-L63