### PR TITLE
[logging] make FileLogger thread safe

### DIFF
--- a/src/app/file_logger.hpp
+++ b/src/app/file_logger.hpp
@@ -35,8 +35,10 @@
 #ifndef OT_COMM_APP_FILE_LOGGER_HPP_
 #define OT_COMM_APP_FILE_LOGGER_HPP_
 
-#include <fstream>
+#include <mutex>
 #include <string>
+
+#include <stdio.h>
 
 #include <commissioner/commissioner.hpp>
 
@@ -51,21 +53,30 @@ namespace commissioner {
 class FileLogger : public Logger
 {
 public:
+    ~FileLogger() override;
+
     /**
-     * The constructor with given log file name and minimum log level.
+     * This function returns a file logger with given filename and minimum log level.
      *
      * @param[in] aFilename  The log file name.
      * @param[in] aLogLevel  The minimum log level. Log messages with a lower
      *                       log level than this will be dropped silently.
      *
+     * @retval Error::kNone  Successfully created the file logger.
+     * @retval ...           Failed to create the file logger.
+     *
      */
-    FileLogger(const std::string &aFilename, LogLevel aLogLevel);
+    static Error Create(std::shared_ptr<FileLogger> &aFileLogger, const std::string &aFilename, LogLevel aLogLevel);
 
     void Log(LogLevel aLevel, const std::string &aMsg) override;
 
 private:
-    std::ofstream mFileStream;
-    LogLevel      mLogLevel;
+    FileLogger() = default;
+    Error Init(const std::string &aFilename, LogLevel aLogLevel);
+
+    FILE *     mLogFile;
+    LogLevel   mLogLevel;
+    std::mutex mLogMutex;
 };
 
 } // namespace commissioner

--- a/src/app/json.cpp
+++ b/src/app/json.cpp
@@ -75,13 +75,13 @@ private:
 
 } // namespace ot
 
