### PR TITLE
[config]  refine commissioner configuration and logger

### DIFF
--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -80,7 +80,8 @@ enum class LogLevel : uint8_t
  * @brief The Commissioner logger.
  *
  */
-class Logger {
+class Logger
+{
 public:
     virtual ~Logger() = default;
 
@@ -105,7 +106,7 @@ struct Config
     uint32_t mMaxConnectionNum  = 100; ///< Max number of parallel connection from joiner.
 
     std::shared_ptr<Logger> mLogger;
-    bool      mEnableDtlsDebugLogging = false;
+    bool                    mEnableDtlsDebugLogging = false;
 
     // Mandatory for CCM Thread network.
     std::string mDomainName = "Thread"; ///< The domain name of connecting Thread network.

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -268,7 +268,6 @@ public:
      * @brief Create an instance of the commissioner.
      *
      * @param[in] aConfig     A commissioner configuration.
-     * @param[in] aLogger     A commissioner logger. nullable.
      * @param[in] aEventBase  A libevent event_base object. nullable.
      *
      * @return std::shared_ptr<Commissioner>  nullptr is returned if failed.

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -77,12 +77,21 @@ enum class LogLevel : uint8_t
 };
 
 /**
- * @brief The function write a single log message.
+ * @brief The Commissioner logger.
  *
- * @param[in] aLevel    A logging level.
- * @param[in] aMsg      A logging message.
  */
-using LogWriter = std::function<void(LogLevel aLevel, const std::string &aMsg)>;
+class Logger {
+public:
+    virtual ~Logger() = default;
+
+    /**
+     * @brief The function write a single log message.
+     *
+     * @param[in] aLevel    A logging level.
+     * @param[in] aMsg      A logging message.
+     */
+    virtual void Log(LogLevel aLevel, const std::string &aMsg) = 0;
+};
 
 /**
  * @brief Configuration of a commissioner.
@@ -95,8 +104,7 @@ struct Config
     uint32_t mKeepAliveInterval = 40;  ///< The interval of keep-alive message. In seconds.
     uint32_t mMaxConnectionNum  = 100; ///< Max number of parallel connection from joiner.
 
-    LogLevel  mLogLevel               = LogLevel::kInfo;
-    LogWriter mLogWriter              = nullptr;
+    std::shared_ptr<Logger> mLogger;
     bool      mEnableDtlsDebugLogging = false;
 
     // Mandatory for CCM Thread network.
@@ -259,7 +267,9 @@ public:
      * @brief Create an instance of the commissioner.
      *
      * @param[in] aConfig     A commissioner configuration.
+     * @param[in] aLogger     A commissioner logger. nullable.
      * @param[in] aEventBase  A libevent event_base object. nullable.
+     *
      * @return std::shared_ptr<Commissioner>  nullptr is returned if failed.
      *
      * @note If @p aEventBase is not provided, commissioner will create it by itself and

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -32,6 +32,10 @@ target_sources(commissioner-app
     PRIVATE
         commissioner_app.cpp
         commissioner_app.hpp
+        file_logger.cpp
+        file_logger.hpp
+        file_util.cpp
+        file_util.hpp
         json.cpp
         json.hpp
 )

--- a/src/app/cli/interpreter.cpp
+++ b/src/app/cli/interpreter.cpp
@@ -37,8 +37,10 @@
 
 #include <limits>
 
-#include "json.hpp"
 #include <utils.hpp>
+
+#include "file_util.hpp"
+#include "json.hpp"
 
 #if defined(SuccessOrExit)
 #undef SuccessOrExit
@@ -184,7 +186,14 @@ static inline bool CaseInsensitiveEqual(const std::string &aLhs, const std::stri
 Error Interpreter::Init(const std::string &aConfigFile)
 {
     Error error   = Error::kNone;
-    mCommissioner = CommissionerApp::Create(aConfigFile);
+
+    std::string configJson;
+    Config config;
+
+    SuccessOrExit(error = ReadFile(configJson, aConfigFile));
+    SuccessOrExit(error = ConfigFromJson(config, configJson));
+
+    mCommissioner = CommissionerApp::Create(config);
 
     VerifyOrExit(mCommissioner != nullptr, error = Error::kInvalidArgs);
 
@@ -370,8 +379,8 @@ Interpreter::Value Interpreter::ProcessToken(const Expression &aExpr)
     {
         ByteArray signedToken, signerCert;
         VerifyOrExit(aExpr.size() >= 4, msg = Usage(aExpr));
-        SuccessOrExit(error = CommissionerApp::ReadHexStringFile(signedToken, aExpr[2]));
-        SuccessOrExit(error = CommissionerApp::ReadPemFile(signerCert, aExpr[3]));
+        SuccessOrExit(error = ReadHexStringFile(signedToken, aExpr[2]));
+        SuccessOrExit(error = ReadPemFile(signerCert, aExpr[3]));
 
         SuccessOrExit(error = mCommissioner->SetToken(signedToken, signerCert));
     }

--- a/src/app/cli/interpreter.cpp
+++ b/src/app/cli/interpreter.cpp
@@ -185,10 +185,10 @@ static inline bool CaseInsensitiveEqual(const std::string &aLhs, const std::stri
 
 Error Interpreter::Init(const std::string &aConfigFile)
 {
-    Error error   = Error::kNone;
+    Error error = Error::kNone;
 
     std::string configJson;
-    Config config;
+    Config      config;
 
     SuccessOrExit(error = ReadFile(configJson, aConfigFile));
     SuccessOrExit(error = ConfigFromJson(config, configJson));

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -1146,76 +1146,76 @@ size_t CommissionerApp::EraseAllJoiners(JoinerType aJoinerType)
 
 void CommissionerApp::MergeDataset(ActiveOperationalDataset &aDst, const ActiveOperationalDataset &aSrc)
 {
-#define TEST_AND_SET(name)                                            \
+#define SET_IF_PRESENT(name)                                          \
     if (aSrc.mPresentFlags & ActiveOperationalDataset::k##name##Bit)  \
     {                                                                 \
         aDst.m##name = aSrc.m##name;                                  \
         aDst.mPresentFlags |= ActiveOperationalDataset::k##name##Bit; \
     }
 
-    TEST_AND_SET(ActiveTimestamp);
-    TEST_AND_SET(Channel);
-    TEST_AND_SET(ChannelMask);
-    TEST_AND_SET(ExtendedPanId);
-    TEST_AND_SET(MeshLocalPrefix);
-    TEST_AND_SET(NetworkMasterKey);
-    TEST_AND_SET(NetworkName);
-    TEST_AND_SET(PanId);
-    TEST_AND_SET(PSKc);
-    TEST_AND_SET(SecurityPolicy);
+    SET_IF_PRESENT(ActiveTimestamp);
+    SET_IF_PRESENT(Channel);
+    SET_IF_PRESENT(ChannelMask);
+    SET_IF_PRESENT(ExtendedPanId);
+    SET_IF_PRESENT(MeshLocalPrefix);
+    SET_IF_PRESENT(NetworkMasterKey);
+    SET_IF_PRESENT(NetworkName);
+    SET_IF_PRESENT(PanId);
+    SET_IF_PRESENT(PSKc);
+    SET_IF_PRESENT(SecurityPolicy);
 
-#undef TEST_AND_SET
+#undef SET_IF_PRESENT
 }
 
 void CommissionerApp::MergeDataset(PendingOperationalDataset &aDst, const PendingOperationalDataset &aSrc)
 {
     MergeDataset(static_cast<ActiveOperationalDataset &>(aDst), static_cast<const ActiveOperationalDataset &>(aSrc));
 
-#define TEST_AND_SET(name)                                             \
+#define SET_IF_PRESENT(name)                                           \
     if (aSrc.mPresentFlags & PendingOperationalDataset::k##name##Bit)  \
     {                                                                  \
         aDst.m##name = aSrc.m##name;                                   \
         aDst.mPresentFlags |= PendingOperationalDataset::k##name##Bit; \
     }
 
-    TEST_AND_SET(PendingTimestamp);
-    TEST_AND_SET(DelayTimer);
+    SET_IF_PRESENT(PendingTimestamp);
+    SET_IF_PRESENT(DelayTimer);
 
-#undef TEST_AND_SET
+#undef SET_IF_PRESENT
 }
 
 void CommissionerApp::MergeDataset(BbrDataset &aDst, const BbrDataset &aSrc)
 {
-#define TEST_AND_SET(name)                              \
+#define SET_IF_PRESENT(name)                            \
     if (aSrc.mPresentFlags & BbrDataset::k##name##Bit)  \
     {                                                   \
         aDst.m##name = aSrc.m##name;                    \
         aDst.mPresentFlags |= BbrDataset::k##name##Bit; \
     }
 
-    TEST_AND_SET(TriHostname);
-    TEST_AND_SET(RegistrarHostname);
-    TEST_AND_SET(RegistrarIpv6Addr);
+    SET_IF_PRESENT(TriHostname);
+    SET_IF_PRESENT(RegistrarHostname);
+    SET_IF_PRESENT(RegistrarIpv6Addr);
 
-#undef TEST_AND_SET
+#undef SET_IF_PRESENT
 }
 
 // Remove dst dataset's steering data and joiner UDP port
 // if they are not presented in the src dataset.
 void CommissionerApp::MergeDataset(CommissionerDataset &aDst, const CommissionerDataset &aSrc)
 {
-#define TEST_AND_SET(name)                                       \
+#define SET_IF_PRESENT(name)                                     \
     if (aSrc.mPresentFlags & CommissionerDataset::k##name##Bit)  \
     {                                                            \
         aDst.m##name = aSrc.m##name;                             \
         aDst.mPresentFlags |= CommissionerDataset::k##name##Bit; \
     }
 
-    TEST_AND_SET(BorderAgentLocator);
-    TEST_AND_SET(SessionId);
+    SET_IF_PRESENT(BorderAgentLocator);
+    SET_IF_PRESENT(SessionId);
 
-#undef TEST_AND_SET
-#define TEST_AND_SET(name)                                        \
+#undef SET_IF_PRESENT
+#define SET_IF_PRESENT(name)                                      \
     if (aSrc.mPresentFlags & CommissionerDataset::k##name##Bit)   \
     {                                                             \
         aDst.m##name = aSrc.m##name;                              \
@@ -1226,14 +1226,14 @@ void CommissionerApp::MergeDataset(CommissionerDataset &aDst, const Commissioner
         aDst.mPresentFlags &= ~CommissionerDataset::k##name##Bit; \
     }
 
-    TEST_AND_SET(SteeringData);
-    TEST_AND_SET(AeSteeringData);
-    TEST_AND_SET(NmkpSteeringData);
-    TEST_AND_SET(JoinerUdpPort);
-    TEST_AND_SET(AeUdpPort);
-    TEST_AND_SET(NmkpUdpPort);
+    SET_IF_PRESENT(SteeringData);
+    SET_IF_PRESENT(AeSteeringData);
+    SET_IF_PRESENT(NmkpSteeringData);
+    SET_IF_PRESENT(JoinerUdpPort);
+    SET_IF_PRESENT(AeUdpPort);
+    SET_IF_PRESENT(NmkpUdpPort);
 
-#undef TEST_AND_SET
+#undef SET_IF_PRESENT
 }
 
 void CommissionerApp::HandlePanIdConflict(const std::string *aPeerAddr,

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -72,8 +72,8 @@ static bool DefaultCommissioningHandler(const JoinerInfo & aJoinerInfo,
 
 std::shared_ptr<CommissionerApp> CommissionerApp::Create(const Config &aConfig)
 {
-    Error     error = Error::kNone;
-    auto      app = std::shared_ptr<CommissionerApp>(new CommissionerApp());
+    Error error = Error::kNone;
+    auto  app   = std::shared_ptr<CommissionerApp>(new CommissionerApp());
 
     SuccessOrExit(error = app->Init(aConfig));
 
@@ -83,7 +83,7 @@ exit:
 
 Error CommissionerApp::Init(const Config &aConfig)
 {
-    Error error = Error::kNone;
+    Error error        = Error::kNone;
     auto  commissioner = Commissioner::Create(aConfig, nullptr);
 
     VerifyOrExit(commissioner != nullptr, error = Error::kInvalidArgs);

--- a/src/app/commissioner_app.hpp
+++ b/src/app/commissioner_app.hpp
@@ -50,8 +50,6 @@
 
 #include <address.hpp>
 
-#include "app_config.hpp"
-
 namespace ot {
 
 namespace commissioner {
@@ -69,7 +67,7 @@ public:
     using MilliSeconds = std::chrono::milliseconds;
     using Seconds      = std::chrono::seconds;
 
-    static std::shared_ptr<CommissionerApp> Create(const std::string &aConfigFile);
+    static std::shared_ptr<CommissionerApp> Create(const Config &aConfig);
     ~CommissionerApp() = default;
 
     // Discover Border Agent on link-local network.
@@ -215,17 +213,9 @@ public:
     Error              RequestToken(const std::string &aAddr, uint16_t aPort);
     Error              SetToken(const ByteArray &aSignedToken, const ByteArray &aSignerCert);
 
-    static Error ReadFile(std::string &aData, const std::string &aFilename);
-
-    // Read a PEM file. '\0' will be append to the end of the data buffer.
-    static Error ReadPemFile(ByteArray &aData, const std::string &aFilename);
-
-    // Read a hex string file. Any spaces in the file are accepted and ignored.
-    static Error ReadHexStringFile(ByteArray &aData, const std::string &aFilename);
-
 private:
     CommissionerApp() = default;
-    Error Init(const AppConfig &aAppConfig);
+    Error Init(const Config &aConfig);
 
     struct JoinerKey
     {
@@ -245,19 +235,7 @@ private:
     static void MergeDataset(BbrDataset &aDst, const BbrDataset &aSrc);
     static void MergeDataset(CommissionerDataset &aDst, const CommissionerDataset &aSrc);
 
-    static Error WriteFile(const std::string &aData, const std::string &aFilename);
-    static Error ReadConfig(AppConfig &aAppConfig, const std::string &aFilename);
-
     const JoinerInfo *GetJoinerInfo(JoinerType aType, const ByteArray &aJoinerId);
-
-    // Create a commissioner configuration with given app configuration.
-    Error MakeConfig(Config &aConfig, const AppConfig &aAppConfig);
-
-    // The callback function passed to Commissioner lib for writing a single log message.
-    void WriteCommLog(LogLevel aLevel, const std::string &aMsg);
-
-    // The log stream for the Commissioner library, not the app itself.
-    std::ofstream mCommLogStream;
 
     std::shared_ptr<Commissioner> mCommissioner;
 

--- a/src/app/file_logger.cpp
+++ b/src/app/file_logger.cpp
@@ -64,11 +64,14 @@ static std::string ToString(LogLevel aLevel)
     }
 }
 
-FileLogger::FileLogger(const std::string& aFilename,
-                       ot::commissioner::LogLevel aLogLevel)
-    : mFileStream(aFilename), mLogLevel(aLogLevel) {}
+FileLogger::FileLogger(const std::string &aFilename, ot::commissioner::LogLevel aLogLevel)
+    : mFileStream(aFilename)
+    , mLogLevel(aLogLevel)
+{
+}
 
-void FileLogger::Log(ot::commissioner::LogLevel aLevel, const std::string& aMsg) {
+void FileLogger::Log(ot::commissioner::LogLevel aLevel, const std::string &aMsg)
+{
     char        dateBuf[64];
     std::time_t now = std::time(nullptr);
 

--- a/src/app/file_logger.cpp
+++ b/src/app/file_logger.cpp
@@ -28,7 +28,7 @@
 
 /**
  * @file
- *  The file defines file logger.
+ *  This file defines file logger.
  *
  */
 
@@ -44,24 +44,27 @@ namespace commissioner {
 
 static std::string ToString(LogLevel aLevel)
 {
+    std::string ret;
+
     switch (aLevel)
     {
     case LogLevel::kOff:
-        return "off";
+        ret = "off";
     case LogLevel::kCritical:
-        return "critical";
+        ret = "critical";
     case LogLevel::kError:
-        return "error";
+        ret = "error";
     case LogLevel::kWarn:
-        return "warn";
+        ret = "warn";
     case LogLevel::kInfo:
-        return "info";
+        ret = "info";
     case LogLevel::kDebug:
-        return "debug";
+        ret = "debug";
     default:
         ASSERT(false);
-        return "unknown";
     }
+
+    return ret;
 }
 
 FileLogger::FileLogger(const std::string &aFilename, ot::commissioner::LogLevel aLogLevel)

--- a/src/app/file_logger.cpp
+++ b/src/app/file_logger.cpp
@@ -34,7 +34,7 @@
 
 #include "file_logger.hpp"
 
-#include <ctime>
+#include <time.h>
 
 #include <utils.hpp>
 
@@ -73,12 +73,13 @@ FileLogger::FileLogger(const std::string &aFilename, ot::commissioner::LogLevel 
 void FileLogger::Log(ot::commissioner::LogLevel aLevel, const std::string &aMsg)
 {
     char        dateBuf[64];
-    std::time_t now = std::time(nullptr);
+    struct tm localTime;
+    time_t now = time(nullptr);
 
     VerifyOrExit(aLevel <= mLogLevel);
     VerifyOrExit(mFileStream.is_open());
 
-    std::strftime(dateBuf, sizeof(dateBuf), "%Y-%m-%d %H:%M:%S", std::localtime(&now));
+    strftime(dateBuf, sizeof(dateBuf), "%Y-%m-%d %H:%M:%S", localtime_r(&now, &localTime));
     mFileStream << "[ " << dateBuf << " ] [ " << ToString(aLevel) << " ] " << aMsg << std::endl;
 
 exit:

--- a/src/app/file_logger.cpp
+++ b/src/app/file_logger.cpp
@@ -50,18 +50,25 @@ static std::string ToString(LogLevel aLevel)
     {
     case LogLevel::kOff:
         ret = "off";
+        break;
     case LogLevel::kCritical:
         ret = "critical";
+        break;
     case LogLevel::kError:
         ret = "error";
+        break;
     case LogLevel::kWarn:
         ret = "warn";
+        break;
     case LogLevel::kInfo:
         ret = "info";
+        break;
     case LogLevel::kDebug:
         ret = "debug";
+        break;
     default:
         ASSERT(false);
+        break;
     }
 
     return ret;
@@ -75,9 +82,9 @@ FileLogger::FileLogger(const std::string &aFilename, ot::commissioner::LogLevel 
 
 void FileLogger::Log(ot::commissioner::LogLevel aLevel, const std::string &aMsg)
 {
-    char        dateBuf[64];
+    char      dateBuf[64];
     struct tm localTime;
-    time_t now = time(nullptr);
+    time_t    now = time(nullptr);
 
     VerifyOrExit(aLevel <= mLogLevel);
     VerifyOrExit(mFileStream.is_open());

--- a/src/app/file_logger.hpp
+++ b/src/app/file_logger.hpp
@@ -48,7 +48,8 @@ namespace commissioner {
  * @brief An implementation of the Logger interface that write log to a text file.
  *
  */
-class FileLogger : public Logger {
+class FileLogger : public Logger
+{
 public:
     /**
      * The constructor with given log file name and minimum log level.
@@ -62,9 +63,9 @@ public:
 
     void Log(LogLevel aLevel, const std::string &aMsg) override;
 
- private:
+private:
     std::ofstream mFileStream;
-    LogLevel mLogLevel;
+    LogLevel      mLogLevel;
 };
 
 } // namespace commissioner

--- a/src/app/file_logger.hpp
+++ b/src/app/file_logger.hpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright (c) 2019, The OpenThread Authors.
+ *    Copyright (c) 2020, The OpenThread Authors.
  *    All rights reserved.
  *
  *    Redistribution and use in source and binary forms, with or without
@@ -28,35 +28,47 @@
 
 /**
  * @file
- *   This file includes wrapper of mbedtls.
+ *  The file defines file logger.
+ *
  */
 
-#include "logging.hpp"
+#ifndef OT_COMM_APP_FILE_LOGGER_HPP_
+#define OT_COMM_APP_FILE_LOGGER_HPP_
+
+#include <fstream>
+#include <string>
+
+#include <commissioner/commissioner.hpp>
 
 namespace ot {
 
 namespace commissioner {
 
-static std::shared_ptr<Logger> sLogger = nullptr;
+/**
+ * @brief An implementation of the Logger interface that write log to a text file.
+ *
+ */
+class FileLogger : public Logger {
+public:
+    /**
+     * The constructor with given log file name and minimum log level.
+     *
+     * @param[in] aFilename  The log file name.
+     * @param[in] aLogLevel  The minimum log level. Log messages have a lower
+     *                       log level than this will be dropped silently.
+     *
+     */
+    FileLogger(const std::string &aFilename, LogLevel aLogLevel);
 
-void InitLogger(std::shared_ptr<Logger> aLogger)
-{
-    sLogger = aLogger;
-}
+    void Log(LogLevel aLevel, const std::string &aMsg) override;
 
-std::shared_ptr<Logger> GetLogger()
-{
-    return sLogger;
-}
-
-void Log(LogLevel aLevel, const std::string &aMessage)
-{
-    if (GetLogger())
-    {
-        GetLogger()->Log(aLevel, aMessage);
-    }
-}
+ private:
+    std::ofstream mFileStream;
+    LogLevel mLogLevel;
+};
 
 } // namespace commissioner
 
 } // namespace ot
+
+#endif // OT_COMM_APP_FILE_LOGGER_HPP_

--- a/src/app/file_logger.hpp
+++ b/src/app/file_logger.hpp
@@ -28,7 +28,7 @@
 
 /**
  * @file
- *  The file defines file logger.
+ *  This file defines file logger.
  *
  */
 
@@ -55,7 +55,7 @@ public:
      * The constructor with given log file name and minimum log level.
      *
      * @param[in] aFilename  The log file name.
-     * @param[in] aLogLevel  The minimum log level. Log messages have a lower
+     * @param[in] aLogLevel  The minimum log level. Log messages with a lower
      *                       log level than this will be dropped silently.
      *
      */

--- a/src/app/file_util.cpp
+++ b/src/app/file_util.cpp
@@ -28,7 +28,7 @@
 
 /**
  * @file
- *  The file implements file utilities.
+ *  This file implements file utilities.
  *
  */
 

--- a/src/app/file_util.cpp
+++ b/src/app/file_util.cpp
@@ -50,10 +50,7 @@ Error WriteFile(const std::string &aData, const std::string &aFilename)
 
     VerifyOrExit(f != NULL, error = Error::kNotFound);
 
-    for (int c : aData)
-    {
-        fputc(c, f);
-    }
+    fputs(aData.c_str(), f);
 
 exit:
     if (f != NULL)

--- a/src/app/file_util.cpp
+++ b/src/app/file_util.cpp
@@ -42,10 +42,11 @@ namespace ot {
 
 namespace commissioner {
 
-Error WriteFile(const std::string &aData, const std::string &aFilename) {
+Error WriteFile(const std::string &aData, const std::string &aFilename)
+{
     Error error = Error::kNone;
 
-    FILE * f = fopen(aFilename.c_str(), "w");
+    FILE *f = fopen(aFilename.c_str(), "w");
 
     VerifyOrExit(f != NULL, error = Error::kNotFound);
 
@@ -63,10 +64,11 @@ exit:
     return error;
 }
 
-Error ReadFile(std::string &aData, const std::string &aFilename) {
+Error ReadFile(std::string &aData, const std::string &aFilename)
+{
     Error error = Error::kNone;
 
-    FILE * f = fopen(aFilename.c_str(), "r");
+    FILE *f = fopen(aFilename.c_str(), "r");
 
     VerifyOrExit(f != NULL, error = Error::kNotFound);
 
@@ -120,6 +122,5 @@ exit:
 }
 
 } // namespace commissioner
-
 
 } // namespace ot

--- a/src/app/file_util.hpp
+++ b/src/app/file_util.hpp
@@ -28,7 +28,7 @@
 
 /**
  * @file
- *  The file defines file utilities.
+ *  This file defines file utilities.
  *
  */
 
@@ -48,12 +48,12 @@ namespace commissioner {
  * This function writes a string to the target file.
  *
  * Create the target file if it is not found.
- * Clear the target file if it is not empty, and write to it at the begin.
+ * Clear the target file if it is not empty and write from the beginning.
  *
- * @retval Error::kNone Successfully written the whole string.
- * @retval ...          Failed to write the string.
+ * @retval Error::kNone  Successfully written the whole string.
+ * @retval ...           Failed to write the string.
  *
- * @note This function is not atomic, which means, the target file
+ * @note This function is not atomic, which means the target file
  *       could be corrupted if this function failed.
  *
  */
@@ -62,14 +62,17 @@ Error WriteFile(const std::string &aData, const std::string &aFilename);
 /**
  * This function reads a file into a std::string.
  *
- * @retval Error::kNone     Successfully read the whole file.
- * @retval Error::kNotFound Cannot find the given file.
+ * @retval Error::kNone      Successfully read the whole file.
+ * @retval Error::kNotFound  Cannot find the given file.
  *
  */
 Error ReadFile(std::string &aData, const std::string &aFilename);
 
 /**
  * This function reads a PEM file into a ByteArray.
+ *
+ * @retval Error::kNone      Successfully read the whole file.
+ * @retval Error::kNotFound  Cannot find the given file.
  *
  * @note A '\0' will be append to the end of the data buffer
  *       (this is required by mbedtls to distinguish DER and PEM).
@@ -83,9 +86,9 @@ Error ReadPemFile(ByteArray &aData, const std::string &aFilename);
  * Any spaces in the file are accepted and ingored to produce a
  * continuous byte array.
  *
- * @retval Error::kNone      Successfully read the whole file.
- * @retval Error::kNotFound  Cannot find the given file.
- * @retval Error::kBadFormat There are invalid characters in the file.
+ * @retval Error::kNone       Successfully read the whole file.
+ * @retval Error::kNotFound   Cannot find the given file.
+ * @retval Error::kBadFormat  There are invalid characters in the file.
  *
  */
 Error ReadHexStringFile(ByteArray &aData, const std::string &aFilename);

--- a/src/app/file_util.hpp
+++ b/src/app/file_util.hpp
@@ -37,8 +37,8 @@
 
 #include <string>
 
-#include <commissioner/error.hpp>
 #include <commissioner/defines.hpp>
+#include <commissioner/error.hpp>
 
 namespace ot {
 

--- a/src/app/file_util.hpp
+++ b/src/app/file_util.hpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright (c) 2019, The OpenThread Authors.
+ *    Copyright (c) 2020, The OpenThread Authors.
  *    All rights reserved.
  *
  *    Redistribution and use in source and binary forms, with or without
@@ -28,56 +28,70 @@
 
 /**
  * @file
- *   The file defines the json parser of Network Data and Commissioner configuration.
+ *  The file defines file utilities.
  *
  */
 
-#ifndef OT_COMM_APP_JSON_HPP_
-#define OT_COMM_APP_JSON_HPP_
+#ifndef OT_COMM_APP_FILE_UTIL_HPP_
+#define OT_COMM_APP_FILE_UTIL_HPP_
 
 #include <string>
 
-#include <commissioner/commissioner.hpp>
 #include <commissioner/error.hpp>
-#include <commissioner/network_data.hpp>
-
-#include "commissioner_app.hpp"
+#include <commissioner/defines.hpp>
 
 namespace ot {
 
 namespace commissioner {
 
-struct NetworkData
-{
-    ActiveOperationalDataset  mActiveDataset;
-    PendingOperationalDataset mPendingDataset;
-    CommissionerDataset       mCommDataset;
-    BbrDataset                mBbrDataset;
-};
+/**
+ * This function writes a string to the target file.
+ *
+ * Create the target file if it is not found.
+ * Clear the target file if it is not empty, and write to it at the begin.
+ *
+ * @retval Error::kNone Successfully written the whole string.
+ * @retval ...          Failed to write the string.
+ *
+ * @note This function is not atomic, which means, the target file
+ *       could be corrupted if this function failed.
+ *
+ */
+Error WriteFile(const std::string &aData, const std::string &aFilename);
 
-Error       NetworkDataFromJson(NetworkData &aNetworkData, const std::string &aJson);
-std::string NetworkDataToJson(const NetworkData &aNetworkData);
+/**
+ * This function reads a file into a std::string.
+ *
+ * @retval Error::kNone     Successfully read the whole file.
+ * @retval Error::kNotFound Cannot find the given file.
+ *
+ */
+Error ReadFile(std::string &aData, const std::string &aFilename);
 
-Error       CommissionerDatasetFromJson(CommissionerDataset &aDataset, const std::string &aJson);
-std::string CommissionerDatasetToJson(const CommissionerDataset &aDataset);
+/**
+ * This function reads a PEM file into a ByteArray.
+ *
+ * @note A '\0' will be append to the end of the data buffer
+ *       (this is required by mbedtls to distinguish DER and PEM).
+ *
+ */
+Error ReadPemFile(ByteArray &aData, const std::string &aFilename);
 
-Error       BbrDatasetFromJson(BbrDataset &aDataset, const std::string &aJson);
-std::string BbrDatasetToJson(const BbrDataset &aDataset);
-
-Error       ActiveDatasetFromJson(ActiveOperationalDataset &aDataset, const std::string &aJson);
-std::string ActiveDatasetToJson(const ActiveOperationalDataset &aDataset);
-
-Error       PendingDatasetFromJson(PendingOperationalDataset &aDataset, const std::string &aJson);
-std::string PendingDatasetToJson(const PendingOperationalDataset &aDataset);
-
-Error       ConfigFromJson(Config &aConfig, const std::string &aJson);
-
-std::string EnergyReportToJson(const EnergyReport &aEnergyReport);
-
-std::string EnergyReportMapToJson(const EnergyReportMap &aEnergyReportMap);
+/**
+ * This function reads a HEX string file into a ByteArray.
+ *
+ * Any spaces in the file are accepted and ingored to produce a
+ * continuous byte array.
+ *
+ * @retval Error::kNone      Successfully read the whole file.
+ * @retval Error::kNotFound  Cannot find the given file.
+ * @retval Error::kBadFormat There are invalid characters in the file.
+ *
+ */
+Error ReadHexStringFile(ByteArray &aData, const std::string &aFilename);
 
 } // namespace commissioner
 
 } // namespace ot
 
-#endif // OT_COMM_APP_JSON_HPP_
+#endif // OT_COMM_APP_FILE_UTIL_HPP_

--- a/src/app/file_util.hpp
+++ b/src/app/file_util.hpp
@@ -50,6 +50,9 @@ namespace commissioner {
  * Create the target file if it is not found.
  * Clear the target file if it is not empty and write from the beginning.
  *
+ * @param[in] aData      The data to be written.
+ * @param[in] aFileanme  The name of the target file.
+ *
  * @retval Error::kNone  Successfully written the whole string.
  * @retval ...           Failed to write the string.
  *
@@ -62,6 +65,9 @@ Error WriteFile(const std::string &aData, const std::string &aFilename);
 /**
  * This function reads a file into a std::string.
  *
+ * @param[out] aData     The data to read to.
+ * @param[in] aFileanme  The name of the file.
+ *
  * @retval Error::kNone      Successfully read the whole file.
  * @retval Error::kNotFound  Cannot find the given file.
  *
@@ -70,6 +76,9 @@ Error ReadFile(std::string &aData, const std::string &aFilename);
 
 /**
  * This function reads a PEM file into a ByteArray.
+ *
+ * @param[out] aData     The data to read to.
+ * @param[in] aFileanme  The name of the file.
  *
  * @retval Error::kNone      Successfully read the whole file.
  * @retval Error::kNotFound  Cannot find the given file.
@@ -85,6 +94,9 @@ Error ReadPemFile(ByteArray &aData, const std::string &aFilename);
  *
  * Any spaces in the file are accepted and ingored to produce a
  * continuous byte array.
+ *
+ * @param[out] aData     The data to read to.
+ * @param[in] aFileanme  The name of the file.
  *
  * @retval Error::kNone       Successfully read the whole file.
  * @retval Error::kNotFound   Cannot find the given file.

--- a/src/app/json.cpp
+++ b/src/app/json.cpp
@@ -221,7 +221,7 @@ static void from_json(const Json &aJson, Config &aConfig)
 
     if (aJson.contains("PSKc"))
     {
-        SuccessOrThrow(utils::Hex(aConfig.mPSKc, aJson["PSkc"]));
+        SuccessOrThrow(utils::Hex(aConfig.mPSKc, aJson["PSKc"]));
     }
 
     if (aJson.contains("PrivateKeyFile"))

--- a/src/app/json.cpp
+++ b/src/app/json.cpp
@@ -28,7 +28,7 @@
 
 /**
  * @file
- *   The file defines the json parser of Network Data and Commissioner configuration.
+ *   This file defines the json parser of Network Data and Commissioner configuration.
  *
  */
 
@@ -50,7 +50,7 @@ namespace ot {
 namespace commissioner {
 
 /**
- * This is the Exception class represents Network Data
+ * This Exception class represents Network Data
  * and Configuration conversion errors from JSON file.
  *
  * We need this because the nlohmann::json library uses
@@ -189,20 +189,20 @@ NLOHMANN_JSON_SERIALIZE_ENUM(LogLevel,
 
 static void from_json(const Json &aJson, Config &aConfig)
 {
-#define TEST_AND_SET(name)              \
+#define SET_IF_PRESENT(name)            \
     if (aJson.contains(#name))          \
     {                                   \
         aConfig.m##name = aJson[#name]; \
     };
 
-    TEST_AND_SET(Id);
-    TEST_AND_SET(EnableCcm);
-    TEST_AND_SET(EnableDtlsDebugLogging);
+    SET_IF_PRESENT(Id);
+    SET_IF_PRESENT(EnableCcm);
+    SET_IF_PRESENT(EnableDtlsDebugLogging);
 
-    TEST_AND_SET(KeepAliveInterval);
-    TEST_AND_SET(MaxConnectionNum);
+    SET_IF_PRESENT(KeepAliveInterval);
+    SET_IF_PRESENT(MaxConnectionNum);
 
-#undef TEST_AND_SET
+#undef SET_IF_PRESENT
 
     // The default log level is LogLevel::kInfo.
     LogLevel logLevel = LogLevel::kInfo;
@@ -212,7 +212,6 @@ static void from_json(const Json &aJson, Config &aConfig)
         logLevel = aJson["LogLevel"];
     }
 
-    // TODO(wgtdkp): parse logging file.
     if (aJson.contains("LogFile"))
     {
         auto logger     = std::make_shared<FileLogger>(aJson["LogFile"], logLevel);
@@ -242,27 +241,27 @@ static void from_json(const Json &aJson, Config &aConfig)
 
 static void to_json(Json &aJson, const CommissionerDataset &aDataset)
 {
-#define TEST_AND_SET(name)                                          \
+#define SET_IF_PRESENT(name)                                        \
     if (aDataset.mPresentFlags & CommissionerDataset::k##name##Bit) \
     {                                                               \
         aJson[#name] = aDataset.m##name;                            \
     };
 
-    TEST_AND_SET(BorderAgentLocator);
-    TEST_AND_SET(SessionId);
-    TEST_AND_SET(SteeringData);
-    TEST_AND_SET(AeSteeringData);
-    TEST_AND_SET(NmkpSteeringData);
-    TEST_AND_SET(JoinerUdpPort);
-    TEST_AND_SET(AeUdpPort);
-    TEST_AND_SET(NmkpUdpPort);
+    SET_IF_PRESENT(BorderAgentLocator);
+    SET_IF_PRESENT(SessionId);
+    SET_IF_PRESENT(SteeringData);
+    SET_IF_PRESENT(AeSteeringData);
+    SET_IF_PRESENT(NmkpSteeringData);
+    SET_IF_PRESENT(JoinerUdpPort);
+    SET_IF_PRESENT(AeUdpPort);
+    SET_IF_PRESENT(NmkpUdpPort);
 
-#undef TEST_AND_SET
+#undef SET_IF_PRESENT
 }
 
 static void from_json(const Json &aJson, CommissionerDataset &aDataset)
 {
-#define TEST_AND_SET(name)                                                    \
+#define SET_IF_PRESENT(name)                                                  \
     if (aJson.contains(#name))                                                \
     {                                                                         \
         aDataset.m##name = aJson.at(#name).get<decltype(aDataset.m##name)>(); \
@@ -271,45 +270,45 @@ static void from_json(const Json &aJson, CommissionerDataset &aDataset)
 
     // Ignore BorderAgentLocator & CommissionerSessionId
 
-    TEST_AND_SET(SteeringData);
-    TEST_AND_SET(AeSteeringData);
-    TEST_AND_SET(NmkpSteeringData);
-    TEST_AND_SET(JoinerUdpPort);
-    TEST_AND_SET(AeUdpPort);
-    TEST_AND_SET(NmkpUdpPort);
+    SET_IF_PRESENT(SteeringData);
+    SET_IF_PRESENT(AeSteeringData);
+    SET_IF_PRESENT(NmkpSteeringData);
+    SET_IF_PRESENT(JoinerUdpPort);
+    SET_IF_PRESENT(AeUdpPort);
+    SET_IF_PRESENT(NmkpUdpPort);
 
-#undef TEST_AND_SET
+#undef SET_IF_PRESENT
 }
 
 static void to_json(Json &aJson, const BbrDataset &aDataset)
 {
-#define TEST_AND_SET(name)                                 \
+#define SET_IF_PRESENT(name)                               \
     if (aDataset.mPresentFlags & BbrDataset::k##name##Bit) \
     {                                                      \
         aJson[#name] = aDataset.m##name;                   \
     };
 
-    TEST_AND_SET(TriHostname);
-    TEST_AND_SET(RegistrarHostname);
-    TEST_AND_SET(RegistrarIpv6Addr);
+    SET_IF_PRESENT(TriHostname);
+    SET_IF_PRESENT(RegistrarHostname);
+    SET_IF_PRESENT(RegistrarIpv6Addr);
 
-#undef TEST_AND_SET
+#undef SET_IF_PRESENT
 }
 
 static void from_json(const Json &aJson, BbrDataset &aDataset)
 {
-#define TEST_AND_SET(name)                                                    \
+#define SET_IF_PRESENT(name)                                                  \
     if (aJson.contains(#name))                                                \
     {                                                                         \
         aDataset.m##name = aJson.at(#name).get<decltype(aDataset.m##name)>(); \
         aDataset.mPresentFlags |= BbrDataset::k##name##Bit;                   \
     };
 
-    TEST_AND_SET(TriHostname);
-    TEST_AND_SET(RegistrarHostname);
-    TEST_AND_SET(RegistrarIpv6Addr);
+    SET_IF_PRESENT(TriHostname);
+    SET_IF_PRESENT(RegistrarHostname);
+    SET_IF_PRESENT(RegistrarIpv6Addr);
 
-#undef TEST_AND_SET
+#undef SET_IF_PRESENT
 }
 
 static void to_json(Json &aJson, const Timestamp &aTimestamp)
@@ -396,44 +395,44 @@ static void from_json(const Json &aJson, SecurityPolicy &aSecurityPolicy)
 
 static void to_json(Json &aJson, const ActiveOperationalDataset &aDataset)
 {
-#define TEST_AND_SET(name)                                               \
+#define SET_IF_PRESENT(name)                                             \
     if (aDataset.mPresentFlags & ActiveOperationalDataset::k##name##Bit) \
     {                                                                    \
         aJson[#name] = aDataset.m##name;                                 \
     };
 
-    TEST_AND_SET(ActiveTimestamp);
-    TEST_AND_SET(Channel);
-    TEST_AND_SET(ChannelMask);
-    TEST_AND_SET(ExtendedPanId);
+    SET_IF_PRESENT(ActiveTimestamp);
+    SET_IF_PRESENT(Channel);
+    SET_IF_PRESENT(ChannelMask);
+    SET_IF_PRESENT(ExtendedPanId);
 
     if (aDataset.mPresentFlags & ActiveOperationalDataset::kMeshLocalPrefixBit)
     {
         aJson["MeshLocalPrefix"] = Ipv6PrefixToString(aDataset.mMeshLocalPrefix);
     };
 
-    TEST_AND_SET(NetworkMasterKey);
-    TEST_AND_SET(NetworkName);
-    TEST_AND_SET(PanId);
-    TEST_AND_SET(PSKc);
-    TEST_AND_SET(SecurityPolicy);
+    SET_IF_PRESENT(NetworkMasterKey);
+    SET_IF_PRESENT(NetworkName);
+    SET_IF_PRESENT(PanId);
+    SET_IF_PRESENT(PSKc);
+    SET_IF_PRESENT(SecurityPolicy);
 
-#undef TEST_AND_SET
+#undef SET_IF_PRESENT
 }
 
 static void from_json(const Json &aJson, ActiveOperationalDataset &aDataset)
 {
-#define TEST_AND_SET(name)                                                    \
+#define SET_IF_PRESENT(name)                                                  \
     if (aJson.contains(#name))                                                \
     {                                                                         \
         aDataset.m##name = aJson.at(#name).get<decltype(aDataset.m##name)>(); \
         aDataset.mPresentFlags |= ActiveOperationalDataset::k##name##Bit;     \
     };
 
-    TEST_AND_SET(ActiveTimestamp);
-    TEST_AND_SET(Channel);
-    TEST_AND_SET(ChannelMask);
-    TEST_AND_SET(ExtendedPanId);
+    SET_IF_PRESENT(ActiveTimestamp);
+    SET_IF_PRESENT(Channel);
+    SET_IF_PRESENT(ChannelMask);
+    SET_IF_PRESENT(ExtendedPanId);
 
     if (aJson.contains("MeshLocalPrefix"))
     {
@@ -445,46 +444,46 @@ static void from_json(const Json &aJson, ActiveOperationalDataset &aDataset)
         aDataset.mPresentFlags |= ActiveOperationalDataset::kMeshLocalPrefixBit;
     };
 
-    TEST_AND_SET(NetworkMasterKey);
-    TEST_AND_SET(NetworkName);
-    TEST_AND_SET(PanId);
-    TEST_AND_SET(PSKc);
-    TEST_AND_SET(SecurityPolicy);
+    SET_IF_PRESENT(NetworkMasterKey);
+    SET_IF_PRESENT(NetworkName);
+    SET_IF_PRESENT(PanId);
+    SET_IF_PRESENT(PSKc);
+    SET_IF_PRESENT(SecurityPolicy);
 
-#undef TEST_AND_SET
+#undef SET_IF_PRESENT
 }
 
 static void to_json(Json &aJson, const PendingOperationalDataset &aDataset)
 {
     to_json(aJson, static_cast<const ActiveOperationalDataset &>(aDataset));
 
-#define TEST_AND_SET(name)                                                \
+#define SET_IF_PRESENT(name)                                              \
     if (aDataset.mPresentFlags & PendingOperationalDataset::k##name##Bit) \
     {                                                                     \
         aJson[#name] = aDataset.m##name;                                  \
     };
 
-    TEST_AND_SET(PendingTimestamp);
-    TEST_AND_SET(DelayTimer);
+    SET_IF_PRESENT(PendingTimestamp);
+    SET_IF_PRESENT(DelayTimer);
 
-#undef TEST_AND_SET
+#undef SET_IF_PRESENT
 }
 
 static void from_json(const Json &aJson, PendingOperationalDataset &aDataset)
 {
     from_json(aJson, static_cast<ActiveOperationalDataset &>(aDataset));
 
-#define TEST_AND_SET(name)                                                    \
+#define SET_IF_PRESENT(name)                                                  \
     if (aJson.contains(#name))                                                \
     {                                                                         \
         aDataset.m##name = aJson.at(#name).get<decltype(aDataset.m##name)>(); \
         aDataset.mPresentFlags |= PendingOperationalDataset::k##name##Bit;    \
     };
 
-    TEST_AND_SET(PendingTimestamp);
-    TEST_AND_SET(DelayTimer);
+    SET_IF_PRESENT(PendingTimestamp);
+    SET_IF_PRESENT(DelayTimer);
 
-#undef TEST_AND_SET
+#undef SET_IF_PRESENT
 }
 
 static void to_json(Json &aJson, const NetworkData &aNetworkData)
@@ -501,18 +500,18 @@ static void to_json(Json &aJson, const NetworkData &aNetworkData)
 
 static void from_json(const Json &aJson, NetworkData &aNetworkData)
 {
-#define TEST_AND_SET(name)                                                            \
+#define SET_IF_PRESENT(name)                                                          \
     if (aJson.contains(#name))                                                        \
     {                                                                                 \
         aNetworkData.m##name = aJson.at(#name).get<decltype(aNetworkData.m##name)>(); \
     };
 
-    TEST_AND_SET(ActiveDataset);
-    TEST_AND_SET(PendingDataset);
-    TEST_AND_SET(CommDataset);
-    TEST_AND_SET(BbrDataset);
+    SET_IF_PRESENT(ActiveDataset);
+    SET_IF_PRESENT(PendingDataset);
+    SET_IF_PRESENT(CommDataset);
+    SET_IF_PRESENT(BbrDataset);
 
-#undef TEST_AND_SET
+#undef SET_IF_PRESENT
 }
 
 static void to_json(Json &aJson, const EnergyReport &aEnergyReport)

--- a/src/app/json.cpp
+++ b/src/app/json.cpp
@@ -57,12 +57,17 @@ namespace commissioner {
  * exception exclusively.
  *
  */
-class JsonException : public std::invalid_argument {
+class JsonException : public std::invalid_argument
+{
 public:
-    explicit JsonException(const std::string& what_arg)
-        : std::invalid_argument(what_arg) {}
-    explicit JsonException(const char* what_arg)
-        : std::invalid_argument(what_arg) {}
+    explicit JsonException(const std::string &what_arg)
+        : std::invalid_argument(what_arg)
+    {
+    }
+    explicit JsonException(const char *what_arg)
+        : std::invalid_argument(what_arg)
+    {
+    }
 };
 
 } // namespace commissioner
@@ -70,8 +75,10 @@ public:
 } // namespace ot
 
 #define SuccessOrThrow(aError)                                                                  \
-    do {                                                                                        \
-        if (aError != ::ot::commissioner::Error::kNone) {                                       \
+    do                                                                                          \
+    {                                                                                           \
+        if (aError != ::ot::commissioner::Error::kNone)                                         \
+        {                                                                                       \
             throw ::ot::commissioner::JsonException(::ot::commissioner::ErrorToString(aError)); \
         }                                                                                       \
     } while (false)
@@ -208,7 +215,7 @@ static void from_json(const Json &aJson, Config &aConfig)
     // TODO(wgtdkp): parse logging file.
     if (aJson.contains("LogFile"))
     {
-        auto logger = std::make_shared<FileLogger>(aJson["LogFile"], logLevel);
+        auto logger     = std::make_shared<FileLogger>(aJson["LogFile"], logLevel);
         aConfig.mLogger = std::dynamic_pointer_cast<Logger>(logger);
     }
 

--- a/src/app/json.hpp
+++ b/src/app/json.hpp
@@ -28,7 +28,7 @@
 
 /**
  * @file
- *   The file defines the json parser of Network Data and Commissioner configuration.
+ *   This file defines the json parser of Network Data and Commissioner configuration.
  *
  */
 

--- a/src/app/json.hpp
+++ b/src/app/json.hpp
@@ -70,7 +70,7 @@ std::string ActiveDatasetToJson(const ActiveOperationalDataset &aDataset);
 Error       PendingDatasetFromJson(PendingOperationalDataset &aDataset, const std::string &aJson);
 std::string PendingDatasetToJson(const PendingOperationalDataset &aDataset);
 
-Error       ConfigFromJson(Config &aConfig, const std::string &aJson);
+Error ConfigFromJson(Config &aConfig, const std::string &aJson);
 
 std::string EnergyReportToJson(const EnergyReport &aEnergyReport);
 

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -186,7 +186,7 @@ Error CommissionerImpl::Init(const Config &aConfig)
     SuccessOrExit(error = ValidateConfig(aConfig));
     mConfig = aConfig;
 
-    InitLogger(mConfig.mLogLevel, mConfig.mLogWriter);
+    InitLogger(aConfig.mLogger);
     LoggingConfig();
 
     SuccessOrExit(error = mBrClient.Init(GetDtlsConfig(mConfig)));
@@ -213,9 +213,6 @@ Error CommissionerImpl::ValidateConfig(const Config &aConfig)
         VerifyOrExit(!aConfig.mId.empty(), error = "commissioner ID is mandatory");
         VerifyOrExit(commissionerIdTlv.IsValid(), error = "invalid commissioner ID: " + aConfig.mId);
     }
-
-    VerifyOrExit(aConfig.mLogLevel <= LogLevel::kDebug,
-                 error = "invalid logging level: " + std::to_string(utils::to_underlying(aConfig.mLogLevel)));
 
     VerifyOrExit(
         (aConfig.mKeepAliveInterval >= kMinKeepAliveInterval && aConfig.mKeepAliveInterval <= kMaxKeepAliveInterval),
@@ -255,7 +252,6 @@ void CommissionerImpl::LoggingConfig()
     LOG_INFO("config: enable CCM = {}", mConfig.mEnableCcm);
     LOG_INFO("config: domain name = {}", mConfig.mDomainName);
     LOG_INFO("config: keep alive interval = {}", mConfig.mKeepAliveInterval);
-    LOG_INFO("config: log level = {}", mConfig.mLogLevel);
     LOG_INFO("config: enable DTLS debug logging = {}", mConfig.mEnableDtlsDebugLogging);
     LOG_INFO("config: maximum connection number = {}", mConfig.mMaxConnectionNum);
 

--- a/src/library/logging.cpp
+++ b/src/library/logging.cpp
@@ -44,7 +44,7 @@ void InitLogger(std::shared_ptr<Logger> aLogger)
     sLogger = aLogger;
 }
 
-std::shared_ptr<Logger> GetLogger()
+std::shared_ptr<Logger> GetLogger(void)
 {
     return sLogger;
 }

--- a/src/library/logging.hpp
+++ b/src/library/logging.hpp
@@ -57,7 +57,7 @@ namespace commissioner {
 // TODO(wgtdkp): add json format. This is useful for certification.
 
 void                    InitLogger(std::shared_ptr<Logger> aLogger);
-std::shared_ptr<Logger> GetLogger();
+std::shared_ptr<Logger> GetLogger(void);
 
 void Log(LogLevel aLevel, const std::string &aMessage);
 

--- a/src/library/logging.hpp
+++ b/src/library/logging.hpp
@@ -56,7 +56,7 @@ namespace commissioner {
 
 // TODO(wgtdkp): add json format. This is useful for certification.
 
-void InitLogger(std::shared_ptr<Logger> aLogger);
+void                    InitLogger(std::shared_ptr<Logger> aLogger);
 std::shared_ptr<Logger> GetLogger();
 
 void Log(LogLevel aLevel, const std::string &aMessage);

--- a/src/library/logging.hpp
+++ b/src/library/logging.hpp
@@ -56,9 +56,8 @@ namespace commissioner {
 
 // TODO(wgtdkp): add json format. This is useful for certification.
 
-void      InitLogger(LogLevel aLevel, LogWriter aWriter);
-LogLevel  GetLogLevel();
-LogWriter GetLogWriter();
+void InitLogger(std::shared_ptr<Logger> aLogger);
+std::shared_ptr<Logger> GetLogger();
 
 void Log(LogLevel aLevel, const std::string &aMessage);
 


### PR DESCRIPTION
This PR refine the configuration and logger:
1. Defines a new `Logger` abstract class to easily customize an application-provided logger.
2. Throw exception when parsing `Network Data` and `Config` from json file failed and convert it to the commissioner `Error`. This give the chance to return user-friendly error message for the configuration file (or Network Data file) when https://github.com/openthread/ot-commissioner/pull/45 is merged.
3. Separate file utility to `file_util.cpp`.
4. Separate file logging to `file_logger.cpp`.
5. Initialize `CommissionerApp` directly with `Config` and remove the intermediate `AppConfig`. This enable unit tests for `CommissionerApp` (coming with separate PR).
