### PR TITLE
[travis] use GNU make for Mac OS X

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -47,10 +47,10 @@ cmake -G "${CMAKE_GEN}" \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX=/usr/local \
       -DOT_COMM_COVERAGE=ON ..
-cmake --build . "$([ "$CMAKE_GEN" != "Ninja" ] && echo "" || echo "-j2")"
+[ "$CMAKE_GEN" == "Ninja" ] && ninja || make -j2
 
 ## Install
-sudo cmake --install .
+[ "$CMAKE_GEN" == "Ninja" ] && sudo ninja install || sudo make install
 
 commissioner-cli -h
 

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -35,19 +35,22 @@ set -e
 ## Override default travis cmake
 export PATH="${HOME}/.local/bin:$PATH"
 
+CMAKE_GEN="$([ "$TRAVIS_OS_NAME" != "osx" ] && echo "Ninja" || echo "Unix Makefiles")"
+readonly CMAKE_GEN
+
 ## Build commissioner
 mkdir -p build && cd build
-cmake -GNinja \
+cmake -G "${CMAKE_GEN}" \
       -DBUILD_SHARED_LIBS="${OT_COMM_SHARED_LIB:=OFF}" \
       -DCMAKE_CXX_STANDARD="${OT_COMM_CXX_STANDARD}" \
       -DCMAKE_CXX_STANDARD_REQUIRED=ON \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX=/usr/local \
       -DOT_COMM_COVERAGE=ON ..
-ninja
+cmake --build . "$([ "$CMAKE_GEN" != "Ninja" ] && echo "" || echo "-j2")"
 
 ## Install
-sudo ninja install
+sudo cmake --install .
 
 commissioner-cli -h
 

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -50,7 +50,11 @@ cmake -G "${CMAKE_GEN}" \
 [ "$CMAKE_GEN" == "Ninja" ] && ninja || make -j2
 
 ## Install
-[ "$CMAKE_GEN" == "Ninja" ] && sudo ninja install || sudo make install
+if [ "$CMAKE_GEN" == "Ninja" ]; then
+    sudo ninja install
+else
+    sudo make install
+fi
 
 commissioner-cli -h
 


### PR DESCRIPTION
This PR changes travis CI to use GNU make rather than ninja on Mac OS X. This PR is a workaround of a known [issue](https://github.com/ninja-build/ninja/issues/1704) with ninja on Mac OS X.