### PR TITLE
[utils] rename 'ASSERT' to 'VerifyOrDie'

### DIFF
--- a/src/app/cli/interpreter.cpp
+++ b/src/app/cli/interpreter.cpp
@@ -283,7 +283,7 @@ Interpreter::Expression Interpreter::ParseExpression(const std::string &aLiteral
         {
             if (*c == '\'')
             {
-                ASSERT(begin != aLiteral.end());
+                VerifyOrDie(begin != aLiteral.end());
                 expr.emplace_back(begin, c);
                 begin          = aLiteral.end();
                 inSingleQuotes = false;
@@ -1093,14 +1093,14 @@ void Interpreter::BorderAgentHandler(const BorderAgent *aBorderAgent, const std:
     }
     else
     {
-        ASSERT(aBorderAgent != nullptr);
+        VerifyOrDie(aBorderAgent != nullptr);
         Console::Write(ToString(*aBorderAgent), Console::Color::kGreen);
     }
 }
 
 const std::string Interpreter::Usage(Expression aExpr)
 {
-    ASSERT(aExpr.size() >= 1);
+    VerifyOrDie(aExpr.size() >= 1);
     auto usage = mUsageMap.find(aExpr[0]);
     return usage != mUsageMap.end() ? usage->second : "";
 }

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -199,7 +199,7 @@ Error CommissionerApp::GetBorderAgentLocator(uint16_t &aLocator) const
     VerifyOrExit(IsActive(), error = Error::kInvalidState);
 
     // We must have Border Agent Locator in commissioner dataset.
-    ASSERT(mCommDataset.mPresentFlags & CommissionerDataset::kBorderAgentLocatorBit);
+    VerifyOrDie(mCommDataset.mPresentFlags & CommissionerDataset::kBorderAgentLocatorBit);
 
     aLocator = mCommDataset.mBorderAgentLocator;
 
@@ -429,7 +429,7 @@ Error CommissionerApp::GetActiveTimestamp(Timestamp &aTimestamp) const
 
     VerifyOrExit(IsActive(), error = Error::kInvalidState);
 
-    ASSERT(mActiveDataset.mPresentFlags & ActiveOperationalDataset::kActiveTimestampBit);
+    VerifyOrDie(mActiveDataset.mPresentFlags & ActiveOperationalDataset::kActiveTimestampBit);
     aTimestamp = mActiveDataset.mActiveTimestamp;
 
 exit:
@@ -448,7 +448,7 @@ Error CommissionerApp::GetChannel(Channel &aChannel)
     // TODO(wgtdkp): should we send MGMT_ACTIVE_GET.req for all GetXXX APIs ?
     SuccessOrExit(error = mCommissioner->GetActiveDataset(mActiveDataset, 0xFFFF));
 
-    ASSERT(mActiveDataset.mPresentFlags & ActiveOperationalDataset::kChannelBit);
+    VerifyOrDie(mActiveDataset.mPresentFlags & ActiveOperationalDataset::kChannelBit);
 
     aChannel = mActiveDataset.mChannel;
 
@@ -1080,7 +1080,7 @@ ByteArray &CommissionerApp::GetSteeringData(CommissionerDataset &aDataset, Joine
         return aDataset.mNmkpSteeringData;
 
     default:
-        ASSERT(false);
+        VerifyOrDie(false);
         aDataset.mPresentFlags |= CommissionerDataset::kSteeringDataBit;
         return aDataset.mSteeringData;
     }
@@ -1103,7 +1103,7 @@ uint16_t &CommissionerApp::GetJoinerUdpPort(CommissionerDataset &aDataset, Joine
         return aDataset.mNmkpUdpPort;
 
     default:
-        ASSERT(false);
+        VerifyOrDie(false);
         aDataset.mPresentFlags |= CommissionerDataset::kJoinerUdpPortBit;
         return aDataset.mJoinerUdpPort;
     }

--- a/src/app/file_logger.cpp
+++ b/src/app/file_logger.cpp
@@ -68,7 +68,7 @@ static std::string ToString(LogLevel aLevel)
         ret = "debug";
         break;
     default:
-        ASSERT(false);
+        VerifyOrDie(false);
         break;
     }
 

--- a/src/app/json.cpp
+++ b/src/app/json.cpp
@@ -678,14 +678,12 @@ std::string EnergyReportMapToJson(const EnergyReportMap &aEnergyReportMap)
     // the JSON library will map `aEnergyReportMap` into JSON array.
     for (auto &kv : aEnergyReportMap)
     {
-        auto &deviceAddr = kv.first;
-        auto &report     = kv.second;
-
-        ASSERT(deviceAddr.IsValid());
-        Error       error;
+        auto &      deviceAddr = kv.first;
+        auto &      report     = kv.second;
         std::string addr;
-        error = deviceAddr.ToString(addr);
-        ASSERT(error == Error::kNone);
+
+        VerifyOrDie(deviceAddr.IsValid());
+        SuccessOrDie(deviceAddr.ToString(addr));
 
         json[addr] = report;
     }

--- a/src/common/address.cpp
+++ b/src/common/address.cpp
@@ -105,8 +105,8 @@ exit:
 Address Address::FromString(const std::string &aAddr)
 {
     Address ret;
-    auto    error = ret.Set(aAddr);
-    ASSERT(error == Error::kNone);
+
+    SuccessOrDie(ret.Set(aAddr));
     return ret;
 }
 

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -78,7 +78,7 @@ std::string Hex(const ByteArray &aBytes)
 
 static inline uint8_t Hex(char c)
 {
-    ASSERT(isxdigit(c));
+    VerifyOrDie(isxdigit(c));
     return c >= 'A' && c <= 'F' ? (c - 'A' + 10) : c >= 'a' && c <= 'f' ? (c - 'a' + 10) : (c - '0');
 }
 

--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -39,8 +39,13 @@
 #include <commissioner/defines.hpp>
 #include <commissioner/error.hpp>
 
-// ASSERT allows side-effect.
-#define ASSERT(aCondition)                  \
+#define SuccessOrDie(aError)                   \
+    do                                         \
+    {                                          \
+        VerifyOrDie((aError) == Error::kNone); \
+    } while (false)
+
+#define VerifyOrDie(aCondition)             \
     do                                      \
     {                                       \
         if (!(aCondition))                  \
@@ -128,7 +133,7 @@ template <typename T> T Decode(const uint8_t *aBuf)
 
 template <typename T> T Decode(const ByteArray &aBuf)
 {
-    ASSERT(aBuf.size() >= sizeof(T));
+    VerifyOrDie(aBuf.size() >= sizeof(T));
     return Decode<T>(&aBuf[0]);
 }
 

--- a/src/library/coap.cpp
+++ b/src/library/coap.cpp
@@ -64,7 +64,7 @@ size_t Message::GetHeaderLength() const
 {
     ByteArray buf;
 
-    ASSERT(Serialize(mHeader, buf) == Error::kNone);
+    SuccessOrDie(Serialize(mHeader, buf));
     return buf.size();
 }
 
@@ -224,7 +224,7 @@ Error Message::Serialize(OptionType         aOptionNumber,
     size_t   firstByte   = aBuf.size();
     size_t   extend      = aBuf.size() + 1;
 
-    ASSERT(utils::to_underlying(aOptionNumber) >= aLastOptionNumber);
+    VerifyOrDie(utils::to_underlying(aOptionNumber) >= aLastOptionNumber);
 
     VerifyOrExit(IsValidOption(aOptionNumber, aOptionValue), error = Error::kBadFormat);
 
@@ -269,7 +269,7 @@ Error Message::Serialize(OptionType         aOptionNumber,
         aBuf[extend++] = deltaLength & 0xff;
     }
 
-    ASSERT(length + firstByte == extend);
+    VerifyOrDie(length + firstByte == extend);
 
     aBuf.insert(aBuf.end(), aOptionValue.GetOpaqueValue().begin(), aOptionValue.GetOpaqueValue().end());
 
@@ -338,7 +338,7 @@ Error Message::Deserialize(OptionType &     aOptionNumber,
         ExitNow(error = Error::kBadFormat);
     }
 
-    ASSERT(firstByte + length == extend);
+    VerifyOrDie(firstByte + length == extend);
 
     VerifyOrExit(valueLength + extend <= aBuf.size(), error = Error::kBadFormat);
 
@@ -417,7 +417,7 @@ void Coap::SendRequest(const Request &aRequest, ResponseHandler aHandler)
 
     VerifyOrExit(request->IsConfirmable() || request->IsNonConfirmable(), error = Error::kInvalidArgs);
 
-    ASSERT(request->GetMessageId() == 0);
+    VerifyOrDie(request->GetMessageId() == 0);
     request->SetMessageId(AllocMessageId());
     request->SetToken(kDefaultTokenLength);
 
@@ -471,7 +471,7 @@ void Coap::ReceiveMessage(Endpoint &aEndpoint, std::shared_ptr<Message> aMessage
     }
     else
     {
-        ASSERT(aMessage != nullptr);
+        VerifyOrDie(aMessage != nullptr);
 
         aMessage->SetEndpoint(&aEndpoint);
         if (aMessage->IsRequest())
@@ -785,7 +785,7 @@ void Coap::RequestsCache::Put(const RequestHolder &aRequestHolder)
 
 Coap::RequestHolder Coap::RequestsCache::Eliminate()
 {
-    ASSERT(!IsEmpty());
+    VerifyOrDie(!IsEmpty());
     auto ret = *mContainer.begin();
 
     mContainer.erase(mContainer.begin());
@@ -1113,7 +1113,7 @@ void Message::SetToken(const ByteArray &aToken)
 
 void Message::SetToken(uint8_t aTokenLength)
 {
-    ASSERT(aTokenLength <= sizeof(mHeader.mToken));
+    VerifyOrDie(aTokenLength <= sizeof(mHeader.mToken));
 
     mHeader.mTokenLength = aTokenLength;
     random::non_crypto::FillBuffer(mHeader.mToken, aTokenLength);

--- a/src/library/coap.hpp
+++ b/src/library/coap.hpp
@@ -332,7 +332,7 @@ public:
 
     uint32_t GetUint32Value() const
     {
-        ASSERT(mValue.size() <= sizeof(uint32_t));
+        VerifyOrDie(mValue.size() <= sizeof(uint32_t));
         uint32_t ret = 0;
         for (auto byte : mValue)
         {
@@ -713,7 +713,7 @@ private:
 
         TimePoint Earliest() const
         {
-            ASSERT(!IsEmpty());
+            VerifyOrDie(!IsEmpty());
             return mContainer.begin()->mNextTimerShot;
         }
 
@@ -722,7 +722,7 @@ private:
 
         const RequestHolder &Front() const
         {
-            ASSERT(!IsEmpty());
+            VerifyOrDie(!IsEmpty());
             return *mContainer.begin();
         }
 

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -158,11 +158,11 @@ CommissionerImpl::CommissionerImpl(struct event_base *aEventBase)
     , mJoinerInfoRequester(nullptr)
     , mCommissioningHandler(nullptr)
 {
-    ASSERT(mBrClient.AddResource(mResourceUdpRx) == Error::kNone);
-    ASSERT(mBrClient.AddResource(mResourceRlyRx) == Error::kNone);
-    ASSERT(mProxyClient.AddResource(mResourceDatasetChanged) == Error::kNone);
-    ASSERT(mProxyClient.AddResource(mResourcePanIdConflict) == Error::kNone);
-    ASSERT(mProxyClient.AddResource(mResourceEnergyReport) == Error::kNone);
+    SuccessOrDie(mBrClient.AddResource(mResourceUdpRx));
+    SuccessOrDie(mBrClient.AddResource(mResourceRlyRx));
+    SuccessOrDie(mProxyClient.AddResource(mResourceDatasetChanged));
+    SuccessOrDie(mProxyClient.AddResource(mResourcePanIdConflict));
+    SuccessOrDie(mProxyClient.AddResource(mResourceEnergyReport));
 }
 
 CommissionerImpl::~CommissionerImpl()
@@ -383,7 +383,7 @@ void CommissionerImpl::GetCommissionerDataset(Handler<CommissionerDataset> aHand
         CommissionerDataset dataset;
 
         SuccessOrExit(error = aError);
-        ASSERT(aResponse != nullptr);
+        VerifyOrDie(aResponse != nullptr);
 
         VerifyOrExit(aResponse->GetCode() == coap::Code::kChanged, error = Error::kFailed);
 
@@ -2037,8 +2037,7 @@ Error CommissionerImpl::MakeChannelMask(ByteArray &aBuf, uint32_t aChannelMask)
     }
 
     VerifyOrExit(!entry.mMasks.empty(), error = Error::kInvalidArgs);
-    error = EncodeChannelMask(aBuf, {entry});
-    ASSERT(error == Error::kNone);
+    SuccessOrDie(EncodeChannelMask(aBuf, {entry}));
 
 exit:
     return error;
@@ -2150,7 +2149,7 @@ void CommissionerImpl::HandleRlyRx(const coap::Request &aRlyRx)
             }
         }
 
-        ASSERT(it != mCommissioningSessions.end());
+        VerifyOrDie(it != mCommissioningSessions.end());
         auto &session = it->second;
         session.RecvJoinerDtlsRecords(dtlsRecords);
     }

--- a/src/library/commissioner_safe.cpp
+++ b/src/library/commissioner_safe.cpp
@@ -558,7 +558,7 @@ void CommissionerSafe::Invoke(evutil_socket_t, short, void *aContext)
 {
     auto commissionerSafe = reinterpret_cast<CommissionerSafe *>(aContext);
 
-    ASSERT(commissionerSafe != nullptr);
+    VerifyOrDie(commissionerSafe != nullptr);
 
     if (auto asyncReq = commissionerSafe->PopAsyncRequest())
     {

--- a/src/library/commissioning_session.cpp
+++ b/src/library/commissioning_session.cpp
@@ -61,7 +61,7 @@ CommissioningSession::CommissioningSession(CommissionerImpl &aCommImpl,
     , mCoap(aCommImpl.GetEventBase(), *mDtlsSession)
     , mResourceJoinFin(uri::kJoinFin, [this](const coap::Request &aRequest) { HandleJoinFin(aRequest); })
 {
-    ASSERT(mCoap.AddResource(mResourceJoinFin) == Error::kNone);
+    SuccessOrDie(mCoap.AddResource(mResourceJoinFin));
 }
 
 Error CommissioningSession::Start(ConnectHandler aOnConnected)
@@ -222,8 +222,8 @@ CommissioningSession::RelaySocket::RelaySocket(CommissioningSession &aCommission
     mIsConnected = true;
 
     fail = event_assign(&mEvent, mEventBase, -1, EV_PERSIST | EV_READ | EV_WRITE | EV_ET, HandleEvent, this);
-    ASSERT(fail == 0);
-    ASSERT((fail = event_add(&mEvent, nullptr)) == 0);
+    VerifyOrDie(fail == 0);
+    VerifyOrDie((fail = event_add(&mEvent, nullptr)) == 0);
 }
 
 CommissioningSession::RelaySocket::RelaySocket(RelaySocket &&aOther)

--- a/src/library/cose.cpp
+++ b/src/library/cose.cpp
@@ -231,7 +231,7 @@ const uint8_t *Sign1Message::GetPayload(size_t &aLength)
     cn_cbor *      cbor;
     cn_cbor *      payload;
 
-    ASSERT(mSign != nullptr);
+    VerifyOrDie(mSign != nullptr);
     VerifyOrExit((cbor = COSE_get_cbor(reinterpret_cast<HCOSE>(mSign))) != nullptr);
 
     VerifyOrExit(cbor->type == CN_CBOR_ARRAY && (payload = CborArrayAt(cbor, 2)) != nullptr);

--- a/src/library/dtls.cpp
+++ b/src/library/dtls.cpp
@@ -90,7 +90,7 @@ static Error ErrorFromMbedtlsError(int aMbedtlsError)
     static constexpr int kMbedtlsErrorHighLevelModuleIdCipher = 6;
     static constexpr int kMbedtlsErrorHighLevelModuleIdSsl    = 7;
 
-    ASSERT(aMbedtlsError <= 0);
+    VerifyOrDie(aMbedtlsError <= 0);
 
     Error error;
 
@@ -297,7 +297,7 @@ exit:
 
 void DtlsSession::Connect(ConnectHandler aOnConnected)
 {
-    ASSERT(mState == State::kOpen);
+    VerifyOrDie(mState == State::kOpen);
 
     mOnConnected = aOnConnected;
     mState       = State::kConnecting;
@@ -305,7 +305,7 @@ void DtlsSession::Connect(ConnectHandler aOnConnected)
 
 void DtlsSession::Reconnect()
 {
-    ASSERT(mIsServer);
+    VerifyOrDie(mIsServer);
     Reset();
     Connect(mOnConnected);
 }
@@ -425,7 +425,7 @@ void DtlsSession::HandleEvent(short aFlags)
         break;
 
     default:
-        ASSERT(false);
+        VerifyOrDie(false);
         break;
     }
 
@@ -438,7 +438,7 @@ exit:
 
 Error DtlsSession::SetClientTransportId()
 {
-    ASSERT(mIsServer && !mIsClientIdSet);
+    VerifyOrDie(mIsServer && !mIsClientIdSet);
     Error error    = Error::kNone;
     int   rval     = 0;
     auto  peerAddr = GetPeerAddr();
@@ -665,7 +665,7 @@ void DtlsSession::HandshakeTimerCallback(Timer &)
 
     case State::kConnected:
     default:
-        ASSERT(false);
+        VerifyOrDie(false);
     }
 
     if (ShouldStop(error))

--- a/src/library/error.cpp
+++ b/src/library/error.cpp
@@ -80,7 +80,7 @@ const std::string ErrorToString(const Error &aError)
     case Error::kTransportFailed:
         return "TransportFailed";
     default:
-        ASSERT(false);
+        VerifyOrDie(false);
         return "";
     }
 }

--- a/src/library/network_data.cpp
+++ b/src/library/network_data.cpp
@@ -99,16 +99,14 @@ exit:
 
 std::string Ipv6PrefixToString(ByteArray aPrefix)
 {
-    ASSERT(aPrefix.size() <= 16);
-
-    auto prefixLength = aPrefix.size() * 8;
-    aPrefix.resize(16);
-
-    Address addr;
-    ASSERT(addr.Set(aPrefix) == Error::kNone);
-
+    auto        prefixLength = aPrefix.size() * 8;
+    Address     addr;
     std::string ret;
-    ASSERT(addr.ToString(ret) == Error::kNone);
+
+    VerifyOrDie(aPrefix.size() <= 16);
+    aPrefix.resize(16);
+    SuccessOrDie(addr.Set(aPrefix));
+    SuccessOrDie(addr.ToString(ret));
     return ret + "/" + std::to_string(prefixLength);
 }
 

--- a/src/library/socket.cpp
+++ b/src/library/socket.cpp
@@ -52,7 +52,7 @@ static uint16_t GetSockPort(const sockaddr_storage &aSockAddr)
     }
     else
     {
-        ASSERT(false);
+        VerifyOrDie(false);
     }
 }
 
@@ -92,7 +92,7 @@ void Socket::HandleEvent(evutil_socket_t, short aFlags, void *aSocket)
 {
     auto socket = reinterpret_cast<Socket *>(aSocket);
 
-    ASSERT(socket->mEventHandler != nullptr);
+    VerifyOrDie(socket->mEventHandler != nullptr);
     socket->mEventHandler(aFlags);
 }
 
@@ -173,7 +173,7 @@ uint16_t UdpSocket::GetLocalPort() const
     sockaddr_storage addr;
     socklen_t        len = sizeof(sockaddr_storage);
 
-    ASSERT(getsockname(mNetCtx.fd, reinterpret_cast<sockaddr *>(&addr), &len) == 0);
+    VerifyOrDie(getsockname(mNetCtx.fd, reinterpret_cast<sockaddr *>(&addr), &len) == 0);
     return GetSockPort(addr);
 }
 
@@ -181,11 +181,10 @@ Address UdpSocket::GetLocalAddr() const
 {
     sockaddr_storage addr;
     socklen_t        len = sizeof(sockaddr_storage);
+    Address          ret;
 
-    ASSERT(getsockname(mNetCtx.fd, reinterpret_cast<sockaddr *>(&addr), &len) == 0);
-
-    Address ret;
-    ASSERT(ret.Set(addr) == Error::kNone);
+    VerifyOrDie(getsockname(mNetCtx.fd, reinterpret_cast<sockaddr *>(&addr), &len) == 0);
+    SuccessOrDie(ret.Set(addr));
     return ret;
 }
 
@@ -194,9 +193,9 @@ uint16_t UdpSocket::GetPeerPort() const
     sockaddr_storage addr;
     socklen_t        len = sizeof(sockaddr_storage);
 
-    ASSERT(mIsConnected);
+    VerifyOrDie(mIsConnected);
 
-    ASSERT(getpeername(mNetCtx.fd, reinterpret_cast<sockaddr *>(&addr), &len) == 0);
+    VerifyOrDie(getpeername(mNetCtx.fd, reinterpret_cast<sockaddr *>(&addr), &len) == 0);
     return GetSockPort(addr);
 }
 
@@ -204,13 +203,11 @@ Address UdpSocket::GetPeerAddr() const
 {
     sockaddr_storage addr;
     socklen_t        len = sizeof(sockaddr_storage);
+    Address          ret;
 
-    ASSERT(mIsConnected);
-
-    ASSERT(getpeername(mNetCtx.fd, reinterpret_cast<sockaddr *>(&addr), &len) == 0);
-
-    Address ret;
-    ASSERT(ret.Set(addr) == Error::kNone);
+    VerifyOrDie(mIsConnected);
+    VerifyOrDie(getpeername(mNetCtx.fd, reinterpret_cast<sockaddr *>(&addr), &len) == 0);
+    SuccessOrDie(ret.Set(addr));
     return ret;
 }
 
@@ -222,16 +219,16 @@ void UdpSocket::Reset()
 
 int UdpSocket::Send(const uint8_t *aBuf, size_t aLen)
 {
-    ASSERT(mNetCtx.fd != -1);
-    ASSERT(mIsConnected);
+    VerifyOrDie(mNetCtx.fd != -1);
+    VerifyOrDie(mIsConnected);
 
     return mbedtls_net_send(&mNetCtx, aBuf, aLen);
 }
 
 int UdpSocket::Receive(uint8_t *aBuf, size_t aMaxLen)
 {
-    ASSERT(mNetCtx.fd != -1);
-    ASSERT(mIsConnected);
+    VerifyOrDie(mNetCtx.fd != -1);
+    VerifyOrDie(mIsConnected);
 
     return mbedtls_net_recv(&mNetCtx, aBuf, aMaxLen);
 }

--- a/src/library/socket_test.cpp
+++ b/src/library/socket_test.cpp
@@ -94,7 +94,7 @@ MockSocket::MockSocket(MockSocket &&aOther)
 
 int MockSocket::Send(const uint8_t *aBuf, size_t aLen)
 {
-    ASSERT(IsConnected());
+    VerifyOrDie(IsConnected());
 
     auto &peerRecvBuf = mPeerSocket->mRecvBuf;
 
@@ -118,7 +118,7 @@ int MockSocket::Receive(uint8_t *aBuf, size_t aMaxLen)
 
 int MockSocket::Send(const ByteArray &aBuf)
 {
-    ASSERT(!aBuf.empty());
+    VerifyOrDie(!aBuf.empty());
     return Send(aBuf.data(), aBuf.size());
 }
 

--- a/src/library/timer.hpp
+++ b/src/library/timer.hpp
@@ -54,7 +54,7 @@ public:
     {
         int flags = mIsSingle ? 0 : EV_PERSIST;
 
-        ASSERT(event_assign(&mTimerEvent, aEventBase, -1, flags, HandleEvent, this) == 0);
+        VerifyOrDie(event_assign(&mTimerEvent, aEventBase, -1, flags, HandleEvent, this) == 0);
     }
 
     ~Timer() { Stop(); }
@@ -74,7 +74,7 @@ public:
         tv.tv_sec  = delay.count() / 1000000;
         tv.tv_usec = delay.count() % 1000000;
 
-        ASSERT(event_add(&mTimerEvent, &tv) == 0);
+        VerifyOrDie(event_add(&mTimerEvent, &tv) == 0);
         mFireTime = aFireTime;
         mEnabled  = true;
     }

--- a/src/library/tlv.cpp
+++ b/src/library/tlv.cpp
@@ -361,19 +361,19 @@ uint16_t Tlv::GetTotalLength() const
 
 int8_t Tlv::GetValueAsInt8() const
 {
-    ASSERT(mValue.size() >= sizeof(int8_t));
+    VerifyOrDie(mValue.size() >= sizeof(int8_t));
     return static_cast<int8_t>(mValue[0]);
 }
 
 uint16_t Tlv::GetValueAsUint8() const
 {
-    ASSERT(mValue.size() >= sizeof(uint8_t));
+    VerifyOrDie(mValue.size() >= sizeof(uint8_t));
     return utils::Decode<uint8_t>(mValue);
 }
 
 uint16_t Tlv::GetValueAsUint16() const
 {
-    ASSERT(mValue.size() >= sizeof(uint16_t));
+    VerifyOrDie(mValue.size() >= sizeof(uint16_t));
     return utils::Decode<uint16_t>(mValue);
 }
 
@@ -400,7 +400,7 @@ Error GetTlvSet(TlvSet &aTlvSet, const ByteArray &aBuf, Scope aScope)
     {
         auto tlv = tlv::Tlv::Deserialize(error, offset, aBuf, aScope);
         SuccessOrExit(error);
-        ASSERT(tlv != nullptr);
+        VerifyOrDie(tlv != nullptr);
 
         if (tlv->IsValid())
         {

--- a/src/library/token_manager.cpp
+++ b/src/library/token_manager.cpp
@@ -165,7 +165,7 @@ void TokenManager::SendTokenRequest(Commissioner::Handler<ByteArray> aHandler)
         coap::ContentFormat contentFormat;
 
         SuccessOrExit(error = aError);
-        ASSERT(aResponse != nullptr);
+        VerifyOrDie(aResponse != nullptr);
 
         VerifyOrExit(aResponse->GetCode() == coap::Code::kChanged, error = Error::kFailed);
         VerifyOrExit(aResponse->GetContentFormat(contentFormat) == Error::kNone, error = Error::kBadFormat);

--- a/src/library/udp_proxy.cpp
+++ b/src/library/udp_proxy.cpp
@@ -52,7 +52,7 @@ Error ProxyEndpoint::Send(const ByteArray &aRequest, MessageSubType aSubType)
 
     (void)aSubType;
 
-    ASSERT(GetPeerAddr().IsValid() && GetPeerAddr().IsIpv6());
+    VerifyOrDie(GetPeerAddr().IsValid() && GetPeerAddr().IsIpv6());
 
     VerifyOrExit(mBrClient.IsConnected(), error = Error::kInvalidState);
 
@@ -76,7 +76,7 @@ void ProxyClient::SendRequest(const coap::Request & aRequest,
                               const Address &       aPeerAddr,
                               uint16_t              aPeerPort)
 {
-    ASSERT(aPeerAddr.IsValid() && aPeerAddr.IsIpv6());
+    VerifyOrDie(aPeerAddr.IsValid() && aPeerAddr.IsIpv6());
     mEndpoint.SetPeerAddr(aPeerAddr);
     mEndpoint.SetPeerPort(aPeerPort);
 


### PR DESCRIPTION
This PR renames macro `ASSSERT` to `VerifyOrDie`.
See https://github.com/openthread/ot-commissioner/pull/84#discussion_r415919644 for backgrounds.