### PR TITLE
[api] propagate Commissioner construction errors

### DIFF
--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -266,10 +266,12 @@ public:
     /**
      * @brief Create an instance of the commissioner.
      *
-     * @param[in] aConfig     A commissioner configuration.
-     * @param[in] aEventBase  A libevent event_base object. nullable.
+     * @param[out] aCommissioner  The created commissioner instance.
+     * @param[in]  aConfig        A commissioner configuration.
+     * @param[in]  aEventBase     A libevent event_base object. nullable.
      *
-     * @return std::shared_ptr<Commissioner>  nullptr is returned if failed.
+     * @retval Error::kNone  Successfully created a commissioner instance.
+     * @retval ...           Failed to create a commissioner instance.
      *
      * @note If @p aEventBase is not provided, commissioner will create it by itself and
      *       run the event loop in separate background thread. In this case, all callback
@@ -277,7 +279,9 @@ public:
      *       Otherwise, it is the user to run the event loop and no synchronization is
      *       needed in callback functions.
      */
-    static std::shared_ptr<Commissioner> Create(const Config &aConfig, struct event_base *aEventBase);
+    static Error Create(std::shared_ptr<Commissioner> &aCommissioner,
+                        const Config &                 aConfig,
+                        struct event_base *            aEventBase);
 
     virtual ~Commissioner() = default;
 

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -57,13 +57,11 @@ exit:
 
 Error CommissionerApp::Init(const Config &aConfig)
 {
-    Error error        = Error::kNone;
-    auto  commissioner = Commissioner::Create(aConfig, nullptr);
+    Error error;
 
-    VerifyOrExit(commissioner != nullptr, error = Error::kInvalidArgs);
-    SuccessOrExit(error = commissioner->Start());
+    SuccessOrExit(error = Commissioner::Create(mCommissioner, aConfig, nullptr));
+    SuccessOrExit(error = mCommissioner->Start());
 
-    mCommissioner = commissioner;
     mCommissioner->SetPanIdConflictHandler(
         [this](const std::string *aPeerAddr, const ChannelMask *aChannelMask, const uint16_t *aPanId, Error aError) {
             HandlePanIdConflict(aPeerAddr, aChannelMask, aPanId, aError);

--- a/src/library/commissioner_safe.cpp
+++ b/src/library/commissioner_safe.cpp
@@ -44,18 +44,26 @@ namespace ot {
 
 namespace commissioner {
 
-std::shared_ptr<Commissioner> Commissioner::Create(const Config &aConfig, struct event_base *aEventBase)
+Error Commissioner::Create(std::shared_ptr<Commissioner> &aCommissioner,
+                           const Config &                 aConfig,
+                           struct event_base *            aEventBase)
 {
+    Error error;
     if (aEventBase == nullptr)
     {
         auto comm = std::make_shared<CommissionerSafe>();
-        return (comm->Init(aConfig) == Error::kNone) ? comm : nullptr;
+        SuccessOrExit(error = comm->Init(aConfig));
+        aCommissioner = comm;
     }
     else
     {
         auto comm = std::make_shared<CommissionerImpl>(aEventBase);
-        return (comm->Init(aConfig) == Error::kNone) ? comm : nullptr;
+        SuccessOrExit(error = comm->Init(aConfig));
+        aCommissioner = comm;
     }
+
+exit:
+    return error;
 }
 
 CommissionerSafe::CommissionerSafe()

--- a/src/library/commissioner_safe_test.cpp
+++ b/src/library/commissioner_safe_test.cpp
@@ -47,8 +47,8 @@ TEST_CASE("stop-immediately-after-starting", "[commissioner]")
     config.mPSKc = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
 
     // This creates an CommissionerSafe instance.
-    auto commissioner = Commissioner::Create(config, nullptr);
-    REQUIRE(commissioner != nullptr);
+    std::shared_ptr<Commissioner> commissioner;
+    REQUIRE(Commissioner::Create(commissioner, config, nullptr) == Error::kNone);
 }
 
 } // namespace commissioner

--- a/src/library/commissioner_safe_test.cpp
+++ b/src/library/commissioner_safe_test.cpp
@@ -49,6 +49,7 @@ TEST_CASE("stop-immediately-after-starting", "[commissioner]")
     // This creates an CommissionerSafe instance.
     std::shared_ptr<Commissioner> commissioner;
     REQUIRE(Commissioner::Create(commissioner, config, nullptr) == Error::kNone);
+    REQUIRE(commissioner != nullptr);
 }
 
 } // namespace commissioner


### PR DESCRIPTION
This PR changes API `Commissioner::Create` to propagate initialization errors.