### PR TITLE
[third-party] use libevent 2.1.11-stable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,10 @@
 cmake_minimum_required(VERSION 3.13.1)
 project(ot-commissioner VERSION 1.0.0)
 
+option(OT_COMM_ANDROID          "Build with Android NDK" OFF)
+option(OT_COMM_APP              "Build the CLI App" ON)
 option(OT_COMM_COVERAGE         "Enable coverage reporting" OFF)
 option(OT_COMM_TEST             "Build tests" ON)
-option(OT_COMM_APP              "Build the CLI App" ON)
 
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -86,6 +86,7 @@ target_link_libraries(commissioner
         fmt::fmt
         event_core
         event_pthreads
+        pthread
         commissioner-common
 )
 

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -86,7 +86,7 @@ target_link_libraries(commissioner
         fmt::fmt
         event_core
         event_pthreads
-        pthread
+        $<$<NOT:$<BOOL:${OT_COMM_ANDROID}>>:pthread>
         commissioner-common
 )
 

--- a/third_party/libevent/CMakeLists.txt
+++ b/third_party/libevent/CMakeLists.txt
@@ -41,4 +41,5 @@ add_subdirectory(repo)
 target_include_directories(event_core
     INTERFACE
         ${CMAKE_CURRENT_SOURCE_DIR}/repo/include
+        ${CMAKE_CURRENT_BINARY_DIR}/repo/include
 )


### PR DESCRIPTION
This PR set the version of libevent to [2.1.11-stable](https://github.com/libevent/libevent/tree/release-2.1.11-stable).

The latest libevent master introduced pthread features ([pthread_mutexattr_setprotocol](https://www.gnu.org/software/gnulib/manual/html_node/pthread_005fmutexattr_005fsetprotocol.html)) that are not supported on Android 5 (API level = 21).