### PR TITLE
[provisioning-url] move matching to application layer

### DIFF
--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -1318,23 +1318,18 @@ bool CommissionerApp::HandleCommissioning(const JoinerInfo & aJoinerInfo,
     (void)aVendorStackVersion;
     (void)aVendorData;
 
-    constexpr auto kJoinerNotAccepted = false;
-    constexpr auto kJoinerAccepted    = true;
+    bool accepted = false;
 
     auto configuredJoinerInfo = GetJoinerInfo(aJoinerInfo.mType, Commissioner::ComputeJoinerId(aJoinerInfo.mEui64));
-    if (configuredJoinerInfo == nullptr)
-    {
-        // TODO(wgtdkp): logging
-        return kJoinerNotAccepted;
-    }
 
-    if (aProvisioningUrl != configuredJoinerInfo->mProvisioningUrl)
-    {
-        // TODO(wgtdkp): logging
-        return kJoinerNotAccepted;
-    }
+    // TODO(deimi): logging
+    VerifyOrExit(configuredJoinerInfo != nullptr, accepted = false);
+    VerifyOrExit(aProvisioningUrl == configuredJoinerInfo->mProvisioningUrl, accepted = false);
 
-    return kJoinerAccepted;
+    accepted = true;
+
+exit:
+    return accepted;
 }
 
 } // namespace commissioner

--- a/src/app/commissioner_app.hpp
+++ b/src/app/commissioner_app.hpp
@@ -280,6 +280,14 @@ private:
 
     void HandleDatasetChanged(Error error);
 
+    bool HandleCommissioning(const JoinerInfo & aJoinerInfo,
+                             const std::string &aVendorName,
+                             const std::string &aVendorModel,
+                             const std::string &aVendorSwVersion,
+                             const ByteArray &  aVendorStackVersion,
+                             const std::string &aProvisioningUrl,
+                             const ByteArray &  aVendorData);
+
     /*
      * Below are network data associated to the connected Thread network.
      */

--- a/src/library/commissioning_session.cpp
+++ b/src/library/commissioning_session.cpp
@@ -191,7 +191,6 @@ void CommissioningSession::HandleJoinFin(const coap::Request &aJoinFin)
         auto vendorDataTlv = tlvSet[tlv::Type::kVendorData];
         VerifyOrExit(vendorDataTlv != nullptr, error = Error::kNotFound);
         VerifyOrExit(vendorDataTlv->IsValid(), error = Error::kBadFormat);
-        VerifyOrExit(provisioningUrlTlv->GetValueAsString() == mJoinerInfo.mProvisioningUrl, error = Error::kReject);
 
         provisioningUrl = provisioningUrlTlv->GetValueAsString();
         vendorData      = vendorDataTlv->GetValue();
@@ -209,6 +208,7 @@ void CommissioningSession::HandleJoinFin(const coap::Request &aJoinFin)
         // Accepts a joiner if requirement on vendor-specific provisioning.
         accepted = provisioningUrl.empty();
     }
+    VerifyOrExit(accepted == true, error = Error::kReject);
 
 exit:
     if (error != Error::kNone)

--- a/src/library/commissioning_session.cpp
+++ b/src/library/commissioning_session.cpp
@@ -192,10 +192,10 @@ void CommissioningSession::HandleJoinFin(const coap::Request &aJoinFin)
     }
 
     LOG_INFO("received JOIN_FIN.req: vendorName={}, vendorModel={}, vendorSWVversion={}, "
-             "vendorStackVersion={}, provisioningUrl={}, vendorData={:#04x}",
+             "vendorStackVersion={}, provisioningUrl={}, vendorData={}",
              vendorNameTlv->GetValueAsString(), vendorModelTlv->GetValueAsString(),
              vendorSwVersionTlv->GetValueAsString(), utils::Hex(vendorStackVersionTlv->GetValue()), provisioningUrl,
-             fmt::join(vendorData, " "));
+             utils::Hex(vendorData));
 
     // Validation done, request commissioning by user.
     if (mCommImpl.mCommissioningHandler != nullptr)

--- a/src/library/commissioning_session.cpp
+++ b/src/library/commissioning_session.cpp
@@ -209,7 +209,7 @@ void CommissioningSession::HandleJoinFin(const coap::Request &aJoinFin)
         // Accepts a joiner if requirement on vendor-specific provisioning.
         accepted = provisioningUrl.empty();
     }
-    VerifyOrExit(accepted == true, error = Error::kReject);
+    VerifyOrExit(accepted, error = Error::kReject);
 
 exit:
     if (error != Error::kNone)

--- a/src/library/commissioning_session.cpp
+++ b/src/library/commissioning_session.cpp
@@ -181,11 +181,6 @@ void CommissioningSession::HandleJoinFin(const coap::Request &aJoinFin)
     VerifyOrExit((vendorStackVersionTlv = tlvSet[tlv::Type::kVendorStackVersion]) != nullptr, error = Error::kNotFound);
     VerifyOrExit(vendorStackVersionTlv->IsValid(), error = Error::kBadFormat);
 
-    LOG_INFO("received JOIN_FIN.req: vendorName={}, vendorModel={}, vendorSWVversion={}, "
-             "vendorStackVersion={}",
-             vendorNameTlv->GetValueAsString(), vendorModelTlv->GetValueAsString(),
-             vendorSwVersionTlv->GetValueAsString(), utils::Hex(vendorStackVersionTlv->GetValue()));
-
     if (auto provisioningUrlTlv = tlvSet[tlv::Type::kProvisioningURL])
     {
         auto vendorDataTlv = tlvSet[tlv::Type::kVendorData];
@@ -195,6 +190,12 @@ void CommissioningSession::HandleJoinFin(const coap::Request &aJoinFin)
         provisioningUrl = provisioningUrlTlv->GetValueAsString();
         vendorData      = vendorDataTlv->GetValue();
     }
+
+    LOG_INFO("received JOIN_FIN.req: vendorName={}, vendorModel={}, vendorSWVversion={}, "
+             "vendorStackVersion={}, provisioningUrl={}, vendorData={:#04x}",
+             vendorNameTlv->GetValueAsString(), vendorModelTlv->GetValueAsString(),
+             vendorSwVersionTlv->GetValueAsString(), utils::Hex(vendorStackVersionTlv->GetValue()), provisioningUrl,
+             fmt::join(vendorData, " "));
 
     // Validation done, request commissioning by user.
     if (mCommImpl.mCommissioningHandler != nullptr)


### PR DESCRIPTION
This way it would be possible to let every device join, no matter what kind of application layer provisioning is required later.