-#define SuccessOrThrow(aError)                                  \
-    do                                                          \
-    {                                                           \
-        if (aError != ::ot::commissioner::Error::kNone)         \
-        {                                                       \
-            throw ::ot::commissioner::JsonException(aError);    \
-        }                                                       \
+#define SuccessOrThrow(aError)                               \
+    do                                                       \
+    {                                                        \
+        if (aError != ::ot::commissioner::Error::kNone)      \
+        {                                                    \
+            throw ::ot::commissioner::JsonException(aError); \
+        }                                                    \
     } while (false)
 
 /**
@@ -552,13 +552,11 @@ Error CommissionerDatasetFromJson(CommissionerDataset &aDataset, const std::stri
     try
     {
         aDataset = Json::parse(StripComments(aJson));
-        error = Error::kNone;
-    }
-    catch (JsonException &e)
+        error    = Error::kNone;
+    } catch (JsonException &e)
     {
         error = e.GetError();
-    }
-    catch (std::exception &e)
+    } catch (std::exception &e)
     {
         error = Error::kBadFormat;
     }
@@ -579,13 +577,11 @@ Error BbrDatasetFromJson(BbrDataset &aDataset, const std::string &aJson)
     try
     {
         aDataset = Json::parse(StripComments(aJson));
-        error = Error::kNone;
-    }
-    catch (JsonException &e)
+        error    = Error::kNone;
+    } catch (JsonException &e)
     {
         error = e.GetError();
-    }
-    catch (std::exception &e)
+    } catch (std::exception &e)
     {
         error = Error::kBadFormat;
     }
@@ -606,13 +602,11 @@ Error ActiveDatasetFromJson(ActiveOperationalDataset &aDataset, const std::strin
     try
     {
         aDataset = Json::parse(StripComments(aJson));
-        error = Error::kNone;
-    }
-    catch (JsonException &e)
+        error    = Error::kNone;
+    } catch (JsonException &e)
     {
         error = e.GetError();
-    }
-    catch (std::exception &e)
+    } catch (std::exception &e)
     {
         error = Error::kBadFormat;
     }
@@ -633,13 +627,11 @@ Error PendingDatasetFromJson(PendingOperationalDataset &aDataset, const std::str
     try
     {
         aDataset = Json::parse(StripComments(aJson));
-        error = Error::kNone;
-    }
-    catch (JsonException &e)
+        error    = Error::kNone;
+    } catch (JsonException &e)
     {
         error = e.GetError();
-    }
-    catch (std::exception &e)
+    } catch (std::exception &e)
     {
         error = Error::kBadFormat;
     }
@@ -660,13 +652,11 @@ Error ConfigFromJson(Config &aConfig, const std::string &aJson)
     try
     {
         aConfig = Json::parse(StripComments(aJson));
-        error = Error::kNone;
-    }
-    catch (JsonException &e)
+        error   = Error::kNone;
+    } catch (JsonException &e)
     {
         error = e.GetError();
-    }
-    catch (std::exception &e)
+    } catch (std::exception &e)
     {
         error = Error::kBadFormat;
     }

--- a/src/app/json.cpp
+++ b/src/app/json.cpp
@@ -213,8 +213,10 @@ static void from_json(const Json &aJson, Config &aConfig)
 
     if (aJson.contains("LogFile"))
     {
-        auto logger     = std::make_shared<FileLogger>(aJson["LogFile"], logLevel);
-        aConfig.mLogger = std::dynamic_pointer_cast<Logger>(logger);
+        std::shared_ptr<FileLogger> logger;
+
+        SuccessOrThrow(FileLogger::Create(logger, aJson["LogFile"], logLevel));
+        aConfig.mLogger = logger;
     }
 
     if (aJson.contains("PSKc"))

--- a/src/app/json.cpp
+++ b/src/app/json.cpp
@@ -59,27 +59,29 @@ namespace commissioner {
 class JsonException : public std::invalid_argument
 {
 public:
-    explicit JsonException(const std::string &what_arg)
-        : std::invalid_argument(what_arg)
+    explicit JsonException(Error aError)
+        : std::invalid_argument(ErrorToString(aError))
+        , mError(aError)
     {
     }
-    explicit JsonException(const char *what_arg)
-        : std::invalid_argument(what_arg)
-    {
-    }
+
+    Error GetError() const { return mError; }
+
+private:
+    Error mError;
 };
 
 } // namespace commissioner
 
 } // namespace ot
 
-#define SuccessOrThrow(aError)                                                                  \
-    do                                                                                          \
-    {                                                                                           \
-        if (aError != ::ot::commissioner::Error::kNone)                                         \
-        {                                                                                       \
-            throw ::ot::commissioner::JsonException(::ot::commissioner::ErrorToString(aError)); \
-        }                                                                                       \
+#define SuccessOrThrow(aError)                                  \
+    do                                                          \
+    {                                                           \
+        if (aError != ::ot::commissioner::Error::kNone)         \
+        {                                                       \
+            throw ::ot::commissioner::JsonException(aError);    \
+        }                                                       \
     } while (false)
 
 /**
@@ -545,14 +547,23 @@ std::string NetworkDataToJson(const NetworkData &aNetworkData)
 
 Error CommissionerDatasetFromJson(CommissionerDataset &aDataset, const std::string &aJson)
 {
+    Error error;
+
     try
     {
         aDataset = Json::parse(StripComments(aJson));
-        return Error::kNone;
-    } catch (std::exception &e)
-    {
-        return Error::kBadFormat;
+        error = Error::kNone;
     }
+    catch (JsonException &e)
+    {
+        error = e.GetError();
+    }
+    catch (std::exception &e)
+    {
+        error = Error::kBadFormat;
+    }
+
+    return error;
 }
 
 std::string CommissionerDatasetToJson(const CommissionerDataset &aDataset)
@@ -563,14 +574,23 @@ std::string CommissionerDatasetToJson(const CommissionerDataset &aDataset)
 
 Error BbrDatasetFromJson(BbrDataset &aDataset, const std::string &aJson)
 {
+    Error error;
+
     try
     {
         aDataset = Json::parse(StripComments(aJson));
-        return Error::kNone;
-    } catch (std::exception &e)
-    {
-        return Error::kBadFormat;
+        error = Error::kNone;
     }
+    catch (JsonException &e)
+    {
+        error = e.GetError();
+    }
+    catch (std::exception &e)
+    {
+        error = Error::kBadFormat;
+    }
+
+    return error;
 }
 
 std::string BbrDatasetToJson(const BbrDataset &aDataset)
@@ -581,14 +601,23 @@ std::string BbrDatasetToJson(const BbrDataset &aDataset)
 
 Error ActiveDatasetFromJson(ActiveOperationalDataset &aDataset, const std::string &aJson)
 {
+    Error error;
+
     try
     {
         aDataset = Json::parse(StripComments(aJson));
-        return Error::kNone;
-    } catch (std::exception &e)
-    {
-        return Error::kBadFormat;
+        error = Error::kNone;
     }
+    catch (JsonException &e)
+    {
+        error = e.GetError();
+    }
+    catch (std::exception &e)
+    {
+        error = Error::kBadFormat;
+    }
+
+    return error;
 }
 
 std::string ActiveDatasetToJson(const ActiveOperationalDataset &aDataset)
@@ -599,14 +628,23 @@ std::string ActiveDatasetToJson(const ActiveOperationalDataset &aDataset)
 
 Error PendingDatasetFromJson(PendingOperationalDataset &aDataset, const std::string &aJson)
 {
+    Error error;
+
     try
     {
         aDataset = Json::parse(StripComments(aJson));
-        return Error::kNone;
-    } catch (std::exception &e)
-    {
-        return Error::kBadFormat;
+        error = Error::kNone;
     }
+    catch (JsonException &e)
+    {
+        error = e.GetError();
+    }
+    catch (std::exception &e)
+    {
+        error = Error::kBadFormat;
+    }
+
+    return error;
 }
 
 std::string PendingDatasetToJson(const PendingOperationalDataset &aDataset)
@@ -617,14 +655,23 @@ std::string PendingDatasetToJson(const PendingOperationalDataset &aDataset)
 
 Error ConfigFromJson(Config &aConfig, const std::string &aJson)
 {
+    Error error;
+
     try
     {
         aConfig = Json::parse(StripComments(aJson));
-        return Error::kNone;
-    } catch (std::exception &e)
-    {
-        return Error::kBadFormat;
+        error = Error::kNone;
     }
+    catch (JsonException &e)
+    {
+        error = e.GetError();
+    }
+    catch (std::exception &e)
+    {
+        error = Error::kBadFormat;
+    }
+
+    return error;
 }
 
 std::string EnergyReportToJson(const EnergyReport &aEnergyReport)


### PR DESCRIPTION
This PR:
1. Makes concurrent call to `FileLogger::Log(...)` safe.
2. Refactors `FileLogger` to return `Error` when construction failed.