### PR TITLE
[app] push Commissioner Dataset when connected

### DIFF
--- a/src/app/cli/README.md
+++ b/src/app/cli/README.md
@@ -356,17 +356,17 @@ OT Commissioner sends a `MGMT_PENDING_SET.req` message to set those parameters.
 > help network
 usage:
 network save <network-data-file>
-network pull
+network sync
 [done]
 >
 ```
 
-#### Pull network data
+#### Sync network data
 
-This command pulls down all Thread network data (active or pending dataset, commissioner dataset, BBR dataset) to local.
+This command pushes local Commissioner Dataset to the Thread Network and pulls down Active / Pending Dataset and BBR Dataset (if in CCM mode) to local.
 
 ```shell
-> network pull
+> network sync
 [done]
 >
 ```

--- a/src/app/cli/interpreter.cpp
+++ b/src/app/cli/interpreter.cpp
@@ -88,7 +88,7 @@ const std::map<std::string, std::string> &Interpreter::mUsageMap = *new std::map
               "token print\n"
               "token set <signed-token-hex-string-file> <signer-cert-pem-file>"},
     {"network", "network save <network-data-file>\n"
-                "network pull"},
+                "network sync"},
     {"sessionid", "sessionid"},
     {"borderagent", "borderagent discover\n"
                     "borderagent list\n"
@@ -396,9 +396,9 @@ Interpreter::Value Interpreter::ProcessNetwork(const Expression &aExpr)
         VerifyOrExit(aExpr.size() >= 3, msg = Usage(aExpr));
         SuccessOrExit(error = mCommissioner->SaveNetworkData(aExpr[2]));
     }
-    else if (CaseInsensitiveEqual(aExpr[1], "pull"))
+    else if (CaseInsensitiveEqual(aExpr[1], "sync"))
     {
-        SuccessOrExit(error = mCommissioner->PullNetworkData());
+        SuccessOrExit(error = mCommissioner->SyncNetworkData());
     }
     else
     {

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -109,6 +109,13 @@ Error CommissionerApp::Init(const AppConfig &aAppConfig)
     // This is the default behavior of OpenThread on-Mesh Commissioner.
     mCommissioner->SetCommissioningHandler(DefaultCommissioningHandler);
 
+    mCommDataset.mJoinerUdpPort = kDefaultJoinerUdpPort;
+    mCommDataset.mPresentFlags |= CommissionerDataset::kJoinerUdpPortBit;
+    mCommDataset.mAeUdpPort = kDefaultAeUdpPort;
+    mCommDataset.mPresentFlags |= CommissionerDataset::kAeUdpPortBit;
+    mCommDataset.mNmkpUdpPort = kDefaultNmkpUdpPort;
+    mCommDataset.mPresentFlags |= CommissionerDataset::kNmkpUdpPortBit;
+
 exit:
     return error;
 }

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -109,7 +109,7 @@ Error CommissionerApp::Init(const AppConfig &aAppConfig)
     // This is the default behavior of OpenThread on-Mesh Commissioner.
     mCommissioner->SetCommissioningHandler(DefaultCommissioningHandler);
 
-    SetDefaultCommissionerDataset();
+    mCommDataset = MakeDefaultCommissionerDataset();
 
 exit:
     return error;
@@ -1084,16 +1084,18 @@ bool CommissionerApp::JoinerKey::operator<(const JoinerKey &aOther) const
     return mType < aOther.mType || (mType == aOther.mType && mId < aOther.mId);
 }
 
-void CommissionerApp::SetDefaultCommissionerDataset()
+CommissionerDataset CommissionerApp::MakeDefaultCommissionerDataset()
 {
-    mCommDataset.mPresentFlags = 0;
+    CommissionerDataset dataset;
 
-    mCommDataset.mJoinerUdpPort = kDefaultJoinerUdpPort;
-    mCommDataset.mPresentFlags |= CommissionerDataset::kJoinerUdpPortBit;
-    mCommDataset.mAeUdpPort = kDefaultAeUdpPort;
-    mCommDataset.mPresentFlags |= CommissionerDataset::kAeUdpPortBit;
-    mCommDataset.mNmkpUdpPort = kDefaultNmkpUdpPort;
-    mCommDataset.mPresentFlags |= CommissionerDataset::kNmkpUdpPortBit;
+    dataset.mJoinerUdpPort = kDefaultJoinerUdpPort;
+    dataset.mPresentFlags |= CommissionerDataset::kJoinerUdpPortBit;
+    dataset.mAeUdpPort = kDefaultAeUdpPort;
+    dataset.mPresentFlags |= CommissionerDataset::kAeUdpPortBit;
+    dataset.mNmkpUdpPort = kDefaultNmkpUdpPort;
+    dataset.mPresentFlags |= CommissionerDataset::kNmkpUdpPortBit;
+
+    return dataset;
 }
 
 ByteArray &CommissionerApp::GetSteeringData(CommissionerDataset &aDataset, JoinerType aJoinerType)

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -1091,7 +1091,7 @@ CommissionerDataset CommissionerApp::MakeDefaultCommissionerDataset()
     dataset.mJoinerUdpPort = kDefaultJoinerUdpPort;
     dataset.mPresentFlags |= CommissionerDataset::kJoinerUdpPortBit;
 
-    if (mCommissioner->GetConfig().mEnableCcm)
+    if (IsCcmMode())
     {
         dataset.mAeUdpPort = kDefaultAeUdpPort;
         dataset.mPresentFlags |= CommissionerDataset::kAeUdpPortBit;

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -143,7 +143,7 @@ Error CommissionerApp::Start(std::string &      aExistingCommissionerId,
 
     // We need to report the already active commissioner ID if one exists.
     SuccessOrExit(error = mCommissioner->Petition(aExistingCommissionerId, aBorderAgentAddr, aBorderAgentPort));
-    SuccessOrExit(error = PullNetworkData());
+    SuccessOrExit(error = SyncNetworkData());
 
 exit:
     if (error != Error::kNone)
@@ -190,15 +190,14 @@ exit:
     return error;
 }
 
-Error CommissionerApp::PullNetworkData()
+Error CommissionerApp::SyncNetworkData()
 {
     Error                     error = Error::kNone;
-    CommissionerDataset       commDataset;
     ActiveOperationalDataset  activeDataset;
     PendingOperationalDataset pendingDataset;
     BbrDataset                bbrDataset;
 
-    SuccessOrExit(error = mCommissioner->GetCommissionerDataset(commDataset, 0xFFFF));
+    SuccessOrExit(error = mCommissioner->SetCommissionerDataset(mCommDataset));
     if (IsCcmMode())
     {
         SuccessOrExit(error = mCommissioner->GetBbrDataset(bbrDataset, 0xFFFF));
@@ -207,7 +206,6 @@ Error CommissionerApp::PullNetworkData()
     SuccessOrExit(error = mCommissioner->GetActiveDataset(activeDataset, 0xFFFF));
     SuccessOrExit(error = mCommissioner->GetPendingDataset(pendingDataset, 0xFFFF));
 
-    MergeDataset(mCommDataset, commDataset);
     if (IsCcmMode())
     {
         mBbrDataset = bbrDataset;

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -1090,10 +1090,14 @@ CommissionerDataset CommissionerApp::MakeDefaultCommissionerDataset()
 
     dataset.mJoinerUdpPort = kDefaultJoinerUdpPort;
     dataset.mPresentFlags |= CommissionerDataset::kJoinerUdpPortBit;
-    dataset.mAeUdpPort = kDefaultAeUdpPort;
-    dataset.mPresentFlags |= CommissionerDataset::kAeUdpPortBit;
-    dataset.mNmkpUdpPort = kDefaultNmkpUdpPort;
-    dataset.mPresentFlags |= CommissionerDataset::kNmkpUdpPortBit;
+
+    if (mCommissioner->GetConfig().mEnableCcm)
+    {
+        dataset.mAeUdpPort = kDefaultAeUdpPort;
+        dataset.mPresentFlags |= CommissionerDataset::kAeUdpPortBit;
+        dataset.mNmkpUdpPort = kDefaultNmkpUdpPort;
+        dataset.mPresentFlags |= CommissionerDataset::kNmkpUdpPortBit;
+    }
 
     return dataset;
 }

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -109,12 +109,7 @@ Error CommissionerApp::Init(const AppConfig &aAppConfig)
     // This is the default behavior of OpenThread on-Mesh Commissioner.
     mCommissioner->SetCommissioningHandler(DefaultCommissioningHandler);
 
-    mCommDataset.mJoinerUdpPort = kDefaultJoinerUdpPort;
-    mCommDataset.mPresentFlags |= CommissionerDataset::kJoinerUdpPortBit;
-    mCommDataset.mAeUdpPort = kDefaultAeUdpPort;
-    mCommDataset.mPresentFlags |= CommissionerDataset::kAeUdpPortBit;
-    mCommDataset.mNmkpUdpPort = kDefaultNmkpUdpPort;
-    mCommDataset.mPresentFlags |= CommissionerDataset::kNmkpUdpPortBit;
+    SetDefaultCommissionerDataset();
 
 exit:
     return error;
@@ -1087,6 +1082,18 @@ Error CommissionerApp::SetToken(const ByteArray &aSignedToken, const ByteArray &
 bool CommissionerApp::JoinerKey::operator<(const JoinerKey &aOther) const
 {
     return mType < aOther.mType || (mType == aOther.mType && mId < aOther.mId);
+}
+
+void CommissionerApp::SetDefaultCommissionerDataset()
+{
+    mCommDataset.mPresentFlags = 0;
+
+    mCommDataset.mJoinerUdpPort = kDefaultJoinerUdpPort;
+    mCommDataset.mPresentFlags |= CommissionerDataset::kJoinerUdpPortBit;
+    mCommDataset.mAeUdpPort = kDefaultAeUdpPort;
+    mCommDataset.mPresentFlags |= CommissionerDataset::kAeUdpPortBit;
+    mCommDataset.mNmkpUdpPort = kDefaultNmkpUdpPort;
+    mCommDataset.mPresentFlags |= CommissionerDataset::kNmkpUdpPortBit;
 }
 
 ByteArray &CommissionerApp::GetSteeringData(CommissionerDataset &aDataset, JoinerType aJoinerType)

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -192,7 +192,7 @@ exit:
     return error;
 }
 
-Error CommissionerApp::SyncNetworkData()
+Error CommissionerApp::SyncNetworkData(void)
 {
     Error                     error = Error::kNone;
     ActiveOperationalDataset  activeDataset;

--- a/src/app/commissioner_app.hpp
+++ b/src/app/commissioner_app.hpp
@@ -235,7 +235,7 @@ private:
         bool operator<(const JoinerKey &aOther) const;
     };
 
-    void SetDefaultCommissionerDataset();
+    CommissionerDataset MakeDefaultCommissionerDataset();
 
     static ByteArray &GetSteeringData(CommissionerDataset &aDataset, JoinerType aJoinerType);
     static uint16_t & GetJoinerUdpPort(CommissionerDataset &aDataset, JoinerType aJoinerType);

--- a/src/app/commissioner_app.hpp
+++ b/src/app/commissioner_app.hpp
@@ -96,8 +96,8 @@ public:
     // Save network data of current Thread network to file in JSON format.
     Error SaveNetworkData(const std::string &aFilename);
 
-    // Pull network data to local.
-    Error PullNetworkData();
+    // Sync network data between the Thread Network and Commissioner.
+    Error SyncNetworkData();
 
     /*
      * Commissioner Dataset APIs

--- a/src/app/commissioner_app.hpp
+++ b/src/app/commissioner_app.hpp
@@ -97,7 +97,7 @@ public:
     Error SaveNetworkData(const std::string &aFilename);
 
     // Sync network data between the Thread Network and Commissioner.
-    Error SyncNetworkData();
+    Error SyncNetworkData(void);
 
     /*
      * Commissioner Dataset APIs

--- a/src/app/commissioner_app.hpp
+++ b/src/app/commissioner_app.hpp
@@ -235,6 +235,8 @@ private:
         bool operator<(const JoinerKey &aOther) const;
     };
 
+    void SetDefaultCommissionerDataset();
+
     static ByteArray &GetSteeringData(CommissionerDataset &aDataset, JoinerType aJoinerType);
     static uint16_t & GetJoinerUdpPort(CommissionerDataset &aDataset, JoinerType aJoinerType);
 

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -38,6 +38,7 @@
 ##
 
 . "$(dirname "$0")"/test_announce_begin.sh
+. "$(dirname "$0")"/test_cli.sh
 . "$(dirname "$0")"/test_discover.sh
 . "$(dirname "$0")"/test_energy_scan.sh
 . "$(dirname "$0")"/test_joining.sh

--- a/tests/integration/test_cli.sh
+++ b/tests/integration/test_cli.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+#  Copyright (c) 2020, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+[ -z "${TEST_ROOT_DIR}" ] && . "$(dirname "$0")"/common.sh
+
+test_network_sync() {
+    set -e
+
+    start_otbr "${NON_CCM_NCP}" "eth0"
+    form_network "${PSKC}"
+
+    start_commissioner "${NON_CCM_CONFIG}"
+    send_command_to_commissioner "start :: 49191"
+    send_command_to_commissioner "network sync"
+    stop_commissioner
+}

--- a/tests/integration/test_cli.sh
+++ b/tests/integration/test_cli.sh
@@ -29,7 +29,8 @@
 
 [ -z "${TEST_ROOT_DIR}" ] && . "$(dirname "$0")"/common.sh
 
-test_network_sync() {
+test_network_sync()
+{
     set -e
 
     start_otbr "${NON_CCM_NCP}" "eth0"
@@ -38,5 +39,18 @@ test_network_sync() {
     start_commissioner "${NON_CCM_CONFIG}"
     send_command_to_commissioner "start :: 49191"
     send_command_to_commissioner "network sync"
+    stop_commissioner
+}
+
+test_get_commissioner_dataset()
+{
+    set -e
+
+    start_otbr "${NON_CCM_NCP}" "eth0"
+    form_network "${PSKC}"
+
+    start_commissioner "${NON_CCM_CONFIG}"
+    send_command_to_commissioner "start :: 49191"
+    send_command_to_commissioner "commdataset get"
     stop_commissioner
 }


### PR DESCRIPTION
Instead of pull Commissioner Dataset from the Thread Network, This PR pushes a default Commissioner Dataset to the Thread Network when connected.

This changes the CLI command `network pull` to `network sync`.