### PR TITLE
[meshcop] include KEK TLV for only JOIN_FIN.rsp message

### DIFF
--- a/src/app/file_logger.cpp
+++ b/src/app/file_logger.cpp
@@ -34,8 +34,7 @@
 
 #include "app/file_logger.hpp"
 
-#include <time.h>
-
+#include "common/time.hpp"
 #include "common/utils.hpp"
 
 namespace ot {
@@ -82,15 +81,10 @@ FileLogger::FileLogger(const std::string &aFilename, ot::commissioner::LogLevel 
 
 void FileLogger::Log(ot::commissioner::LogLevel aLevel, const std::string &aMsg)
 {
-    char      dateBuf[64];
-    struct tm localTime;
-    time_t    now = time(nullptr);
-
     VerifyOrExit(aLevel <= mLogLevel);
     VerifyOrExit(mFileStream.is_open());
 
-    strftime(dateBuf, sizeof(dateBuf), "%Y-%m-%d %H:%M:%S", localtime_r(&now, &localTime));
-    mFileStream << "[ " << dateBuf << " ] [ " << ToString(aLevel) << " ] " << aMsg << std::endl;
+    mFileStream << "[ " << TimePointToString(Clock::now()) << " ] [ " << ToString(aLevel) << " ] " << aMsg << std::endl;
 
 exit:
     return;

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -32,6 +32,8 @@ target_sources(commissioner-common
     PRIVATE
         address.cpp
         address.hpp
+        time.cpp
+        time.hpp
         utils.cpp
         utils.hpp
 )

--- a/src/common/time.cpp
+++ b/src/common/time.cpp
@@ -44,8 +44,8 @@ namespace commissioner {
 
 std::string TimePointToString(const TimePoint &aTimePoint)
 {
-    struct tm   localTime;
-    std::time_t time = Clock::to_time_t(aTimePoint);
+    struct tm         localTime;
+    std::time_t       time = Clock::to_time_t(aTimePoint);
     std::stringstream ss;
 
     localtime_r(&time, &localTime);

--- a/src/common/time.cpp
+++ b/src/common/time.cpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright (c) 2019, The OpenThread Authors.
+ *    Copyright (c) 2020, The OpenThread Authors.
  *    All rights reserved.
  *
  *    Redistribution and use in source and binary forms, with or without
@@ -26,42 +26,33 @@
  *    POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef OT_COMM_LIBRARY_ENDPOINT_HPP_
-#define OT_COMM_LIBRARY_ENDPOINT_HPP_
+/**
+ * @file
+ *   This file implements time measurements.
+ */
 
-#include <functional>
-#include <stdint.h>
-#include <string>
+#include "time.hpp"
 
-#include <commissioner/error.hpp>
+#include <time.h>
 
-#include "common/address.hpp"
-#include "library/message.hpp"
+#include <iomanip>
+#include <sstream>
 
 namespace ot {
 
 namespace commissioner {
 
-class Endpoint
+std::string TimePointToString(const TimePoint &aTimePoint)
 {
-public:
-    using Receiver = std::function<void(Endpoint &, const ByteArray &)>;
+    struct tm   localTime;
+    std::time_t time = Clock::to_time_t(aTimePoint);
+    localtime_r(&time, &localTime);
 
-    Endpoint()          = default;
-    virtual ~Endpoint() = default;
-
-    virtual Error    Send(const ByteArray &aBuf, MessageSubType aSubType) = 0;
-    virtual Address  GetPeerAddr() const                                  = 0;
-    virtual uint16_t GetPeerPort() const                                  = 0;
-
-    void SetReceiver(Receiver aReceiver) { mReceiver = aReceiver; }
-
-protected:
-    Receiver mReceiver = nullptr;
-};
+    std::stringstream ss;
+    ss << std::put_time(&localTime, "%Y-%m-%d %H:%M:%S");
+    return ss.str();
+}
 
 } // namespace commissioner
 
 } // namespace ot
-
-#endif // OT_COMM_LIBRARY_ENDPOINT_HPP_

--- a/src/common/time.cpp
+++ b/src/common/time.cpp
@@ -46,9 +46,9 @@ std::string TimePointToString(const TimePoint &aTimePoint)
 {
     struct tm   localTime;
     std::time_t time = Clock::to_time_t(aTimePoint);
-    localtime_r(&time, &localTime);
-
     std::stringstream ss;
+
+    localtime_r(&time, &localTime);
     ss << std::put_time(&localTime, "%Y-%m-%d %H:%M:%S");
     return ss.str();
 }

--- a/src/common/time.hpp
+++ b/src/common/time.hpp
@@ -31,10 +31,11 @@
  *   This file includes definition for time measurements.
  */
 
-#ifndef OT_COMM_LIBRARY_TIME_HPP_
-#define OT_COMM_LIBRARY_TIME_HPP_
+#ifndef OT_COMM_COMMON_TIME_HPP_
+#define OT_COMM_COMMON_TIME_HPP_
 
 #include <chrono>
+#include <string>
 
 namespace ot {
 
@@ -51,8 +52,10 @@ template <typename D> D NowSinceEpoch()
     return now.time_since_epoch();
 }
 
+std::string TimePointToString(const TimePoint &aTimePoint);
+
 } // namespace commissioner
 
 } // namespace ot
 
-#endif // OT_COMM_LIBRARY_TIME_HPP_
+#endif // OT_COMM_COMMON_TIME_HPP_

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -51,6 +51,7 @@ target_sources(commissioner
         event.hpp
         logging.cpp
         logging.hpp
+        message.hpp
         network_data.cpp
         openthread/bloom_filter.cpp
         openthread/bloom_filter.hpp
@@ -64,7 +65,6 @@ target_sources(commissioner
         openthread/sha256.hpp
         socket.cpp
         socket.hpp
-        time.hpp
         timer.hpp
         tlv.cpp
         tlv.hpp

--- a/src/library/coap.cpp
+++ b/src/library/coap.cpp
@@ -55,6 +55,7 @@ Message::Message(Type aType, Code aCode)
 }
 
 Message::Message()
+    : mSubType(MessageSubType::kNone)
 {
     SetVersion(kVersion1);
 }
@@ -491,13 +492,14 @@ void Coap::HandleRequest(const Request &aRequest)
     std::string                          uriPath;
     decltype(mResources)::const_iterator resource;
 
+    SuccessOrExit(error = aRequest.GetUriPath(uriPath));
+
     response = mResponsesCache.Match(aRequest);
     if (response != nullptr)
     {
+        LOG_INFO("found cached CoAP response for resource {}", uriPath);
         ExitNow(error = Send(*response));
     }
-
-    SuccessOrExit(error = aRequest.GetUriPath(uriPath));
 
     resource = mResources.find(uriPath);
     if (resource != mResources.end())
@@ -694,7 +696,7 @@ Error Coap::Send(const Message &aMessage)
         aMessage.SetEndpoint(&mEndpoint);
     }
 
-    error = aMessage.GetEndpoint()->Send(data);
+    error = aMessage.GetEndpoint()->Send(data, aMessage.GetSubType());
     SuccessOrExit(error);
 
 exit:

--- a/src/library/coap.hpp
+++ b/src/library/coap.hpp
@@ -48,6 +48,7 @@
 #include "common/address.hpp"
 #include "common/utils.hpp"
 #include "library/endpoint.hpp"
+#include "library/message.hpp"
 #include "library/timer.hpp"
 
 namespace ot {
@@ -535,6 +536,9 @@ public:
 
     Endpoint *GetEndpoint() const { return mEndpoint; }
 
+    MessageSubType GetSubType() const { return mSubType; }
+    void           SetSubType(MessageSubType aSubType) { mSubType = aSubType; }
+
     static Error NormalizeUriPath(std::string &uriPath);
 
 protected:
@@ -573,6 +577,8 @@ protected:
     Header                            mHeader;
     std::map<OptionType, OptionValue> mOptions;
     ByteArray                         mPayload;
+
+    MessageSubType mSubType;
 
     mutable Endpoint *mEndpoint = nullptr;
 };

--- a/src/library/coap_secure.hpp
+++ b/src/library/coap_secure.hpp
@@ -80,6 +80,17 @@ public:
         mDtlsSession.Connect(aOnConnected);
     }
 
+    Error GetLocalAddr(Address &aAddr) const
+    {
+        Error error = Error::kNone;
+
+        VerifyOrExit(mSocket->IsConnected(), error = Error::kInvalidState);
+        aAddr = mSocket->GetLocalAddr();
+
+    exit:
+        return error;
+    }
+
     void Stop() { Disconnect(); }
 
     void Disconnect()

--- a/src/library/coap_test.cpp
+++ b/src/library/coap_test.cpp
@@ -291,8 +291,10 @@ public:
 
     void SetPeer(MockEndpoint *aPeer) { mPeer = aPeer; }
 
-    Error Send(const ByteArray &aBuf) override
+    Error Send(const ByteArray &aBuf, MessageSubType aSubType) override
     {
+        (void)aSubType;
+
         if (!mDropMessage)
         {
             mSendQueue.emplace(aBuf);

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -2111,8 +2111,8 @@ void CommissionerImpl::HandleRlyRx(const coap::Request &aRlyRx)
             it = mCommissioningSessions
                      .emplace(std::piecewise_construct, std::forward_as_tuple(joinerIid),
                               std::forward_as_tuple(*this, *joinerInfo, joinerUdpPort, joinerRouterLocator, joinerIid,
-                                                    aRlyRx.GetEndpoint()->GetPeerAddr(), aRlyRx.GetEndpoint()->GetPeerPort(),
-                                                    localAddr, kCommissioningPort))
+                                                    aRlyRx.GetEndpoint()->GetPeerAddr(),
+                                                    aRlyRx.GetEndpoint()->GetPeerPort(), localAddr, kCommissioningPort))
                      .first;
             auto &session = it->second;
 

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -2105,11 +2105,14 @@ void CommissionerImpl::HandleRlyRx(const coap::Request &aRlyRx)
 
         if (it == mCommissioningSessions.end())
         {
+            Address localAddr;
+
+            SuccessOrExit(error = mBrClient.GetLocalAddr(localAddr));
             it = mCommissioningSessions
                      .emplace(std::piecewise_construct, std::forward_as_tuple(joinerIid),
                               std::forward_as_tuple(*this, *joinerInfo, joinerUdpPort, joinerRouterLocator, joinerIid,
-                                                    aRlyRx.GetEndpoint()->GetPeerAddr(),
-                                                    aRlyRx.GetEndpoint()->GetPeerPort()))
+                                                    aRlyRx.GetEndpoint()->GetPeerAddr(), aRlyRx.GetEndpoint()->GetPeerPort(),
+                                                    localAddr, kCommissioningPort))
                      .first;
             auto &session = it->second;
 
