### PR TITLE
[code] include C++ standard headers before C standard headers

### DIFF
--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -34,13 +34,13 @@
 #ifndef OT_COMM_COMMISSIONER_HPP_
 #define OT_COMM_COMMISSIONER_HPP_
 
-#include <stddef.h>
-#include <stdint.h>
-
 #include <functional>
 #include <list>
 #include <memory>
 #include <string>
+
+#include <stddef.h>
+#include <stdint.h>
 
 #include <commissioner/defines.hpp>
 #include <commissioner/error.hpp>

--- a/include/commissioner/defines.hpp
+++ b/include/commissioner/defines.hpp
@@ -34,9 +34,9 @@
 #ifndef OT_COMM_DEFINES_HPP_
 #define OT_COMM_DEFINES_HPP_
 
-#include <stdint.h>
-
 #include <vector>
+
+#include <stdint.h>
 
 #if defined(__clang__)
 #define OT_COMM_MUST_USE_RESULT __attribute__((warn_unused_result))

--- a/include/commissioner/network_data.hpp
+++ b/include/commissioner/network_data.hpp
@@ -34,9 +34,9 @@
 #ifndef OT_COMM_NETWORK_DATA_HPP_
 #define OT_COMM_NETWORK_DATA_HPP_
 
-#include <stdint.h>
-
 #include <string>
+
+#include <stdint.h>
 
 #include <commissioner/defines.hpp>
 #include <commissioner/error.hpp>

--- a/src/app/cli/interpreter.cpp
+++ b/src/app/cli/interpreter.cpp
@@ -33,9 +33,9 @@
 
 #include "app/cli/interpreter.hpp"
 
-#include <string.h>
-
 #include <limits>
+
+#include <string.h>
 
 #include "app/file_util.hpp"
 #include "app/json.hpp"

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -34,7 +34,6 @@
 #include "app/commissioner_app.hpp"
 
 #include <algorithm>
-#include <ctime>
 
 #include "app/file_util.hpp"
 #include "app/json.hpp"

--- a/src/common/address.hpp
+++ b/src/common/address.hpp
@@ -29,9 +29,9 @@
 #ifndef OT_COMM_COMMON_ADDRESS_HPP_
 #define OT_COMM_COMMON_ADDRESS_HPP_
 
-#include <sys/socket.h>
-
 #include <string>
+
+#include <sys/socket.h>
 
 #include <commissioner/defines.hpp>
 #include <commissioner/error.hpp>

--- a/src/library/coap.cpp
+++ b/src/library/coap.cpp
@@ -33,10 +33,10 @@
 
 #include "library/coap.hpp"
 
+#include <algorithm>
+
 #include <ctype.h>
 #include <memory.h>
-
-#include <algorithm>
 
 #include "library/logging.hpp"
 #include "library/openthread/random.hpp"

--- a/src/library/commissioner_safe.cpp
+++ b/src/library/commissioner_safe.cpp
@@ -39,7 +39,6 @@
 #include "library/cose.hpp"
 #include "library/logging.hpp"
 #include "library/openthread/bloom_filter.hpp"
-#include "library/uri.hpp"
 
 namespace ot {
 

--- a/src/library/dtls.cpp
+++ b/src/library/dtls.cpp
@@ -33,12 +33,8 @@
 
 #include "library/dtls.hpp"
 
-#include <algorithm>
-#include <iostream>
-
 #include <mbedtls/debug.h>
 #include <mbedtls/error.h>
-#include <mbedtls/pem.h>
 #include <mbedtls/platform.h>
 
 #include "library/logging.hpp"

--- a/src/library/endpoint.hpp
+++ b/src/library/endpoint.hpp
@@ -30,8 +30,9 @@
 #define OT_COMM_LIBRARY_ENDPOINT_HPP_
 
 #include <functional>
-#include <stdint.h>
 #include <string>
+
+#include <stdint.h>
 
 #include <commissioner/error.hpp>
 

--- a/src/library/tlv.hpp
+++ b/src/library/tlv.hpp
@@ -34,12 +34,12 @@
 #ifndef OT_COMM_LIBRARY_TLV_HPP_
 #define OT_COMM_LIBRARY_TLV_HPP_
 
-#include <stdint.h>
-
 #include <limits>
 #include <list>
 #include <map>
 #include <memory>
+
+#include <stdint.h>
 
 #include <commissioner/defines.hpp>
 #include <commissioner/error.hpp>

--- a/src/library/udp_proxy.hpp
+++ b/src/library/udp_proxy.hpp
@@ -34,11 +34,6 @@
 #ifndef OT_COMM_LIBRARY_UDP_PROXY_HPP_
 #define OT_COMM_LIBRARY_UDP_PROXY_HPP_
 
-#include <sys/time.h>
-
-#include <chrono>
-#include <functional>
-
 #include <commissioner/error.hpp>
 
 #include "common/address.hpp"


### PR DESCRIPTION
OpenThread style puts C++ headers before C headers. https://github.com/openthread/openthread/blob/master/STYLE_GUIDE.md