### PR TITLE
[event-loop] break event loop from inside

### DIFF
--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -141,6 +141,8 @@ target_sources(commissioner-test
         coap_test.cpp
         commissioner_impl.hpp
         commissioner_impl_test.cpp
+        commissioner_safe.hpp
+        commissioner_safe_test.cpp
         cose.hpp
         cose_test.cpp
         dtls.hpp

--- a/src/library/commissioner_safe.cpp
+++ b/src/library/commissioner_safe.cpp
@@ -76,6 +76,7 @@ Error CommissionerSafe::Init(const Config &aConfig)
 
     VerifyOrExit(event_assign(&mInvokeEvent, mEventBase.Get(), -1, EV_PERSIST, Invoke, this) == 0);
     VerifyOrExit(event_add(&mInvokeEvent, nullptr) == 0);
+
 exit:
     return error;
 }

--- a/src/library/commissioner_safe.hpp
+++ b/src/library/commissioner_safe.hpp
@@ -232,7 +232,7 @@ private:
     std::queue<AsyncRequest> mAsyncRequestQueue;
 
     // The even loop thread running in background.
-    std::shared_ptr<std::thread> mEventThread;
+    std::thread mEventThread;
 };
 
 } // namespace commissioner

--- a/src/library/commissioner_safe.hpp
+++ b/src/library/commissioner_safe.hpp
@@ -52,15 +52,17 @@ namespace ot {
 
 namespace commissioner {
 
-// This is the implementation of Thread Commissioner interface.
-// It is based on the event-driven implementation and runs the
-// even loop in a background thread. All API calls are synchronized
-// to the even loop or guarded by locks, which means they can be
-// concurrently called from multiple threads.
-//
-// This is the standard Commissioner instance returned by
-// Commissioner::Create().
-//
+/**
+ * This class implements the Commissioner interface.
+ *
+ * It is based on the event-driven implementation and runs the
+ * event loop in a background thread. Accesses to the event-driven
+ * implementation are synchronized between user thread and the
+ * event-loop thread which means the user can safely call a
+ * Commissioner API from a user thread. But it is not safe to
+ * concurrently call a Commissioner API from multiple user threads.
+ *
+ */
 class CommissionerSafe : public Commissioner
 {
 public:

--- a/src/library/commissioner_safe_test.cpp
+++ b/src/library/commissioner_safe_test.cpp
@@ -1,0 +1,56 @@
+/*
+ *    Copyright (c) 2020, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file defines test cases of CommissionerSafe.
+ *
+ */
+
+#include <catch2/catch.hpp>
+
+#include "library/commissioner_safe.hpp"
+
+namespace ot {
+
+namespace commissioner {
+
+TEST_CASE("stop-immediately-after-starting", "[commissioner]")
+{
+    Config config;
+    config.mEnableCcm = false;
+    config.mPSKc = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
+
+    // This creates an CommissionerSafe instance.
+    auto commApp = Commissioner::Create(config, nullptr);
+    REQUIRE(commApp != nullptr);
+}
+
+} // namespace commissioner
+
+} // namespace ot

--- a/src/library/commissioner_safe_test.cpp
+++ b/src/library/commissioner_safe_test.cpp
@@ -47,8 +47,8 @@ TEST_CASE("stop-immediately-after-starting", "[commissioner]")
     config.mPSKc = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
 
     // This creates an CommissionerSafe instance.
-    auto commApp = Commissioner::Create(config, nullptr);
-    REQUIRE(commApp != nullptr);
+    auto commissioner = Commissioner::Create(config, nullptr);
+    REQUIRE(commissioner != nullptr);
 }
 
 } // namespace commissioner


### PR DESCRIPTION
# Problem
We were directly calling [event_base_loopbreak](http://www.wangafu.net/~nickm/libevent-2.0/doxygen/html/event_8h.html#a07a7599e478e4031fa8cf52e26d8aa1e) to stop the event loop running in background thread from user thread. It has a problem that if `event_base_loopbreak` is called even before the event loop has been started (`event_base_loop` has not been called), the event loop will not be breaked (because it has not been started yet). This will result in dead loop when we stop immediately after starting the commissioner.
```text
T     user thread                                      event loop thread
----------------------------------------------------------------------------------------
t0    commissioner->Start():start event loop thread
----------------------------------------------------------------------------------------             
t1    commissioner->Stop(): try to break event loop    (no effect)
---------------------------------------------------------------------------------------- 
t2                                                     run event loop
---------------------------------------------------------------------------------------- 
t3    join event loop thread and wait forever.
---------------------------------------------------------------------------------------- 
...
```

# Solve
This PR fixes this issue by sending `event_base_loopbreak` to the event loop and breaks it from inside the event loop. This makes sure that the event loop has been started when `event_base_loopbreak` is actually executed.
```text
T     user thread                                         event loop thread
----------------------------------------------------------------------------------------
t0    commissioner->Start():start event loop thread
----------------------------------------------------------------------------------------              
t1    commissioner->Stop(): send event-loop-break       
      event and wait for it being processed.
---------------------------------------------------------------------------------------- 
t2    waiting...                                          run event loop: process event-loop-break event
---------------------------------------------------------------------------------------- 
t3                                                        event loop is stopped and event loop thread exits.
----------------------------------------------------------------------------------------
t4    join event loop thread
----------------------------------------------------------------------------------------
t5    commissioner->Stop() exit
...
```

This PR also replaces `std::shared_ptr<std::thread>` with `std::thread` and use [`std::thread::joinable`](https://en.cppreference.com/w/cpp/thread/thread/joinable) to uniquely identifies whether the event loop thread is actively running and joinable.
