### PR TITLE
[api] refactor commissioner handlers

### DIFF
--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -208,6 +208,18 @@ public:
     }
 
     /**
+     * This funtions notifies the response of a keep-alive message.
+     *
+     * @param[in] aError  An error indicates whether the keep-alive message
+     *                    was accepted by the leader.
+     *
+     */
+    virtual void OnKeepAliveResponse(Error aError)
+    {
+        (void)aError;
+    }
+
+    /**
      * This function notifies the receiving a PAN ID conflict answer.
      *
      * @param[in] aPeerAddr     A peer address that sent the MGMT_PANID_CONFLICT.ans request.

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -214,10 +214,7 @@ public:
      *                    was accepted by the leader.
      *
      */
-    virtual void OnKeepAliveResponse(Error aError)
-    {
-        (void)aError;
-    }
+    virtual void OnKeepAliveResponse(Error aError) { (void)aError; }
 
     /**
      * This function notifies the receiving a PAN ID conflict answer.

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -217,7 +217,7 @@ public:
      * @param[in] aPanId        The PAN ID that has a conflict.
      *
      */
-    virtual void OnPanIdConflict(const std::string &aPeerAddr, const ChannelMask &aChannelMask, const uint16_t &aPanId)
+    virtual void OnPanIdConflict(const std::string &aPeerAddr, const ChannelMask &aChannelMask, uint16_t aPanId)
     {
         (void)aPeerAddr;
         (void)aChannelMask;
@@ -263,7 +263,7 @@ public:
     /**
      * The response handler of a general TMF request.
      *
-     * @param[in] aError  A error code.
+     * @param[in] aError  An error code.
      */
     using ErrorHandler = std::function<void(Error aError)>;
 
@@ -271,12 +271,12 @@ public:
      * The response handler of a general TMF request.
      *
      * @param[in] aResponseData  A response data. nullable.
-     * @param[in] aError         A error code.
+     * @param[in] aError         An error code.
      *
      * @note @p aResponseData is guaranteed to be not null only when @p aError == Error::kNone.
      *       Otherwise, @p aResponseData should never be accessed.
      */
-    template <class T> using Handler = std::function<void(const T *aResponseData, Error aError)>;
+    template <typename T> using Handler = std::function<void(const T *aResponseData, Error aError)>;
 
     /**
      * The petition result handler.
@@ -293,7 +293,7 @@ public:
      * @brief Create an instance of the commissioner.
      *
      * @param[out] aCommissioner  The created commissioner instance.
-     * @param[in] aHandler    A handler of commissioner events.
+     * @param[in]  aHandler       A handler of commissioner events.
      * @param[in]  aConfig        A commissioner configuration.
      *
      * @retval Error::kNone  Successfully created a commissioner instance.
@@ -1000,12 +1000,12 @@ public:
      * by sending MLR.req message to the Primary Backbone Router.
      * It will not return until errors happened, timeouted or succeed.
      *
-     * @param[out] aStatus            The Status.
-     * @param[in] aPbbrAddr           A Primary Backbone Router Address that the MLR.req message
-     *                                will be sent to.
-     * @param[in] aMulticastAddrList  A list of multicast address to be registered.
-     * @param[in] aTimeout            A time period after which the registration as a
-     *                                listener to the included multicast group(s) expires; In seconds.
+     * @param[out] aStatus             The Status.
+     * @param[in]  aPbbrAddr           A Primary Backbone Router Address that the MLR.req message
+     *                                 will be sent to.
+     * @param[in]  aMulticastAddrList  A list of multicast address to be registered.
+     * @param[in]  aTimeout            A time period after which the registration as a
+     *                                 listener to the included multicast group(s) expires; In seconds.
      * @return Error::kNone, succeed, the address has been successfully registered; Otherwise, failed;
      */
     virtual Error RegisterMulticastListener(uint8_t &                       aStatus,

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -132,7 +132,11 @@ struct Config
  * Application should inherit this class and override the virtual
  * functions to provide specific handler.
  *
- * @note keep in mind that those handlers will be called in another threads.
+ * @note Those handlers will be called in another threads and synchronization
+ *       is needed if user data is accessed there.
+ * @note Keep the handlers simple and light, no heavy jobs or blocking operations
+ *       (e.g. those synchronized APIs provided by the Commissioner) should be
+ *       executed in those handlers.
  *
  */
 class CommissionerHandler
@@ -271,6 +275,13 @@ public:
      * The response handler of a general TMF request.
      *
      * @param[in] aError  An error code.
+     *
+     * @note Those handlers will be called in another threads and synchronization
+     *       is needed if user data is accessed there.
+     * @note Keep the handlers simple and light, no heavy jobs or blocking operations
+     *       (e.g. those synchronized APIs provided by the Commissioner) should be
+     *       executed in those handlers.
+     *
      */
     using ErrorHandler = std::function<void(Error aError)>;
 
@@ -282,6 +293,12 @@ public:
      *
      * @note @p aResponseData is guaranteed to be not null only when @p aError == Error::kNone.
      *       Otherwise, @p aResponseData should never be accessed.
+     * @note Those handlers will be called in another threads and synchronization
+     *       is needed if user data is accessed there.
+     * @note Keep the handlers simple and light, no heavy jobs or blocking operations
+     *       (e.g. those synchronized APIs provided by the Commissioner) should be
+     *       executed in those handlers.
+     *
      */
     template <typename T> using Handler = std::function<void(const T *aResponseData, Error aError)>;
 
@@ -293,6 +310,12 @@ public:
      *
      * @note There is an exiting active commissioner if @p aError != Error::kNone
      *       and @p aExistingCommissionerId is not null.
+     * @note Those handlers will be called in another threads and synchronization
+     *       is needed if user data is accessed there.
+     * @note Keep the handlers simple and light, no heavy jobs or blocking operations
+     *       (e.g. those synchronized APIs provided by the Commissioner) should be
+     *       executed in those handlers.
+     *
      */
     using PetitionHandler = std::function<void(const std::string *aExistingCommissionerId, Error aError)>;
 

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -335,8 +335,8 @@ public:
      *
      */
     static Error Create(std::shared_ptr<Commissioner> &aCommissioner,
-                        CommissionerHandler &aHandler,
-                        const Config &aConfig);
+                        CommissionerHandler &          aHandler,
+                        const Config &                 aConfig);
 
     virtual ~Commissioner() = default;
 

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -141,18 +141,16 @@ public:
     /**
      * The function notifies the start of a joining request from given joiner.
      *
-     * @param[out] aPSKd      The password of the joiner.
      * @param[in]  aJoinerId  A joiner ID.
      *
-     * @return Error::kNotFound  Cannot find the given joiner.
-     * @return Error::kNone      The given joiner is found, EUI64 and PSKd are set.
+     * @return PSKd of the joiner. An empty PSKd indicates that the joiner is not
+     *         enabled.
      *
      */
-    virtual Error OnJoinerRequest(std::string &aPSKd, const ByteArray &aJoinerId)
+    virtual std::string OnJoinerRequest(const ByteArray &aJoinerId)
     {
-        (void)aPSKd;
         (void)aJoinerId;
-        return Error::kNotFound;
+        return "";
     }
 
     /**

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -134,6 +134,7 @@ struct Config
  *
  * @note Those handlers will be called in another threads and synchronization
  *       is needed if user data is accessed there.
+ * @note No more than one handler will be called concurrently.
  * @note Keep the handlers simple and light, no heavy jobs or blocking operations
  *       (e.g. those synchronized APIs provided by the Commissioner) should be
  *       executed in those handlers.
@@ -278,6 +279,7 @@ public:
      *
      * @note Those handlers will be called in another threads and synchronization
      *       is needed if user data is accessed there.
+     * @note No more than one handler will be called concurrently.
      * @note Keep the handlers simple and light, no heavy jobs or blocking operations
      *       (e.g. those synchronized APIs provided by the Commissioner) should be
      *       executed in those handlers.
@@ -295,6 +297,7 @@ public:
      *       Otherwise, @p aResponseData should never be accessed.
      * @note Those handlers will be called in another threads and synchronization
      *       is needed if user data is accessed there.
+     * @note No more than one handler will be called concurrently.
      * @note Keep the handlers simple and light, no heavy jobs or blocking operations
      *       (e.g. those synchronized APIs provided by the Commissioner) should be
      *       executed in those handlers.
@@ -312,6 +315,7 @@ public:
      *       and @p aExistingCommissionerId is not null.
      * @note Those handlers will be called in another threads and synchronization
      *       is needed if user data is accessed there.
+     * @note No more than one handler will be called concurrently.
      * @note Keep the handlers simple and light, no heavy jobs or blocking operations
      *       (e.g. those synchronized APIs provided by the Commissioner) should be
      *       executed in those handlers.

--- a/src/app/cli/interpreter.cpp
+++ b/src/app/cli/interpreter.cpp
@@ -495,14 +495,14 @@ Interpreter::Value Interpreter::ProcessJoiner(const Expression &aExpr)
     if (CaseInsensitiveEqual(aExpr[1], "enable"))
     {
         uint64_t    eui64;
-        ByteArray   pskd;
+        std::string pskd;
         std::string provisioningUrl;
 
         VerifyOrExit(aExpr.size() >= (type == JoinerType::kMeshCoP ? 5 : 4), msg = Usage(aExpr));
         SuccessOrExit(ParseInteger(eui64, aExpr[3]), msg = aExpr[3]);
         if (type == JoinerType::kMeshCoP)
         {
-            pskd = {aExpr[4].begin(), aExpr[4].end()};
+            pskd = aExpr[4];
             if (aExpr.size() >= 6)
             {
                 provisioningUrl = aExpr[5];
@@ -513,12 +513,12 @@ Interpreter::Value Interpreter::ProcessJoiner(const Expression &aExpr)
     }
     else if (CaseInsensitiveEqual(aExpr[1], "enableall"))
     {
-        ByteArray   pskd;
+        std::string pskd;
         std::string provisioningUrl;
         if (type == JoinerType::kMeshCoP)
         {
             VerifyOrExit(aExpr.size() >= 4, msg = Usage(aExpr));
-            pskd = {aExpr[3].begin(), aExpr[3].end()};
+            pskd = aExpr[3];
             if (aExpr.size() >= 5)
             {
                 provisioningUrl = aExpr[4];

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -1194,29 +1194,25 @@ void CommissionerApp::MergeDataset(CommissionerDataset &aDst, const Commissioner
 #undef SET_IF_PRESENT
 }
 
-Error CommissionerApp::OnJoinerRequest(std::string &aPSKd, const ByteArray &aJoinerId)
+std::string CommissionerApp::OnJoinerRequest(const ByteArray &aJoinerId)
 {
-    Error error;
+    std::string pskd;
 
     auto joinerInfo = mJoiners.find({JoinerType::kMeshCoP, aJoinerId});
     if (joinerInfo != mJoiners.end())
     {
-        aPSKd = joinerInfo->second.mPSKd;
-        ExitNow(error = Error::kNone);
+        ExitNow(pskd = joinerInfo->second.mPSKd);
     }
 
     // Check if all joiners has been enabled.
     joinerInfo = mJoiners.find({JoinerType::kMeshCoP, Commissioner::ComputeJoinerId(0)});
     if (joinerInfo != mJoiners.end())
     {
-        aPSKd = joinerInfo->second.mPSKd;
-        ExitNow(error = Error::kNone);
+        ExitNow(pskd = joinerInfo->second.mPSKd);
     }
 
-    error = Error::kNotFound;
-
 exit:
-    return error;
+    return pskd;
 }
 
 void CommissionerApp::OnJoinerConnected(const ByteArray &aJoinerId, Error aError)

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -1261,8 +1261,8 @@ void CommissionerApp::OnKeepAliveResponse(Error aError)
 void CommissionerApp::OnPanIdConflict(const std::string &aPeerAddr, const ChannelMask &aChannelMask, uint16_t aPanId)
 {
     (void)aPeerAddr;
-    // Main thread will wait for updates to mPanIdConflicts,
-    // which guarantees no concurrent access to it.
+
+    // FIXME(wgtdkp): synchronization
     mPanIdConflicts[aPanId] = aChannelMask;
 }
 
@@ -1274,8 +1274,7 @@ void CommissionerApp::OnEnergyReport(const std::string &aPeerAddr,
 
     SuccessOrDie(addr.Set(aPeerAddr));
 
-    // Main thread will wait for updates to mPanIdConflicts,
-    // which guarantees no concurrent access to it.
+    // FIXME(wgtdkp): synchronization
     mEnergyReports[addr] = {aChannelMask, aEnergyList};
 }
 
@@ -1285,7 +1284,7 @@ void CommissionerApp::OnDatasetChanged()
         [this](const ActiveOperationalDataset *aDataset, Error aError) {
             if (aError == Error::kNone)
             {
-                // FIXME(wgtdkp): syncronization
+                // FIXME(wgtdkp): synchronization
                 mActiveDataset = *aDataset;
             }
             else
@@ -1299,7 +1298,7 @@ void CommissionerApp::OnDatasetChanged()
         [this](const PendingOperationalDataset *aDataset, Error aError) {
             if (aError == Error::kNone)
             {
-                // FIXME(wgtdkp): syncronization
+                // FIXME(wgtdkp): synchronization
                 mPendingDataset = *aDataset;
             }
             else

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -1255,9 +1255,7 @@ exit:
     return accepted;
 }
 
-void CommissionerApp::OnPanIdConflict(const std::string &aPeerAddr,
-                                      const ChannelMask &aChannelMask,
-                                      const uint16_t &   aPanId)
+void CommissionerApp::OnPanIdConflict(const std::string &aPeerAddr, const ChannelMask &aChannelMask, uint16_t aPanId)
 {
     (void)aPeerAddr;
     // Main thread will wait for updates to mPanIdConflicts,

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -1251,6 +1251,13 @@ exit:
     return accepted;
 }
 
+void CommissionerApp::OnKeepAliveResponse(Error aError)
+{
+    (void)aError;
+
+    // Dummy handler.
+}
+
 void CommissionerApp::OnPanIdConflict(const std::string &aPeerAddr, const ChannelMask &aChannelMask, uint16_t aPanId)
 {
     (void)aPeerAddr;

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -1271,7 +1271,8 @@ void CommissionerApp::OnEnergyReport(const std::string &aPeerAddr,
                                      const ByteArray &  aEnergyList)
 {
     Address addr;
-    ASSERT(addr.Set(aPeerAddr) == Error::kNone);
+
+    SuccessOrDie(addr.Set(aPeerAddr));
 
     // Main thread will wait for updates to mPanIdConflicts,
     // which guarantees no concurrent access to it.

--- a/src/app/commissioner_app.hpp
+++ b/src/app/commissioner_app.hpp
@@ -114,6 +114,8 @@ public:
                           const std::string &aProvisioningUrl,
                           const ByteArray &  aVendorData) override;
 
+    void OnKeepAliveResponse(Error aError) override;
+
     void OnPanIdConflict(const std::string &aPeerAddr, const ChannelMask &aChannelMask, uint16_t aPanId) override;
 
     void OnEnergyReport(const std::string &aPeerAddr,

--- a/src/app/commissioner_app.hpp
+++ b/src/app/commissioner_app.hpp
@@ -102,7 +102,7 @@ public:
     ~CommissionerApp() = default;
 
     // Handle commissioner events.
-    Error OnJoinerRequest(std::string &aPSKd, const ByteArray &aJoinerId) override;
+    std::string OnJoinerRequest(const ByteArray &aJoinerId) override;
 
     void OnJoinerConnected(const ByteArray &aJoinerId, Error aError) override;
 

--- a/src/app/commissioner_app.hpp
+++ b/src/app/commissioner_app.hpp
@@ -114,9 +114,7 @@ public:
                           const std::string &aProvisioningUrl,
                           const ByteArray &  aVendorData) override;
 
-    void OnPanIdConflict(const std::string &aPeerAddr,
-                         const ChannelMask &aChannelMask,
-                         const uint16_t &   aPanId) override;
+    void OnPanIdConflict(const std::string &aPeerAddr, const ChannelMask &aChannelMask, uint16_t aPanId) override;
 
     void OnEnergyReport(const std::string &aPeerAddr,
                         const ChannelMask &aChannelMask,

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1139,7 +1139,7 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
         if (error == Error::kNone)
         {
             mKeepAliveTimer.Start(GetKeepAliveInterval());
-            LOG_INFO("keep alive message accepted, keep-alive timer restarted");
+            LOG_INFO(LOG_REGION_MESHCOP, "keep alive message accepted, keep-alive timer restarted");
         }
         else
         {
@@ -1150,8 +1150,6 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
         }
 
         mCommissionerHandler.OnKeepAliveResponse(error);
-
-        return;
     };
 
     VerifyOrExit(IsActive(), error = Error::kInvalidState);
@@ -2020,8 +2018,8 @@ void CommissionerImpl::HandleRlyRx(const coap::Request &aRlyRx)
 
     joinerId = joinerIid;
     joinerId[0] ^= kLocalExternalAddrMask;
-    LOG_DEBUG(LOG_REGION_JOINER_SESSION, "received RLY_RX.ntf: joinerID={}, joinerRouterLocator={}, length={}", utils::Hex(joinerId),
-              joinerRouterLocator, dtlsRecords.size());
+    LOG_DEBUG(LOG_REGION_JOINER_SESSION, "received RLY_RX.ntf: joinerID={}, joinerRouterLocator={}, length={}",
+              utils::Hex(joinerId), joinerRouterLocator, dtlsRecords.size());
 
     joinerPSKd = mCommissionerHandler.OnJoinerRequest(joinerId);
     if (joinerPSKd.empty())
@@ -2055,12 +2053,13 @@ void CommissionerImpl::HandleRlyRx(const coap::Request &aRlyRx)
             std::string peerAddr = "unknown address";
             IgnoreError(session.GetPeerAddr().ToString(peerAddr));
 
-            LOG_DEBUG(LOG_REGION_JOINER_SESSION, "received a new joiner(ID={}) DTLS connection from [{}]:{}", utils::Hex(joinerId), peerAddr,
-                      session.GetPeerPort());
+            LOG_DEBUG(LOG_REGION_JOINER_SESSION, "received a new joiner(ID={}) DTLS connection from [{}]:{}",
+                      utils::Hex(joinerId), peerAddr, session.GetPeerPort());
 
             session.Connect();
 
-            LOG_INFO(LOG_REGION_JOINER_SESSION, "commissioning timer started, expiration-time={}", TimePointToString(session.GetExpirationTime()));
+            LOG_INFO(LOG_REGION_JOINER_SESSION, "commissioning timer started, expiration-time={}",
+                     TimePointToString(session.GetExpirationTime()));
             mJoinerSessionTimer.Start(session.GetExpirationTime());
         }
 
@@ -2093,7 +2092,8 @@ void CommissionerImpl::HandleJoinerSessionTimer(Timer &aTimer)
         {
             it = mJoinerSessions.erase(it);
 
-            LOG_INFO(LOG_REGION_JOINER_SESSION, "commissioning session (joiner ID={}) removed", utils::Hex(session.GetJoinerId()));
+            LOG_INFO(LOG_REGION_JOINER_SESSION, "commissioning session (joiner ID={}) removed",
+                     utils::Hex(session.GetJoinerId()));
         }
         else
         {

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1893,6 +1893,8 @@ void CommissionerImpl::HandlePanIdConflict(const coap::Request &aRequest)
 {
     Error       error = Error::kNone;
     tlv::TlvSet tlvSet;
+    tlv::TlvPtr channelMaskTlv;
+    tlv::TlvPtr panIdTlv;
     ChannelMask channelMask;
     uint16_t    panId;
     std::string peerAddr = "unknown address";
@@ -1904,16 +1906,12 @@ void CommissionerImpl::HandlePanIdConflict(const coap::Request &aRequest)
     mProxyClient.SendEmptyChanged(aRequest);
 
     SuccessOrExit(error = GetTlvSet(tlvSet, aRequest));
-    if (auto channelMaskTlv = tlvSet[tlv::Type::kChannelMask])
-    {
-        SuccessOrExit(error = DecodeChannelMask(channelMask, channelMaskTlv->GetValue()));
-    }
-    if (auto panIdTlv = tlvSet[tlv::Type::kPanId])
-    {
-        panId = panIdTlv->GetValueAsUint16();
-    }
+    VerifyOrExit((channelMaskTlv = tlvSet[tlv::Type::kChannelMask]) != nullptr, error = Error::kBadFormat);
+    VerifyOrExit((panIdTlv = tlvSet[tlv::Type::kPanId]) != nullptr, error = Error::kBadFormat);
 
-    error = Error::kNone;
+    SuccessOrExit(error = DecodeChannelMask(channelMask, channelMaskTlv->GetValue()));
+    panId = panIdTlv->GetValueAsUint16();
+
     mCommissionerHandler.OnPanIdConflict(peerAddr, channelMask, panId);
 
 exit:

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -2020,11 +2020,11 @@ void CommissionerImpl::HandleRlyRx(const coap::Request &aRlyRx)
     LOG_DEBUG(LOG_REGION_JOINER_SESSION, "received RLY_RX.ntf: joinerID={}, joinerRouterLocator={}, length={}", utils::Hex(joinerId),
               joinerRouterLocator, dtlsRecords.size());
 
-    error = mCommissionerHandler.OnJoinerRequest(joinerPSKd, joinerId);
-    if (error != Error::kNone)
+    joinerPSKd = mCommissionerHandler.OnJoinerRequest(joinerId);
+    if (joinerPSKd.empty())
     {
         LOG_INFO(LOG_REGION_JOINER_SESSION, "joiner(ID={}) is disabled", utils::Hex(joinerId));
-        ExitNow();
+        ExitNow(error = Error::kReject);
     }
 
     {

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1139,15 +1139,18 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
         if (error == Error::kNone)
         {
             mKeepAliveTimer.Start(GetKeepAliveInterval());
+            LOG_INFO("keep alive message accepted, keep-alive timer restarted");
         }
         else
         {
             mState = State::kDisabled;
             Resign([](Error) {});
 
-            // TODO(wgtdkp): notify user that we are rejected.
             LOG_WARN(LOG_REGION_MESHCOP, "keep alive message rejected: {}", ErrorToString(error));
         }
+
+        mCommissionerHandler.OnKeepAliveResponse(error);
+
         return;
     };
 

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -46,8 +46,6 @@ namespace ot {
 
 namespace commissioner {
 
-static constexpr uint8_t kLocalExternalAddrMask = 1 << 1;
-
 Error Commissioner::GeneratePSKc(ByteArray &        aPSKc,
                                  const std::string &aPassphrase,
                                  const std::string &aNetworkName,
@@ -128,17 +126,10 @@ exit:
     return error;
 }
 
-JoinerInfo::JoinerInfo(JoinerType aType, uint64_t aEui64, const ByteArray &aPSKd, const std::string &aProvisioningUrl)
-    : mType(aType)
-    , mEui64(aEui64)
-    , mPSKd(aPSKd)
-    , mProvisioningUrl(aProvisioningUrl)
-{
-}
-
-CommissionerImpl::CommissionerImpl(struct event_base *aEventBase)
+CommissionerImpl::CommissionerImpl(CommissionerHandler &aHandler, struct event_base *aEventBase)
     : mState(State::kDisabled)
     , mSessionId(0)
+    , mCommissionerHandler(aHandler)
     , mEventBase(aEventBase)
     , mKeepAliveTimer(mEventBase, [this](Timer &aTimer) { SendKeepAlive(aTimer); })
     , mBrClient(mEventBase)
@@ -152,11 +143,6 @@ CommissionerImpl::CommissionerImpl(struct event_base *aEventBase)
     , mResourcePanIdConflict(uri::kMgmtPanidConflict,
                              [this](const coap::Request &aRequest) { HandlePanIdConflict(aRequest); })
     , mResourceEnergyReport(uri::kMgmtEdReport, [this](const coap::Request &aRequest) { HandleEnergyReport(aRequest); })
-    , mDatasetChangedHandler(nullptr)
-    , mPanIdConflictHandler(nullptr)
-    , mEnergyReportHandler(nullptr)
-    , mJoinerInfoRequester(nullptr)
-    , mCommissioningHandler(nullptr)
 {
     SuccessOrDie(mBrClient.AddResource(mResourceUdpRx));
     SuccessOrDie(mBrClient.AddResource(mResourceRlyRx));
@@ -258,16 +244,6 @@ void CommissionerImpl::LoggingConfig()
 const Config &CommissionerImpl::GetConfig() const
 {
     return mConfig;
-}
-
-void CommissionerImpl::SetJoinerInfoRequester(JoinerInfoRequester aJoinerInfoRequester)
-{
-    mJoinerInfoRequester = aJoinerInfoRequester;
-}
-
-void CommissionerImpl::SetCommissioningHandler(CommissioningHandler aCommissioningHandler)
-{
-    mCommissioningHandler = aCommissioningHandler;
 }
 
 Error CommissionerImpl::Start()
@@ -1072,21 +1048,6 @@ Error CommissionerImpl::SetToken(const ByteArray &aSignedToken, const ByteArray 
         return Error::kInvalidState;
     }
     return mTokenManager.SetToken(aSignedToken, aSignerCert);
-}
-
-void CommissionerImpl::SetDatasetChangedHandler(ErrorHandler aHandler)
-{
-    mDatasetChangedHandler = aHandler;
-}
-
-void CommissionerImpl::SetPanIdConflictHandler(PanIdConflictHandler aHandler)
-{
-    mPanIdConflictHandler = aHandler;
-}
-
-void CommissionerImpl::SetEnergyReportHandler(EnergyReportHandler aHandler)
-{
-    mEnergyReportHandler = aHandler;
 }
 
 void CommissionerImpl::SendPetition(PetitionHandler aHandler)
@@ -1925,10 +1886,7 @@ void CommissionerImpl::HandleDatasetChanged(const coap::Request &aRequest)
 
     mProxyClient.SendEmptyChanged(aRequest);
 
-    if (mDatasetChangedHandler != nullptr)
-    {
-        mDatasetChangedHandler(Error::kNone);
-    }
+    mCommissionerHandler.OnDatasetChanged();
 }
 
 void CommissionerImpl::HandlePanIdConflict(const coap::Request &aRequest)
@@ -1956,20 +1914,12 @@ void CommissionerImpl::HandlePanIdConflict(const coap::Request &aRequest)
     }
 
     error = Error::kNone;
-    if (mPanIdConflictHandler != nullptr)
-    {
-        mPanIdConflictHandler(&peerAddr, &channelMask, &panId, Error::kNone);
-    }
+    mCommissionerHandler.OnPanIdConflict(peerAddr, channelMask, panId);
 
 exit:
     if (error != Error::kNone)
     {
         LOG_WARN(LOG_REGION_MGMT, "handle MGMT_PANID_CONFLICT.ans from {} failed: {}", peerAddr, ErrorToString(error));
-
-        if (mPanIdConflictHandler != nullptr)
-        {
-            mPanIdConflictHandler(nullptr, nullptr, nullptr, error);
-        }
     }
 }
 
@@ -1998,20 +1948,12 @@ void CommissionerImpl::HandleEnergyReport(const coap::Request &aRequest)
     }
 
     error = Error::kNone;
-    if (mEnergyReportHandler != nullptr)
-    {
-        mEnergyReportHandler(&peerAddr, &channelMask, &energyList, Error::kNone);
-    }
+    mCommissionerHandler.OnEnergyReport(peerAddr, channelMask, energyList);
 
 exit:
     if (error != Error::kNone)
     {
         LOG_WARN(LOG_REGION_MGMT, "handle MGMT_ED_REPORT.ans from {} failed: {}", peerAddr, ErrorToString(error));
-
-        if (mEnergyReportHandler != nullptr)
-        {
-            mEnergyReportHandler(nullptr, nullptr, nullptr, error);
-        }
     }
 }
 
@@ -2048,14 +1990,14 @@ void CommissionerImpl::HandleRlyRx(const coap::Request &aRlyRx)
 {
     Error       error = Error::kNone;
     tlv::TlvSet tlvSet;
-
     tlv::TlvPtr tlv;
 
-    const JoinerInfo *joinerInfo = nullptr;
-    uint16_t          joinerUdpPort;
-    uint16_t          joinerRouterLocator;
-    ByteArray         joinerIid;
-    ByteArray         dtlsRecords;
+    std::string joinerPSKd;
+    uint16_t    joinerUdpPort;
+    uint16_t    joinerRouterLocator;
+    ByteArray   joinerIid;
+    ByteArray   joinerId;
+    ByteArray   dtlsRecords;
 
     SuccessOrExit(error = GetTlvSet(tlvSet, aRlyRx));
 
@@ -2075,28 +2017,20 @@ void CommissionerImpl::HandleRlyRx(const coap::Request &aRlyRx)
     VerifyOrExit(tlv->IsValid(), error = Error::kBadFormat);
     dtlsRecords = tlv->GetValue();
 
-    LOG_DEBUG(LOG_REGION_JOINER_SESSION, "received RLY_RX.ntf: joinerIID={}, joinerRouterLocator={}, length={}",
-              utils::Hex(joinerIid), joinerRouterLocator, dtlsRecords.size());
+    joinerId = joinerIid;
+    joinerId[0] ^= kLocalExternalAddrMask;
+    LOG_DEBUG(LOG_REGION_JOINER_SESSION, "received RLY_RX.ntf: joinerID={}, joinerRouterLocator={}, length={}", utils::Hex(joinerId),
+              joinerRouterLocator, dtlsRecords.size());
 
-    if (mJoinerInfoRequester == nullptr)
+    error = mCommissionerHandler.OnJoinerRequest(joinerPSKd, joinerId);
+    if (error != Error::kNone)
     {
-        LOG_WARN(LOG_REGION_JOINER_SESSION, "joiner info requester is nil, give up");
+        LOG_INFO(LOG_REGION_JOINER_SESSION, "joiner(ID={}) is disabled", utils::Hex(joinerId));
         ExitNow();
     }
-    else
-    {
-        auto joinerId = joinerIid;
-        joinerId[0] ^= kLocalExternalAddrMask;
-        joinerInfo = mJoinerInfoRequester(JoinerType::kMeshCoP, joinerId);
-        if (joinerInfo == nullptr)
-        {
-            LOG_INFO(LOG_REGION_JOINER_SESSION, "joiner(IID={}) is disabled", utils::Hex(joinerIid));
-            ExitNow();
-        }
-    }
 
     {
-        auto it = mJoinerSessions.find(joinerIid);
+        auto it = mJoinerSessions.find(joinerId);
         if (it != mJoinerSessions.end() && it->second.Disabled())
         {
             mJoinerSessions.erase(it);
@@ -2109,8 +2043,8 @@ void CommissionerImpl::HandleRlyRx(const coap::Request &aRlyRx)
 
             SuccessOrExit(error = mBrClient.GetLocalAddr(localAddr));
             it = mJoinerSessions
-                     .emplace(std::piecewise_construct, std::forward_as_tuple(joinerIid),
-                              std::forward_as_tuple(*this, *joinerInfo, joinerUdpPort, joinerRouterLocator, joinerIid,
+                     .emplace(std::piecewise_construct, std::forward_as_tuple(joinerId),
+                              std::forward_as_tuple(*this, joinerId, joinerPSKd, joinerUdpPort, joinerRouterLocator,
                                                     aRlyRx.GetEndpoint()->GetPeerAddr(),
                                                     aRlyRx.GetEndpoint()->GetPeerPort(), localAddr,
                                                     kListeningJoinerPort))
@@ -2120,35 +2054,13 @@ void CommissionerImpl::HandleRlyRx(const coap::Request &aRlyRx)
             std::string peerAddr = "unknown address";
             IgnoreError(session.GetPeerAddr().ToString(peerAddr));
 
-            LOG_DEBUG(LOG_REGION_JOINER_SESSION, "received a new joiner(IID={}) DTLS connection from [{}]:{}",
-                      utils::Hex(session.GetJoinerIid()), peerAddr, session.GetPeerPort());
+            LOG_DEBUG(LOG_REGION_JOINER_SESSION, "received a new joiner(ID={}) DTLS connection from [{}]:{}", utils::Hex(joinerId), peerAddr,
+                      session.GetPeerPort());
 
-            auto onConnected = [peerAddr](JoinerSession &aSession, Error aError) {
-                if (aError != Error::kNone)
-                {
-                    LOG_ERROR(LOG_REGION_JOINER_SESSION, "a joiner(IID={}) DTLS connection from [{}]:{} failed: {}",
-                              utils::Hex(aSession.GetJoinerIid()), peerAddr, aSession.GetPeerPort(),
-                              ErrorToString(aError));
-                }
-                else
-                {
-                    LOG_INFO(LOG_REGION_JOINER_SESSION, "a joiner(IID={}) DTLS connection from [{}]:{} succeed",
-                             utils::Hex(aSession.GetJoinerIid()), peerAddr, aSession.GetPeerPort());
-                }
-            };
+            session.Connect();
 
-            if ((error = session.Start(onConnected)) != Error::kNone)
-            {
-                mJoinerSessions.erase(it);
-                it = mJoinerSessions.end();
-                ExitNow();
-            }
-            else
-            {
-                LOG_INFO(LOG_REGION_JOINER_SESSION, "commissioning timer started, expiration-time={}",
-                         TimePointToString(session.GetExpirationTime()));
-                mJoinerSessionTimer.Start(session.GetExpirationTime());
-            }
+            LOG_INFO(LOG_REGION_JOINER_SESSION, "commissioning timer started, expiration-time={}", TimePointToString(session.GetExpirationTime()));
+            mJoinerSessionTimer.Start(session.GetExpirationTime());
         }
 
         VerifyOrDie(it != mJoinerSessions.end());
@@ -2159,7 +2071,7 @@ void CommissionerImpl::HandleRlyRx(const coap::Request &aRlyRx)
 exit:
     if (error != Error::kNone)
     {
-        LOG_ERROR(LOG_REGION_JOINER_SESSION, "handle RLY_RX.ntf message failed: {}", ErrorToString(error));
+        LOG_ERROR(LOG_REGION_JOINER_SESSION, "failed to handle RLY_RX.ntf message: {}", ErrorToString(error));
     }
 }
 
@@ -2180,8 +2092,7 @@ void CommissionerImpl::HandleJoinerSessionTimer(Timer &aTimer)
         {
             it = mJoinerSessions.erase(it);
 
-            LOG_INFO(LOG_REGION_JOINER_SESSION, "session(={}, joinerIid={}) removed", static_cast<void *>(&(*it)),
-                     utils::Hex(session.GetJoinerIid()));
+            LOG_INFO(LOG_REGION_JOINER_SESSION, "commissioning session (joiner ID={}) removed", utils::Hex(session.GetJoinerId()));
         }
         else
         {

--- a/src/library/commissioner_impl.hpp
+++ b/src/library/commissioner_impl.hpp
@@ -67,7 +67,7 @@ class CommissionerImpl : public Commissioner
     friend class JoinerSession;
 
 public:
-    explicit CommissionerImpl(struct event_base *aEventBase);
+    explicit CommissionerImpl(CommissionerHandler &aHandler, struct event_base *aEventBase);
 
     CommissionerImpl(const CommissionerImpl &aCommissioner) = delete;
     const CommissionerImpl &operator=(const CommissionerImpl &aCommissioner) = delete;
@@ -77,9 +77,6 @@ public:
     ~CommissionerImpl() override;
 
     const Config &GetConfig() const override;
-
-    void SetJoinerInfoRequester(JoinerInfoRequester aJoinerInfoRequester) override;
-    void SetCommissioningHandler(CommissioningHandler aCommissioningHandler) override;
 
     uint16_t GetSessionId() const override;
 
@@ -192,12 +189,6 @@ public:
 
     Error SetToken(const ByteArray &aSignedToken, const ByteArray &aSignerCert) override;
 
-    void SetDatasetChangedHandler(ErrorHandler aHandler) override;
-
-    void SetPanIdConflictHandler(PanIdConflictHandler aHandler) override;
-
-    void SetEnergyReportHandler(EnergyReportHandler aHandler) override;
-
     struct event_base *GetEventBase() { return mEventBase; }
 
 private:
@@ -206,10 +197,6 @@ private:
     static Error ValidateConfig(const Config &aConfig);
     void         LoggingConfig();
 
-    ByteArray &  GetPendingSteeringData(JoinerType aJoinerType);
-    uint16_t &   GetPendingJoinerUdpPort(JoinerType aJoinerType);
-    bool         IsValidJoinerUdpPort(JoinerType aType, uint16_t aUdpPort);
-    void         UpdateCommissionerDataset(const std::list<tlv::Tlv> &aTlvList);
     static Error HandleStateResponse(const coap::Response *aResponse, Error aError);
 
     static ByteArray GetActiveOperationalDatasetTlvs(uint16_t aDatasetFlags);
@@ -266,7 +253,8 @@ private:
     static constexpr uint32_t kMinKeepAliveInterval = 30;
     static constexpr uint32_t kMaxKeepAliveInterval = 45;
 
-    struct event_base *mEventBase;
+    CommissionerHandler &mCommissionerHandler;
+    struct event_base *  mEventBase;
 
     Config mConfig;
 
@@ -284,15 +272,9 @@ private:
 
     TokenManager mTokenManager;
 
-    coap::Resource       mResourceDatasetChanged;
-    coap::Resource       mResourcePanIdConflict;
-    coap::Resource       mResourceEnergyReport;
-    ErrorHandler         mDatasetChangedHandler;
-    PanIdConflictHandler mPanIdConflictHandler;
-    EnergyReportHandler  mEnergyReportHandler;
-
-    JoinerInfoRequester  mJoinerInfoRequester;
-    CommissioningHandler mCommissioningHandler;
+    coap::Resource mResourceDatasetChanged;
+    coap::Resource mResourcePanIdConflict;
+    coap::Resource mResourceEnergyReport;
 };
 
 /*

--- a/src/library/commissioner_impl_test.cpp
+++ b/src/library/commissioner_impl_test.cpp
@@ -126,8 +126,9 @@ TEST_CASE("commissioner-impl-not-implemented-APIs", "[comm-impl]")
     config.mEnableCcm = false;
     config.mPSKc = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
 
-    struct event_base *eventBase = event_base_new();
-    CommissionerImpl   commImpl(eventBase);
+    CommissionerHandler dummyHandler;
+    struct event_base * eventBase = event_base_new();
+    CommissionerImpl    commImpl(dummyHandler, eventBase);
     REQUIRE(commImpl.Init(config) == Error::kNone);
 
     REQUIRE(commImpl.Connect("::1", 5684) == Error::kNotImplemented);

--- a/src/library/commissioner_safe.cpp
+++ b/src/library/commissioner_safe.cpp
@@ -44,13 +44,12 @@ namespace ot {
 
 namespace commissioner {
 
-std::shared_ptr<Commissioner> Commissioner::Create(CommissionerHandler &aHandler, const Config &aConfig)
 Error Commissioner::Create(std::shared_ptr<Commissioner> &aCommissioner,
-                           CommissionerHandler &aHandler,
+                           CommissionerHandler &          aHandler,
                            const Config &                 aConfig)
 {
     Error error;
-    auto comm = std::make_shared<CommissionerSafe>(aHandler);
+    auto  comm = std::make_shared<CommissionerSafe>(aHandler);
 
     SuccessOrExit(error = comm->Init(aConfig));
     aCommissioner = comm;

--- a/src/library/commissioner_safe.hpp
+++ b/src/library/commissioner_safe.hpp
@@ -66,7 +66,7 @@ namespace commissioner {
 class CommissionerSafe : public Commissioner
 {
 public:
-    CommissionerSafe();
+    explicit CommissionerSafe(CommissionerHandler &aHandler);
 
     CommissionerSafe(const CommissionerSafe &aCommissioner) = delete;
     const CommissionerSafe &operator=(const CommissionerSafe &aCommissioner) = delete;
@@ -76,9 +76,6 @@ public:
     ~CommissionerSafe() override;
 
     const Config &GetConfig() const override;
-
-    void SetJoinerInfoRequester(JoinerInfoRequester aJoinerInfoRequester) override;
-    void SetCommissioningHandler(CommissioningHandler aCommissioningHandler) override;
 
     uint16_t GetSessionId() const override;
 
@@ -190,12 +187,6 @@ public:
     Error RequestToken(ByteArray &aSignedToken, const std::string &aAddr, uint16_t aPort) override;
 
     Error SetToken(const ByteArray &aSignedToken, const ByteArray &aSignerCert) override;
-
-    void SetDatasetChangedHandler(ErrorHandler aHandler) override;
-
-    void SetPanIdConflictHandler(PanIdConflictHandler aHandler) override;
-
-    void SetEnergyReportHandler(EnergyReportHandler aHandler) override;
 
 private:
     using AsyncRequest = std::function<void()>;

--- a/src/library/commissioner_safe_test.cpp
+++ b/src/library/commissioner_safe_test.cpp
@@ -42,13 +42,15 @@ namespace commissioner {
 
 TEST_CASE("stop-immediately-after-starting", "[commissioner]")
 {
+    CommissionerHandler dummyHandler;
+
     Config config;
     config.mEnableCcm = false;
     config.mPSKc = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
 
     // This creates an CommissionerSafe instance.
     std::shared_ptr<Commissioner> commissioner;
-    REQUIRE(Commissioner::Create(commissioner, config, nullptr) == Error::kNone);
+    REQUIRE(Commissioner::Create(commissioner, dummyHandler, config) == Error::kNone);
     REQUIRE(commissioner != nullptr);
 }
 

--- a/src/library/joiner_session.cpp
+++ b/src/library/joiner_session.cpp
@@ -42,20 +42,20 @@ namespace ot {
 
 namespace commissioner {
 
-JoinerSession::JoinerSession(CommissionerImpl &aCommImpl,
-                             const JoinerInfo &aJoinerInfo,
-                             uint16_t          aJoinerUdpPort,
-                             uint16_t          aJoinerRouterLocator,
-                             const ByteArray & aJoinerIid,
-                             const Address &   aJoinerAddr,
-                             uint16_t          aJoinerPort,
-                             const Address &   aLocalAddr,
-                             uint16_t          aLocalPort)
+JoinerSession::JoinerSession(CommissionerImpl & aCommImpl,
+                                           const ByteArray &  aJoinerId,
+                                           const std::string &aJoinerPSkd,
+                                           uint16_t           aJoinerUdpPort,
+                                           uint16_t           aJoinerRouterLocator,
+                                           const Address &    aJoinerAddr,
+                                           uint16_t           aJoinerPort,
+                                           const Address &    aLocalAddr,
+                                           uint16_t           aLocalPort)
     : mCommImpl(aCommImpl)
-    , mJoinerInfo(aJoinerInfo)
+    , mJoinerId(aJoinerId)
+    , mJoinerPSKd(aJoinerPSkd)
     , mJoinerUdpPort(aJoinerUdpPort)
     , mJoinerRouterLocator(aJoinerRouterLocator)
-    , mJoinerIid(aJoinerIid)
     , mRelaySocket(std::make_shared<RelaySocket>(*this, aJoinerAddr, aJoinerPort, aLocalAddr, aLocalPort))
     , mDtlsSession(std::make_shared<DtlsSession>(aCommImpl.GetEventBase(), /* aIsServer */ true, mRelaySocket))
     , mCoap(aCommImpl.GetEventBase(), *mDtlsSession)