@@ -2141,13 +2144,15 @@ void CommissionerImpl::HandleRlyRx(const coap::Request &aRlyRx)
             }
             else
             {
+                LOG_INFO("commissioning timer started, expiration-time={}",
+                         TimePointToString(session.GetExpirationTime()));
                 mCommissioningSessionTimer.Start(session.GetExpirationTime());
             }
         }
 
         ASSERT(it != mCommissioningSessions.end());
         auto &session = it->second;
-        SuccessOrExit(error = session.RecvJoinerDtlsRecords(dtlsRecords));
+        session.RecvJoinerDtlsRecords(dtlsRecords);
     }
 
 exit:
@@ -2161,9 +2166,11 @@ void CommissionerImpl::HandleCommissioningSessionTimer(Timer &aTimer)
 {
     TimePoint nextShot;
     bool      hasNextShot = false;
+    auto      now         = Clock::now();
 
-    auto now = Clock::now();
-    auto it  = mCommissioningSessions.begin();
+    LOG_DEBUG("commissioning session timer triggered");
+
+    auto it = mCommissioningSessions.begin();
     while (it != mCommissioningSessions.end())
     {
         auto &session = it->second;

--- a/src/library/dtls.hpp
+++ b/src/library/dtls.hpp
@@ -93,7 +93,7 @@ public:
     DtlsSession(const DtlsSession &aOther) = delete;
     const DtlsSession &operator=(const DtlsSession &aOther) = delete;
 
-    Error Send(const ByteArray &aBuf) override;
+    Error Send(const ByteArray &aBuf, MessageSubType aSubType) override;
 
     Error Init(const DtlsConfig &aConfig);
 
@@ -104,7 +104,8 @@ public:
     Error Bind(const std::string &aBindIp, uint16_t aPort);
     void  Disconnect(Error aError);
 
-    State GetState() const { return mState; }
+    State       GetState() const { return mState; }
+    std::string GetStateString() const;
 
     Address  GetPeerAddr() const override { return mSocket->GetPeerAddr(); }
     uint16_t GetPeerPort() const override { return mSocket->GetPeerPort(); }
@@ -154,7 +155,7 @@ private:
     //   Error::kInvalidArgs
     //   Error::kTransportBusy
     //   Error::kTransportFailed
-    Error Write(const ByteArray &aBuf);
+    Error Write(const ByteArray &aBuf, MessageSubType aSubType);
 
     Error TryWrite();
 
@@ -193,7 +194,7 @@ private:
 
     ConnectHandler mOnConnected = nullptr;
 
-    std::queue<ByteArray> mSendQueue;
+    std::queue<std::pair<ByteArray, MessageSubType>> mSendQueue;
 
     std::vector<int>         mCipherSuites;
     mbedtls_ssl_config       mConfig;

--- a/src/library/dtls_test.cpp
+++ b/src/library/dtls_test.cpp
@@ -161,7 +161,7 @@ TEST_CASE("dtls-mbedtls-client-server", "[dtls]")
         REQUIRE(aError == Error::kNone);
         REQUIRE(aSession.GetState() == DtlsSession::State::kConnected);
 
-        REQUIRE(aSession.Send(kHello) == Error::kNone);
+        REQUIRE(aSession.Send(kHello, MessageSubType::kNone) == Error::kNone);
     };
     dtlsClient.Connect(clientConnected);
 

--- a/src/library/message.hpp
+++ b/src/library/message.hpp
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for abstract message.
+ */
+
+#ifndef OT_COMM_LIBRARY_MESSAGE_HPP_
+#define OT_COMM_LIBRARY_MESSAGE_HPP_
+
+#include <stdint.h>
+
+namespace ot {
+
+namespace commissioner {
+
+/**
+ * This class represents the message sub-type.
+ *
+ * It is designed to carry additional information about
+ * the message when processed by low-level transporter.
+ *
+ */
+enum class MessageSubType : uint8_t
+{
+    kNone = 0,        ///< None
+    kJoinFinResponse, ///< Joiner Finalize Response (JOIN_FIN.rsp)
+};
+
+} // namespace commissioner
+
+} // namespace ot
+
+#endif // OT_COMM_LIBRARY_MESSAGE_HPP_

--- a/src/library/network_data.cpp
+++ b/src/library/network_data.cpp
@@ -34,8 +34,8 @@
 #include <commissioner/network_data.hpp>
 
 #include "common/address.hpp"
+#include "common/time.hpp"
 #include "common/utils.hpp"
-#include "library/time.hpp"
 
 namespace ot {
 

--- a/src/library/socket.hpp
+++ b/src/library/socket.hpp
@@ -43,6 +43,7 @@
 
 #include "common/address.hpp"
 #include "library/event.hpp"
+#include "library/message.hpp"
 
 namespace ot {
 
@@ -81,6 +82,12 @@ public:
 
     virtual void SetEventHandler(EventHandler aEventHandler) { mEventHandler = aEventHandler; }
 
+    // Set the sub-type of the next message. Required by CommissioningSession::RelaySocket.
+    MessageSubType GetSubType() const { return mSubType; }
+
+    // Get the sub-type of the next message. Required by CommissioningSession::RelaySocket.
+    void SetSubType(MessageSubType aSubType) { mSubType = aSubType; }
+
     // Designed for mbedtls callbacks.
     static int Send(void *aSocket, const uint8_t *aBuf, size_t aLen);
     static int Receive(void *aSocket, uint8_t *aBuf, size_t aMaxLen);
@@ -92,6 +99,8 @@ protected:
     struct event       mEvent;
     EventHandler       mEventHandler;
     bool               mIsConnected;
+
+    MessageSubType mSubType;
 };
 
 using SocketPtr = std::shared_ptr<Socket>;
@@ -129,34 +138,6 @@ using UdpSocketPtr = std::shared_ptr<UdpSocket>;
 
 class MockSocket;
 using MockSocketPtr = std::shared_ptr<MockSocket>;
-
-class MockSocket : public Socket
-{
-public:
-    MockSocket(struct event_base *aEventBase, const Address &aLocalAddr, uint16_t aLocalPort);
-    MockSocket(MockSocket &&aOther);
-    ~MockSocket() override = default;
-
-    uint16_t GetLocalPort() const override { return mLocalPort; }
-    Address  GetLocalAddr() const override { return mLocalAddr; }
-    uint16_t GetPeerPort() const override { return mPeerSocket->GetLocalPort(); }
-    Address  GetPeerAddr() const override { return mPeerSocket->GetLocalAddr(); }
-
-    int Send(const uint8_t *aBuf, size_t aLen) override;
-    int Receive(uint8_t *aBuf, size_t aMaxLen) override;
-
-    int Send(const ByteArray &aBuf);
-    int Receive(ByteArray &aBuf);
-
-    int Connect(MockSocketPtr aPeerSocket);
-
-private:
-    Address  mLocalAddr;
-    uint16_t mLocalPort;
-
-    MockSocketPtr mPeerSocket;
-    ByteArray     mRecvBuf;
-};
 
 } // namespace commissioner
 

--- a/src/library/socket_test.cpp
+++ b/src/library/socket_test.cpp
@@ -126,14 +126,15 @@ int MockSocket::Receive(ByteArray &aBuf)
 {
     uint8_t buf[512];
     int     rval;
+
     while ((rval = Receive(buf, sizeof(buf))) > 0)
     {
         aBuf.insert(aBuf.end(), buf, buf + rval);
     }
-    if (rval == MBEDTLS_ERR_SSL_WANT_READ && !aBuf.empty())
-    {
-        return 0;
-    }
+
+    VerifyOrExit(rval != MBEDTLS_ERR_SSL_WANT_READ || aBuf.empty(), rval = 0);
+
+exit:
     return rval;
 }
 

--- a/src/library/socket_test.cpp
+++ b/src/library/socket_test.cpp
@@ -33,7 +33,7 @@
 
 #include "library/socket.hpp"
 
-#include "memory.h"
+#include <memory.h>
 
 #include <catch2/catch.hpp>
 

--- a/src/library/socket_test.cpp
+++ b/src/library/socket_test.cpp
@@ -33,7 +33,11 @@
 
 #include "library/socket.hpp"
 
+#include "memory.h"
+
 #include <catch2/catch.hpp>
+
+#include "common/utils.hpp"
 
 namespace ot {
 
@@ -43,6 +47,109 @@ static std::string kServerAddr = "::";
 static uint16_t    kServerPort = 9527;
 static std::string kClientAddr = "::";
 static uint16_t    kClientPort = 12345;
+
+class MockSocket : public Socket
+{
+public:
+    MockSocket(struct event_base *aEventBase, const Address &aLocalAddr, uint16_t aLocalPort);
+    MockSocket(MockSocket &&aOther);
+    ~MockSocket() override = default;
+
+    uint16_t GetLocalPort() const override { return mLocalPort; }
+    Address  GetLocalAddr() const override { return mLocalAddr; }
+    uint16_t GetPeerPort() const override { return mPeerSocket->GetLocalPort(); }
+    Address  GetPeerAddr() const override { return mPeerSocket->GetLocalAddr(); }
+
+    int Send(const uint8_t *aBuf, size_t aLen) override;
+    int Receive(uint8_t *aBuf, size_t aMaxLen) override;
+
+    int Send(const ByteArray &aBuf);
+    int Receive(ByteArray &aBuf);
+
+    int Connect(MockSocketPtr aPeerSocket);
+
+private:
+    Address  mLocalAddr;
+    uint16_t mLocalPort;
+
+    MockSocketPtr mPeerSocket;
+    ByteArray     mRecvBuf;
+};
+
+MockSocket::MockSocket(struct event_base *aEventBase, const Address &aLocalAddr, uint16_t aLocalPort)
+    : Socket(aEventBase)
+    , mLocalAddr(aLocalAddr)
+    , mLocalPort(aLocalPort)
+    , mPeerSocket(nullptr)
+{
+}
+
+MockSocket::MockSocket(MockSocket &&aOther)
+    : Socket(std::move(aOther))
+    , mLocalAddr(std::move(aOther.mLocalAddr))
+    , mLocalPort(std::move(aOther.mLocalPort))
+    , mPeerSocket(std::move(aOther.mPeerSocket))
+{
+}
+
+int MockSocket::Send(const uint8_t *aBuf, size_t aLen)
+{
+    ASSERT(IsConnected());
+
+    auto &peerRecvBuf = mPeerSocket->mRecvBuf;
+
+    peerRecvBuf.insert(peerRecvBuf.end(), aBuf, aBuf + aLen);
+    event_active(&mPeerSocket->mEvent, EV_READ, 0);
+
+    return static_cast<int>(aLen);
+}
+
+int MockSocket::Receive(uint8_t *aBuf, size_t aMaxLen)
+{
+    if (mRecvBuf.empty())
+    {
+        return MBEDTLS_ERR_SSL_WANT_READ;
+    }
+    auto len = std::min(aMaxLen, mRecvBuf.size());
+    memcpy(aBuf, mRecvBuf.data(), len);
+    mRecvBuf.erase(mRecvBuf.begin(), mRecvBuf.begin() + len);
+    return static_cast<int>(len);
+}
+
+int MockSocket::Send(const ByteArray &aBuf)
+{
+    ASSERT(!aBuf.empty());
+    return Send(aBuf.data(), aBuf.size());
+}
+
+int MockSocket::Receive(ByteArray &aBuf)
+{
+    uint8_t buf[512];
+    int     rval;
+    while ((rval = Receive(buf, sizeof(buf))) > 0)
+    {
+        aBuf.insert(aBuf.end(), buf, buf + rval);
+    }
+    if (rval == MBEDTLS_ERR_SSL_WANT_READ && !aBuf.empty())
+    {
+        return 0;
+    }
+    return rval;
+}
+
+int MockSocket::Connect(MockSocketPtr aPeerSocket)
+{
+    mPeerSocket  = aPeerSocket;
+    mIsConnected = true;
+
+    // Setup Event
+    int rval = event_assign(&mEvent, mEventBase, -1, EV_PERSIST | EV_READ | EV_WRITE | EV_ET, HandleEvent, this);
+    VerifyOrExit(rval == 0);
+    VerifyOrExit((rval = event_add(&mEvent, nullptr)) == 0);
+
+exit:
+    return rval;
+}
 
 TEST_CASE("UDP-socket-hello", "[socket]")
 {

--- a/src/library/timer.hpp
+++ b/src/library/timer.hpp
@@ -33,9 +33,9 @@
 
 #include <commissioner/error.hpp>
 
+#include "common/time.hpp"
 #include "common/utils.hpp"
 #include "library/event.hpp"
-#include "library/time.hpp"
 
 namespace ot {
 

--- a/src/library/udp_proxy.cpp
+++ b/src/library/udp_proxy.cpp
@@ -44,11 +44,13 @@ namespace commissioner {
 /**
  * Encapsulate the request and send it as a UDP_TX.ntf message.
  */
-Error ProxyEndpoint::Send(const ByteArray &aRequest)
+Error ProxyEndpoint::Send(const ByteArray &aRequest, MessageSubType aSubType)
 {
     Error         error = Error::kNone;
     coap::Request udpTx{coap::Type::kNonConfirmable, coap::Code::kPost};
     ByteArray     udpPayload;
+
+    (void)aSubType;
 
     ASSERT(GetPeerAddr().IsValid() && GetPeerAddr().IsIpv6());
 

--- a/src/library/udp_proxy.hpp
+++ b/src/library/udp_proxy.hpp
@@ -61,7 +61,7 @@ public:
     }
     ~ProxyEndpoint() override = default;
 
-    Error    Send(const ByteArray &aBuf) override;
+    Error    Send(const ByteArray &aBuf, MessageSubType aSubType) override;
     Address  GetPeerAddr() const override { return mPeerAddr; }
     uint16_t GetPeerPort() const override { return mPeerPort; }
 


### PR DESCRIPTION
This PR fixes the issues that the `KEK TLV` is not included for only `JOIN_FIN.rsp` messages.

