### PR TITLE
[pretty] fix yapf version to 0.29.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
           packages:
             - clang-format-6.0
             - python3-pip
-      script: python3 -m pip install yapf && script/make-pretty check
+      script: python3 -m pip install yapf==0.29.0 && script/make-pretty check
     - env: OT_COMM_CXX_STANDARD=14
       os: linux
       compiler: gcc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ This will open up a text editor where you can specify which commits to squash.
 
 #### Coding conventions and style
 
-OT Commissioner uses and enforces the [OpenThread code format](./.clang-format) on all code, except for code located in [third_party](third_party).  Use `script/make-pretty` and `script/make-pretty check` to automatically reformat code and check for code-style compliance, respectively. OpenThread currently requires [clang-format v6.0.0](http://releases.llvm.org/download.html#6.0.0) for C/C++ and [yapf](https://github.com/google/yapf) for Python.
+OT Commissioner uses and enforces the [OpenThread code format](./.clang-format) on all code, except for code located in [third_party](third_party).  Use `script/make-pretty` and `script/make-pretty check` to automatically reformat code and check for code-style compliance, respectively. OpenThread currently requires [clang-format v6.0.0](http://releases.llvm.org/download.html#6.0.0) for C/C++ and [yapf v0.29.0](https://github.com/google/yapf) for Python.
 
 As part of the cleanup process, also run `script/make-pretty check` to ensure that your code passes the baseline code style checks.
 


### PR DESCRIPTION
v0.30.0 (released on 2020-04-23) introduces formatting changes that
are not compatible with v0.29.0.