@@ -64,29 +64,37 @@ JoinerSession::JoinerSession(CommissionerImpl &aCommImpl,
     SuccessOrDie(mCoap.AddResource(mResourceJoinFin));
 }
 
-Error JoinerSession::Start(ConnectHandler aOnConnected)
+void JoinerSession::Connect()
 {
     Error error = Error::kNone;
 
     auto dtlsConfig = GetDtlsConfig(mCommImpl.GetConfig());
-    dtlsConfig.mPSK = mJoinerInfo.mPSKd;
+    dtlsConfig.mPSK = {mJoinerPSKd.begin(), mJoinerPSKd.end()};
 
     mExpirationTime = Clock::now() + MilliSeconds(kDtlsHandshakeTimeoutMax * 1000 + kJoinerTimeout * 1000);
 
     SuccessOrExit(error = mDtlsSession->Init(dtlsConfig));
 
     {
-        auto onConnected = [this, aOnConnected](const DtlsSession &, Error aError) { aOnConnected(*this, aError); };
+        auto onConnected = [this](const DtlsSession &, Error aError) { HandleConnect(aError); };
         mDtlsSession->Connect(onConnected);
     }
 
 exit:
-    return error;
+    if (error != Error::kNone)
+    {
+        HandleConnect(error);
+    }
 }
 
