### PR TITLE
[app] clear network data when stopped

### DIFF
--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -112,6 +112,14 @@ exit:
 void CommissionerApp::Stop()
 {
     IgnoreError(mCommissioner->Resign());
+
+    mJoiners.clear();
+    mPanIdConflicts.clear();
+    mEnergyReports.clear();
+    mActiveDataset  = ActiveOperationalDataset();
+    mPendingDataset = PendingOperationalDataset();
+    mCommDataset    = MakeDefaultCommissionerDataset();
+    mBbrDataset     = BbrDataset();
 }
 
 void CommissionerApp::AbortRequests()

--- a/src/app/commissioner_app.hpp
+++ b/src/app/commissioner_app.hpp
@@ -234,8 +234,6 @@ private:
 
     ByteArray mSignedToken;
 
-    std::list<BorderAgent> mBorderAgents;
-
 private:
     void HandlePanIdConflict(const std::string *aPeerAddr,
                              const ChannelMask *aChannelMask,

--- a/src/app/commissioner_app.hpp
+++ b/src/app/commissioner_app.hpp
@@ -48,6 +48,7 @@
 #include <commissioner/commissioner.hpp>
 #include <commissioner/network_data.hpp>
 
+#include "app/border_agent.hpp"
 #include "common/address.hpp"
 
 namespace ot {
@@ -231,9 +232,9 @@ private:
 
     std::shared_ptr<Commissioner> mCommissioner;
 
-    std::map<JoinerKey, JoinerInfo> mJoiners;
-
     ByteArray mSignedToken;
+
+    std::list<BorderAgent> mBorderAgents;
 
 private:
     void HandlePanIdConflict(const std::string *aPeerAddr,
@@ -244,9 +245,6 @@ private:
                             const ChannelMask *aChannelMask,
                             const ByteArray *  aEnergyList,
                             Error              aError);
-
-    std::map<uint16_t, ChannelMask> mPanIdConflicts;
-    EnergyReportMap                 mEnergyReports;
 
     void HandleDatasetChanged(Error error);
 
@@ -259,12 +257,15 @@ private:
                              const ByteArray &  aVendorData);
 
     /*
-     * Below are network data associated to the connected Thread network.
+     * Below are data associated with the connected Thread Network.
      */
-    ActiveOperationalDataset  mActiveDataset;
-    PendingOperationalDataset mPendingDataset;
-    CommissionerDataset       mCommDataset;
-    BbrDataset                mBbrDataset;
+    std::map<JoinerKey, JoinerInfo> mJoiners;
+    std::map<uint16_t, ChannelMask> mPanIdConflicts;
+    EnergyReportMap                 mEnergyReports;
+    ActiveOperationalDataset        mActiveDataset;
+    PendingOperationalDataset       mPendingDataset;
+    CommissionerDataset             mCommDataset;
+    BbrDataset                      mBbrDataset;
 };
 
 } // namespace commissioner


### PR DESCRIPTION
This PR clears data associated with the connected Thread Network when the commissioner is stopped (disconnected from the Thread Network).