### PR TITLE
[joiner] validate joiner PSKd

### DIFF
--- a/include/commissioner/defines.hpp
+++ b/include/commissioner/defines.hpp
@@ -63,6 +63,16 @@ static constexpr size_t kMinCommissionerPassphraseLength = 6;
 static constexpr size_t kMaxCommissionerPassPhraseLength = 255;
 
 /**
+ * The minimum joiner passphrase length.
+ */
+static constexpr size_t kMinJoinerPassphraseLength = 6;
+
+/**
+ * The maximum joiner passphrase length.
+ */
+static constexpr size_t kMaxJoinerPassphraseLength = 32;
+
+/**
  * The maximum PSKc length.
  */
 static constexpr size_t kMaxPSKcLength = 16;

--- a/include/commissioner/defines.hpp
+++ b/include/commissioner/defines.hpp
@@ -53,24 +53,24 @@ namespace commissioner {
  */
 
 /**
- * The minimum commissioner passphrase length.
+ * The minimum Commissioner Credential length.
  */
-static constexpr size_t kMinCommissionerPassphraseLength = 6;
+static constexpr size_t kMinCommissionerCredentialLength = 6;
 
 /**
- * The maximum commissioner passphrase length.
+ * The maximum Commissioner Credential length.
  */
-static constexpr size_t kMaxCommissionerPassPhraseLength = 255;
+static constexpr size_t kMaxCommissionerCredentialLength = 255;
 
 /**
- * The minimum joiner passphrase length.
+ * The minimum Joining Device Credential length.
  */
-static constexpr size_t kMinJoinerPassphraseLength = 6;
+static constexpr size_t kMinJoinerDeviceCredentialLength = 6;
 
 /**
- * The maximum joiner passphrase length.
+ * The maximum Joining Device Credential length.
  */
-static constexpr size_t kMaxJoinerPassphraseLength = 32;
+static constexpr size_t kMaxJoinerDeviceCredentialLength = 32;
 
 /**
  * The maximum PSKc length.

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -74,6 +74,8 @@ if (OT_COMM_TEST)
 
     target_sources(commissioner-app-test
         PRIVATE
+            commissioner_app.hpp
+            commissioner_app_test.cpp
             json.hpp
             json_test.cpp
     )

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -234,6 +234,8 @@ Error CommissionerApp::EnableJoiner(JoinerType         aType,
     commDataset.mPresentFlags &= ~CommissionerDataset::kBorderAgentLocatorBit;
     auto &steeringData = GetSteeringData(commDataset, aType);
 
+    SuccessOrExit(error = ValidatePSKd(aPSKd));
+
     VerifyOrExit(IsActive(), error = Error::kInvalidState);
 
     VerifyOrExit(mJoiners.count({aType, joinerId}) == 0, error = Error::kAlready);
@@ -291,6 +293,7 @@ Error CommissionerApp::EnableAllJoiners(JoinerType aType, const std::string &aPS
     commDataset.mPresentFlags &= ~CommissionerDataset::kBorderAgentLocatorBit;
     auto &steeringData = GetSteeringData(commDataset, aType);
 
+    SuccessOrExit(error = ValidatePSKd(aPSKd));
     VerifyOrExit(IsActive(), error = Error::kInvalidState);
 
     // Set steering data to all 1 to enable all joiners.
@@ -1307,6 +1310,24 @@ void CommissionerApp::OnDatasetChanged()
             }
         },
         0xFFFF);
+}
+
+Error CommissionerApp::ValidatePSKd(const std::string &aPSKd)
+{
+    Error error = Error::kInvalidArgs;
+
+    VerifyOrExit(aPSKd.size() >= kMinJoinerPassphraseLength && aPSKd.size() <= kMaxJoinerPassphraseLength);
+
+    for (auto c : aPSKd)
+    {
+        VerifyOrExit(isdigit(c) || isupper(c));
+        VerifyOrExit(c != 'I' && c != 'O' && c != 'Q' && c != 'Z');
+    }
+
+    error = Error::kNone;
+
+exit:
+    return error;
 }
 
 const JoinerInfo *CommissionerApp::GetJoinerInfo(JoinerType aType, const ByteArray &aJoinerId)

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -1316,7 +1316,7 @@ Error CommissionerApp::ValidatePSKd(const std::string &aPSKd)
 {
     Error error = Error::kInvalidArgs;
 
-    VerifyOrExit(aPSKd.size() >= kMinJoinerPassphraseLength && aPSKd.size() <= kMaxJoinerPassphraseLength);
+    VerifyOrExit(aPSKd.size() >= kMinJoinerDeviceCredentialLength && aPSKd.size() <= kMaxJoinerDeviceCredentialLength);
 
     for (auto c : aPSKd)
     {

--- a/src/app/commissioner_app.hpp
+++ b/src/app/commissioner_app.hpp
@@ -278,6 +278,8 @@ private:
     static void MergeDataset(BbrDataset &aDst, const BbrDataset &aSrc);
     static void MergeDataset(CommissionerDataset &aDst, const CommissionerDataset &aSrc);
 
+    static Error ValidatePSKd(const std::string &aPSKd);
+
     const JoinerInfo *GetJoinerInfo(JoinerType aType, const ByteArray &aJoinerId);
 
     std::shared_ptr<Commissioner> mCommissioner;

--- a/src/app/commissioner_app_test.cpp
+++ b/src/app/commissioner_app_test.cpp
@@ -77,9 +77,6 @@ TEST_CASE("pskd-validation", "[pskd]")
         // Includes capital 'Z' at the end.
         REQUIRE(commApp->EnableJoiner(JoinerType::kMeshCoP, eui64, "22222Z") == Error::kInvalidArgs);
 
-        // Includes lower cases.
-        REQUIRE(commApp->EnableJoiner(JoinerType::kMeshCoP, eui64, "abcedf") == Error::kInvalidArgs);
-
         // Includes lowercase alphanumeric characters.
         REQUIRE(commApp->EnableJoiner(JoinerType::kMeshCoP, eui64, "abcedf") == Error::kInvalidArgs);
 

--- a/src/app/commissioner_app_test.cpp
+++ b/src/app/commissioner_app_test.cpp
@@ -1,0 +1,98 @@
+/*
+ *    Copyright (c) 2020, The OpenThread Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file defines test cases of CommissionerApp.
+ *
+ */
+
+#include <catch2/catch.hpp>
+
+#include "app/commissioner_app.hpp"
+#include "common/utils.hpp"
+
+namespace ot {
+
+namespace commissioner {
+
+TEST_CASE("pskd-validation", "[pskd]")
+{
+    Config config;
+    config.mEnableCcm = false;
+    config.mPSKc = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
+
+    auto commApp = CommissionerApp::Create(config);
+    REQUIRE(commApp != nullptr);
+
+    constexpr uint64_t eui64 = 0x0011223344556677;
+
+    SECTION("A PSKd shorter than 6 characters should be rejected")
+    {
+        REQUIRE(commApp->EnableJoiner(JoinerType::kMeshCoP, eui64, "00001") == Error::kInvalidArgs);
+    }
+
+    SECTION("A PSkd longer than 32 characters should be rejected")
+    {
+        REQUIRE(commApp->EnableJoiner(JoinerType::kMeshCoP, eui64, "000000000000000000000000000000001") ==
+                Error::kInvalidArgs);
+    }
+
+    SECTION("A PSKd includes invalid characters should be rejected")
+    {
+        // Includes capital 'O' at the end.
+        REQUIRE(commApp->EnableJoiner(JoinerType::kMeshCoP, eui64, "00000O") == Error::kInvalidArgs);
+
+        // Includes capital 'I' at the end.
+        REQUIRE(commApp->EnableJoiner(JoinerType::kMeshCoP, eui64, "11111I") == Error::kInvalidArgs);
+
+        // Includes capital 'Q' at the end.
+        REQUIRE(commApp->EnableJoiner(JoinerType::kMeshCoP, eui64, "99999Q") == Error::kInvalidArgs);
+
+        // Includes capital 'Z' at the end.
+        REQUIRE(commApp->EnableJoiner(JoinerType::kMeshCoP, eui64, "22222Z") == Error::kInvalidArgs);
+
+        // Includes lower cases.
+        REQUIRE(commApp->EnableJoiner(JoinerType::kMeshCoP, eui64, "abcedf") == Error::kInvalidArgs);
+
+        // Includes lowercase alphanumeric characters.
+        REQUIRE(commApp->EnableJoiner(JoinerType::kMeshCoP, eui64, "abcedf") == Error::kInvalidArgs);
+
+        // Includes non-alphanumeric characters.
+        REQUIRE(commApp->EnableJoiner(JoinerType::kMeshCoP, eui64, "+-#$%@") == Error::kInvalidArgs);
+    }
+
+    SECTION("A compliant PSKd should be accepted and kInvalidState error is expected")
+    {
+        REQUIRE(commApp->EnableJoiner(JoinerType::kMeshCoP, eui64, "PSKD01") == Error::kInvalidState);
+    }
+}
+
+} // namespace commissioner
+
+} // namespace ot

--- a/src/app/commissioner_app_test.cpp
+++ b/src/app/commissioner_app_test.cpp
@@ -63,7 +63,7 @@ TEST_CASE("pskd-validation", "[pskd]")
                 Error::kInvalidArgs);
     }
 