-void JoinerSession::Stop()
+void JoinerSession::Disconnect()
 {
     mDtlsSession->Disconnect(Error::kAbort);
+}
+
+void JoinerSession::HandleConnect(Error aError)
+{
+    mCommImpl.mCommissionerHandler.OnJoinerConnected(mJoinerId, aError);
 }
 
 void JoinerSession::RecvJoinerDtlsRecords(const ByteArray &aRecords)
@@ -114,10 +122,8 @@ Error JoinerSession::SendRlyTx(const ByteArray &aDtlsMessage, bool aIncludeKek)
 
     mCommImpl.mBrClient.SendRequest(rlyTx, nullptr);
 
-    LOG_DEBUG(LOG_REGION_JOINER_SESSION,
-              "session(={}) sent RLY_TX.ntf: SessionState={}, joinerIID={}, length={}, includeKek={}",
-              static_cast<void *>(this), mDtlsSession->GetStateString(), utils::Hex(GetJoinerIid()),
-              aDtlsMessage.size(), aIncludeKek);
+    LOG_DEBUG(LOG_REGION_JOINER_SESSION, "session(={}) sent RLY_TX.ntf: SessionState={}, joinerID={}, length={}, includeKek={}",
+              static_cast<void *>(this), mDtlsSession->GetStateString(), utils::Hex(GetJoinerId()), aDtlsMessage.size(), aIncludeKek);
 
 exit:
     return error;
