### PR TITLE
[api] remove API 'start' and 'stop'

### DIFF
--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -193,6 +193,7 @@ public:
      * @return  A boolean indicates whether the joiner is accepted.
      *
      * @note This will be called when A well-formed JOIN_FIN.req has been received.
+     *
      */
     virtual bool OnJoinerFinalize(const ByteArray &  aJoinerId,
                                   const std::string &aVendorName,
@@ -346,25 +347,6 @@ public:
      * @return The configuration.
      */
     virtual const Config &GetConfig() const = 0;
-
-    /**
-     * @brief Start the commissioner event loop.
-     *
-     * @return Error::kNone, succeed; otherwise, failed.
-     *
-     * @note A commissioner must be started before it can send TMF requests.
-     *       If the commissioner is created with @p aEventBase != nullptr,
-     *       this function will start event loop in current thread and wait
-     *       until calling `Stop`; Otherwise, this function will start
-     *       event loop in seprate thread.
-     */
-    virtual Error Start() = 0;
-
-    /**
-     * @brief Stop the commissioner event loop.
-     *
-     */
-    virtual void Stop() = 0;
 
     /**
      * @brief Asynchronously connect to a Thread network.

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -68,7 +68,6 @@ Error CommissionerApp::Init(const Config &aConfig)
     Error error;
 
     SuccessOrExit(error = Commissioner::Create(mCommissioner, *this, aConfig));
-    SuccessOrExit(error = mCommissioner->Start());
 
     mCommDataset = MakeDefaultCommissionerDataset();
 

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -151,17 +151,6 @@ CommissionerImpl::CommissionerImpl(CommissionerHandler &aHandler, struct event_b
     SuccessOrDie(mProxyClient.AddResource(mResourceEnergyReport));
 }
 
-CommissionerImpl::~CommissionerImpl()
-{
-    Stop();
-
-    mProxyClient.RemoveResource(mResourceEnergyReport);
-    mProxyClient.RemoveResource(mResourcePanIdConflict);
-    mProxyClient.RemoveResource(mResourceDatasetChanged);
-    mBrClient.RemoveResource(mResourceRlyRx);
-    mBrClient.RemoveResource(mResourceUdpRx);
-}
-
 Error CommissionerImpl::Init(const Config &aConfig)
 {
     Error error = Error::kFailed;
@@ -244,19 +233,6 @@ void CommissionerImpl::LoggingConfig()
 const Config &CommissionerImpl::GetConfig() const
 {
     return mConfig;
-}
-
-Error CommissionerImpl::Start()
-{
-    LOG_INFO(LOG_REGION_MESHCOP, "event loop started in background thread");
-    event_base_loop(mEventBase, EVLOOP_NO_EXIT_ON_EMPTY);
-    return Error::kNone;
-}
-
-// Stop the commissioner event loop.
-void CommissionerImpl::Stop()
-{
-    event_base_loopbreak(mEventBase);
 }
 
 void CommissionerImpl::Petition(PetitionHandler aHandler, const std::string &aAddr, uint16_t aPort)

--- a/src/library/commissioner_impl.hpp
+++ b/src/library/commissioner_impl.hpp
@@ -30,6 +30,7 @@
 #define OT_COMM_LIBRARY_COMMISSIONER_IMPL_HPP_
 
 #include <atomic>
+#include <memory>
 
 #include <commissioner/commissioner.hpp>
 
@@ -74,7 +75,7 @@ public:
 
     Error Init(const Config &aConfig);
 
-    ~CommissionerImpl() override;
+    ~CommissionerImpl() override = default;
 
     const Config &GetConfig() const override;
 
@@ -89,12 +90,6 @@ public:
     const std::string &GetDomainName() const override;
 
     void AbortRequests() override;
-
-    // Start the commissioner event loop and will not return until it is stopped.
-    Error Start() override;
-
-    // Stop the commissioner.
-    void Stop() override;
 
     void  Connect(ErrorHandler aHandler, const std::string &aAddr, uint16_t aPort) override;
     Error Connect(const std::string &, uint16_t) override { return Error::kNotImplemented; }

--- a/src/library/commissioner_safe.cpp
+++ b/src/library/commissioner_safe.cpp
@@ -35,6 +35,8 @@
 
 #include <future>
 
+#include <assert.h>
+
 #include "library/coap.hpp"
 #include "library/cose.hpp"
 #include "library/logging.hpp"
@@ -95,7 +97,7 @@ const Config &CommissionerSafe::GetConfig() const
 
 void CommissionerSafe::StartEventLoopThread()
 {
-    VerifyOrDie(!mEventThread.joinable());
+    assert(!mEventThread.joinable());
 
     mEventThread = std::thread([this]() {
         LOG_INFO("event loop started in background thread");

--- a/src/library/commissioner_safe.cpp
+++ b/src/library/commissioner_safe.cpp
@@ -100,7 +100,7 @@ void CommissionerSafe::StartEventLoopThread()
     assert(!mEventThread.joinable());
 
     mEventThread = std::thread([this]() {
-        LOG_INFO("event loop started in background thread");
+        LOG_INFO(LOG_REGION_MESHCOP, "event loop started in background thread");
         event_base_loop(mEventBase.Get(), EVLOOP_NO_EXIT_ON_EMPTY);
     });
 }

--- a/src/library/commissioner_safe.cpp
+++ b/src/library/commissioner_safe.cpp
@@ -76,8 +76,7 @@ Error CommissionerSafe::Init(const Config &aConfig)
     VerifyOrExit(event_assign(&mInvokeEvent, mEventBase.Get(), -1, EV_PERSIST, Invoke, this) == 0);
     VerifyOrExit(event_add(&mInvokeEvent, nullptr) == 0);
 
-    // Do not propogate the returned error.
-    SuccessOrExit(StartEventLoopThread());
+    StartEventLoopThread();
 
 exit:
     return error;
@@ -94,19 +93,14 @@ const Config &CommissionerSafe::GetConfig() const
     return mImpl.GetConfig();
 }
 
-Error CommissionerSafe::StartEventLoopThread()
+void CommissionerSafe::StartEventLoopThread()
 {
-    Error error = Error::kNone;
-
-    VerifyOrExit(!mEventThread.joinable(), error = Error::kAlready);
+    VerifyOrDie(!mEventThread.joinable());
 
     mEventThread = std::thread([this]() {
         LOG_INFO("event loop started in background thread");
         event_base_loop(mEventBase.Get(), EVLOOP_NO_EXIT_ON_EMPTY);
     });
-
-exit:
-    return error;
 }
 
 void CommissionerSafe::StopEventLoopThread(void)

--- a/src/library/commissioner_safe.hpp
+++ b/src/library/commissioner_safe.hpp
@@ -89,12 +89,6 @@ public:
 
     void AbortRequests() override;
 
-    // Start the commissioner event loop in background.
-    Error Start() override;
-
-    // Stop the commissioner running in background.
-    void Stop() override;
-
     void  Connect(ErrorHandler aHandler, const std::string &aAddr, uint16_t aPort) override;
     Error Connect(const std::string &aAddr, uint16_t aPort) override;
 
@@ -196,6 +190,9 @@ private:
     void         PushAsyncRequest(AsyncRequest &&aAsyncRequest);
     AsyncRequest PopAsyncRequest();
 
+    Error StartEventLoopThread();
+    void  StopEventLoopThread();
+
 private:
     class EventBaseHolder
     {
@@ -208,6 +205,9 @@ private:
         struct event_base *mEventBase;
     };
 
+    // The EventBaseHolder needs to be the first member so that
+    // it is constructed before any other members and destructed
+    // after any other members.
     EventBaseHolder mEventBase;
 
     CommissionerImpl mImpl;

--- a/src/library/commissioner_safe.hpp
+++ b/src/library/commissioner_safe.hpp
@@ -190,8 +190,8 @@ private:
     void         PushAsyncRequest(AsyncRequest &&aAsyncRequest);
     AsyncRequest PopAsyncRequest();
 
-    Error StartEventLoopThread();
-    void  StopEventLoopThread();
+    void StartEventLoopThread();
+    void StopEventLoopThread();
 
 private:
     class EventBaseHolder


### PR DESCRIPTION
This PR removes API `start` and `stop`. Those two APIs are specific to event loop thread, which should be hide behind the public interface.