-    SECTION("A PSKd includes invalid characters should be rejected")
+    SECTION("A PSKd including invalid characters should be rejected")
     {
         // Includes capital 'O' at the end.
         REQUIRE(commApp->EnableJoiner(JoinerType::kMeshCoP, eui64, "00000O") == Error::kInvalidArgs);

--- a/src/app/commissioner_app_test.cpp
+++ b/src/app/commissioner_app_test.cpp
@@ -57,7 +57,7 @@ TEST_CASE("pskd-validation", "[pskd]")
         REQUIRE(commApp->EnableJoiner(JoinerType::kMeshCoP, eui64, "00001") == Error::kInvalidArgs);
     }
 
-    SECTION("A PSkd longer than 32 characters should be rejected")
+    SECTION("A PSKd longer than 32 characters should be rejected")
     {
         REQUIRE(commApp->EnableJoiner(JoinerType::kMeshCoP, eui64, "000000000000000000000000000000001") ==
                 Error::kInvalidArgs);

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -55,8 +55,8 @@ Error Commissioner::GeneratePSKc(ByteArray &        aPSKc,
     const std::string saltPrefix = "Thread";
     ByteArray         salt;
 
-    VerifyOrExit((aPassphrase.size() >= kMinCommissionerPassphraseLength) &&
-                     (aPassphrase.size() <= kMaxCommissionerPassPhraseLength),
+    VerifyOrExit((aPassphrase.size() >= kMinCommissionerCredentialLength) &&
+                     (aPassphrase.size() <= kMaxCommissionerCredentialLength),
                  error = Error::kInvalidArgs);
     VerifyOrExit(aNetworkName.size() <= kMaxNetworkNameLength, error = Error::kInvalidArgs);
     VerifyOrExit(aExtendedPanId.size() == kExtendedPanIdLength, error = Error::kInvalidArgs);

--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -61,7 +61,7 @@ readonly NON_CCM_CONFIG=${TEST_ROOT_DIR}/../../src/app/etc/commissioner/non-ccm-
 
 readonly JOINER_NODE_ID=2
 readonly JOINER_EUI64=0x18b4300000000002
-readonly JOINER_PASSPHRASE=abcd
+readonly JOINER_PASSPHRASE=ABCDEF
 
 ## Thread network parameters
 readonly NETWORK_NAME=openthread-test

--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -61,7 +61,7 @@ readonly NON_CCM_CONFIG=${TEST_ROOT_DIR}/../../src/app/etc/commissioner/non-ccm-
 
 readonly JOINER_NODE_ID=2
 readonly JOINER_EUI64=0x18b4300000000002
-readonly JOINER_PASSPHRASE=ABCDEF
+readonly JOINER_CREDENTIAL=ABCDEF
 
 ## Thread network parameters
 readonly NETWORK_NAME=openthread-test
@@ -175,12 +175,12 @@ start_joiner() {
     local joiner_type=$1
     local joiner_binary=""
     local joining_cmd=""
-    local joiner_passphrase=""
+    local joiner_credential=""
 
     if [ "${joiner_type}" = "meshcop" ]; then
         joiner_binary=${NON_CCM_CLI}
         joining_cmd="start"
-        joiner_passphrase=${JOINER_PASSPHRASE}
+        joiner_credential=${JOINER_CREDENTIAL}
     elif [ "${joiner_type}" = "ae" ]; then
         joiner_binary=${CCM_CLI}
         joining_cmd="startae"
@@ -204,7 +204,7 @@ expect "Done"
 send "channel ${CHANNEL}\r\n"
 expect "Done"
 
-send "joiner ${joining_cmd} ${joiner_passphrase}\r\n"
+send "joiner ${joining_cmd} ${joiner_credential}\r\n"
 set timeout 20
 expect {
     "Join success" {

--- a/tests/integration/test_joining.sh
+++ b/tests/integration/test_joining.sh
@@ -40,7 +40,7 @@ test_joining() {
     send_command_to_commissioner "active"
 
     ## enable all MeshCoP joiners
-    send_command_to_commissioner "joiner enable meshcop ${JOINER_EUI64} ${JOINER_PASSPHRASE}"
+    send_command_to_commissioner "joiner enable meshcop ${JOINER_EUI64} ${JOINER_CREDENTIAL}"
 
     start_joiner "meshcop"
 


### PR DESCRIPTION
This PR addes validation of joiner PSKd to force it conform to the Thread Spec. It also changes PSKd from `ByteArray` to `std::string` since PSKd can be only digits and uppercase chars.

- [X] validation and unittests.
- [X] rebase on PR https://github.com/openthread/ot-commissioner/pull/87.

related comments: https://github.com/openthread/ot-commissioner/pull/72#discussion_r409654671