@@ -172,17 +178,9 @@ void JoinerSession::HandleJoinFin(const coap::Request &aJoinFin)
              utils::Hex(vendorData));
 
     // Validation done, request commissioning by user.
-    if (mCommImpl.mCommissioningHandler != nullptr)
-    {
-        accepted = mCommImpl.mCommissioningHandler(
-            mJoinerInfo, vendorNameTlv->GetValueAsString(), vendorModelTlv->GetValueAsString(),
-            vendorSwVersionTlv->GetValueAsString(), vendorStackVersionTlv->GetValue(), provisioningUrl, vendorData);
-    }
-    else
-    {
-        // Accepts a joiner if requirement on vendor-specific provisioning.
-        accepted = provisioningUrl.empty();
-    }
+    accepted = mCommImpl.mCommissionerHandler.OnJoinerFinalize(
+        mJoinerId, vendorNameTlv->GetValueAsString(), vendorModelTlv->GetValueAsString(),
+        vendorSwVersionTlv->GetValueAsString(), vendorStackVersionTlv->GetValue(), provisioningUrl, vendorData);
     VerifyOrExit(accepted, error = Error::kReject);
 
 exit:

--- a/src/library/joiner_session.cpp
+++ b/src/library/joiner_session.cpp
@@ -43,14 +43,14 @@ namespace ot {
 namespace commissioner {
 
 JoinerSession::JoinerSession(CommissionerImpl & aCommImpl,
-                                           const ByteArray &  aJoinerId,
-                                           const std::string &aJoinerPSkd,
-                                           uint16_t           aJoinerUdpPort,
-                                           uint16_t           aJoinerRouterLocator,
-                                           const Address &    aJoinerAddr,
-                                           uint16_t           aJoinerPort,
-                                           const Address &    aLocalAddr,
-                                           uint16_t           aLocalPort)
+                             const ByteArray &  aJoinerId,
+                             const std::string &aJoinerPSkd,
+                             uint16_t           aJoinerUdpPort,
+                             uint16_t           aJoinerRouterLocator,
+                             const Address &    aJoinerAddr,
+                             uint16_t           aJoinerPort,
+                             const Address &    aLocalAddr,
+                             uint16_t           aLocalPort)
     : mCommImpl(aCommImpl)
     , mJoinerId(aJoinerId)
     , mJoinerPSKd(aJoinerPSkd)
@@ -129,8 +129,10 @@ Error JoinerSession::SendRlyTx(const ByteArray &aDtlsMessage, bool aIncludeKek)
 
     mCommImpl.mBrClient.SendRequest(rlyTx, nullptr);
 
-    LOG_DEBUG(LOG_REGION_JOINER_SESSION, "session(={}) sent RLY_TX.ntf: SessionState={}, joinerID={}, length={}, includeKek={}",
-              static_cast<void *>(this), mDtlsSession->GetStateString(), utils::Hex(GetJoinerId()), aDtlsMessage.size(), aIncludeKek);
+    LOG_DEBUG(LOG_REGION_JOINER_SESSION,
+              "session(={}) sent RLY_TX.ntf: SessionState={}, joinerID={}, length={}, includeKek={}",
+              static_cast<void *>(this), mDtlsSession->GetStateString(), utils::Hex(GetJoinerId()), aDtlsMessage.size(),
+              aIncludeKek);
 
 exit:
     return error;

--- a/src/library/joiner_session.cpp
+++ b/src/library/joiner_session.cpp
@@ -92,6 +92,13 @@ void JoinerSession::Disconnect()
     mDtlsSession->Disconnect(Error::kAbort);
 }
 
+ByteArray JoinerSession::GetJoinerIid() const
+{
+    auto joinerIid = mJoinerId;
+    joinerIid[0] ^= kLocalExternalAddrMask;
+    return joinerIid;
+}
+
 void JoinerSession::HandleConnect(Error aError)
 {
     mCommImpl.mCommissionerHandler.OnJoinerConnected(mJoinerId, aError);

--- a/src/library/joiner_session.hpp
+++ b/src/library/joiner_session.hpp
@@ -67,19 +67,19 @@ class JoinerSession : std::enable_shared_from_this<JoinerSession>
 {
 public:
     JoinerSession(CommissionerImpl & aCommImpl,
-                         const ByteArray &  aJoinerId,
-                         const std::string &aJoinerPSkd,
-                         uint16_t           aJoinerUdpPort,
-                         uint16_t           aJoinerRouterLocator,
-                         const Address &    aJoinerAddr,
-                         uint16_t           aJoinerPort,
-                         const Address &    aLocalAddr,
-                         uint16_t           aLocalPort);
+                  const ByteArray &  aJoinerId,
+                  const std::string &aJoinerPSkd,
+                  uint16_t           aJoinerUdpPort,
+                  uint16_t           aJoinerRouterLocator,
+                  const Address &    aJoinerAddr,
+                  uint16_t           aJoinerPort,
+                  const Address &    aLocalAddr,
+                  uint16_t           aLocalPort);
     JoinerSession(JoinerSession &&aOther) = delete;
     JoinerSession &operator=(JoinerSession &&aOther) = delete;
     JoinerSession(const JoinerSession &aOther)       = delete;
     JoinerSession &operator=(const JoinerSession &aOther) = delete;
-    ~JoinerSession()                                             = default;
+    ~JoinerSession()                                      = default;
 
     ByteArray GetJoinerId() const { return mJoinerId; }
     uint16_t  GetJoinerUdpPort() const { return mJoinerUdpPort; }

--- a/src/library/joiner_session.hpp
+++ b/src/library/joiner_session.hpp
@@ -134,12 +134,7 @@ private:
 
     using RelaySocketPtr = std::shared_ptr<RelaySocket>;
 
-    ByteArray GetJoinerIid() const
-    {
-        auto joinerIid = mJoinerId;
-        joinerIid[0] ^= kLocalExternalAddrMask;
-        return joinerIid;
-    }
+    ByteArray GetJoinerIid() const;
 
     void HandleConnect(Error aError);
 

--- a/src/library/joiner_session.hpp
+++ b/src/library/joiner_session.hpp
@@ -55,6 +55,8 @@ static constexpr uint16_t kListeningJoinerPort = 9527;
 // the joiner session will be closed and removed.
 static constexpr uint32_t kJoinerTimeout = 20;
 
+static constexpr uint8_t kLocalExternalAddrMask = 1 << 1;
+
 class CommissionerImpl;
 class JoinerSession;
 
@@ -64,32 +66,30 @@ using JoinerSessionPtr = std::shared_ptr<JoinerSession>;
 class JoinerSession : std::enable_shared_from_this<JoinerSession>
 {
 public:
-    using ConnectHandler = std::function<void(JoinerSession &, Error)>;
-
-    JoinerSession(CommissionerImpl &aCommImpl,
-                  const JoinerInfo &aJoinerInfo,
-                  uint16_t          aJoinerUdpPort,
-                  uint16_t          aJoinerRouterLocator,
-                  const ByteArray & aJoinerIid,
-                  const Address &   aJoinerAddr,
-                  uint16_t          aJoinerPort,
-                  const Address &   aLocalAddr,
-                  uint16_t          aLocalPort);
+    JoinerSession(CommissionerImpl & aCommImpl,
+                         const ByteArray &  aJoinerId,
+                         const std::string &aJoinerPSkd,
+                         uint16_t           aJoinerUdpPort,
+                         uint16_t           aJoinerRouterLocator,
+                         const Address &    aJoinerAddr,
+                         uint16_t           aJoinerPort,
+                         const Address &    aLocalAddr,
+                         uint16_t           aLocalPort);
     JoinerSession(JoinerSession &&aOther) = delete;
     JoinerSession &operator=(JoinerSession &&aOther) = delete;
     JoinerSession(const JoinerSession &aOther)       = delete;
     JoinerSession &operator=(const JoinerSession &aOther) = delete;
-    ~JoinerSession()                                      = default;
+    ~JoinerSession()                                             = default;
 
+    ByteArray GetJoinerId() const { return mJoinerId; }
     uint16_t  GetJoinerUdpPort() const { return mJoinerUdpPort; }
     uint16_t  GetJoinerRouterLocator() const { return mJoinerRouterLocator; }
-    ByteArray GetJoinerIid() const { return mJoinerIid; }
     Address   GetPeerAddr() const { return mDtlsSession->GetPeerAddr(); }
     uint16_t  GetPeerPort() const { return mDtlsSession->GetPeerPort(); }
 
-    Error Start(ConnectHandler aOnConnected);
+    void Connect();
 
-    void Stop();
+    void Disconnect();
 
     DtlsSession::State GetState() const { return mDtlsSession->GetState(); }
 
@@ -134,16 +134,25 @@ private:
 
     using RelaySocketPtr = std::shared_ptr<RelaySocket>;
 
+    ByteArray GetJoinerIid() const
+    {
+        auto joinerIid = mJoinerId;
+        joinerIid[0] ^= kLocalExternalAddrMask;
+        return joinerIid;
+    }
+
+    void HandleConnect(Error aError);
+
     Error SendRlyTx(const ByteArray &aDtlsMessage, bool aIncludeKek);
     void  HandleJoinFin(const coap::Request &aJoinFin);
     Error SendJoinFinResponse(const coap::Request &aJoinFinReq, bool aAccept);
 
     CommissionerImpl &mCommImpl;
-    JoinerInfo        mJoinerInfo;
 
-    uint16_t  mJoinerUdpPort;
-    uint16_t  mJoinerRouterLocator;
-    ByteArray mJoinerIid;
+    ByteArray   mJoinerId;
+    std::string mJoinerPSKd;
+    uint16_t    mJoinerUdpPort;
+    uint16_t    mJoinerRouterLocator;
 
     RelaySocketPtr mRelaySocket;
     DtlsSessionPtr mDtlsSession;


### PR DESCRIPTION
This PR refactors commissioner handlers to use a `CommissionerHandler` interface for handling all commissioner events. An application should implement the `CommisssionerHandler` interface to handle those events.

Change summary:
- use `CommissionerHandler` interface to handle commissioner events.
- add `OnJoinerConnected` to handle joiner DTLS connection event. This addresses issue https://github.com/openthread/ot-commissioner/issues/28.
- add `OnKeepAliveResponse`  to notify whether the commissioner was rejected or not.
- remove `JoinerType` and `JoinerInfo` from public library interface.

This PR supports Java binding of the commissioner library.
