### PR TITLE
[code] remove throws

### DIFF
--- a/src/app/json.cpp
+++ b/src/app/json.cpp
@@ -440,10 +440,7 @@ static void from_json(const Json &aJson, ActiveOperationalDataset &aDataset)
     if (aJson.contains("MeshLocalPrefix"))
     {
         std::string prefix = aJson["MeshLocalPrefix"];
-        if (Ipv6PrefixFromString(aDataset.mMeshLocalPrefix, prefix) != Error::kNone)
-        {
-            throw std::exception();
-        }
+        SuccessOrThrow(Ipv6PrefixFromString(aDataset.mMeshLocalPrefix, prefix));
         aDataset.mPresentFlags |= ActiveOperationalDataset::kMeshLocalPrefixBit;
     };
 

--- a/src/library/commissioner_safe.cpp
+++ b/src/library/commissioner_safe.cpp
@@ -60,9 +60,9 @@ exit:
     return error;
 }
 
-Error CommissionerSafe::Init(CommissionerHandler & aHandler, const Config &aConfig)
+Error CommissionerSafe::Init(CommissionerHandler &aHandler, const Config &aConfig)
 {
-    Error error = Error::kFailed;
+    Error                             error = Error::kFailed;
     std::shared_ptr<CommissionerImpl> impl;
 
     VerifyOrExit(mEventBase.Get() != nullptr, error = Error::kOutOfMemory);

--- a/src/library/commissioner_safe.cpp
+++ b/src/library/commissioner_safe.cpp
@@ -563,10 +563,7 @@ CommissionerSafe::AsyncRequest CommissionerSafe::PopAsyncRequest()
 CommissionerSafe::EventBaseHolder::EventBaseHolder()
     : mEventBase(event_base_new())
 {
-    if (mEventBase == nullptr)
-    {
-        throw std::bad_alloc();
-    }
+    VerifyOrDie(mEventBase != nullptr);
 }
 
 CommissionerSafe::EventBaseHolder::~EventBaseHolder()

--- a/src/library/commissioner_safe.hpp
+++ b/src/library/commissioner_safe.hpp
@@ -71,7 +71,7 @@ public:
     CommissionerSafe(const CommissionerSafe &aCommissioner) = delete;
     const CommissionerSafe &operator=(const CommissionerSafe &aCommissioner) = delete;
 
-    Error Init(CommissionerHandler & aHandler, const Config &aConfig);
+    Error Init(CommissionerHandler &aHandler, const Config &aConfig);
 
     ~CommissionerSafe() override;
 

--- a/src/library/commissioner_safe.hpp
+++ b/src/library/commissioner_safe.hpp
@@ -66,12 +66,12 @@ namespace commissioner {
 class CommissionerSafe : public Commissioner
 {
 public:
-    explicit CommissionerSafe(CommissionerHandler &aHandler);
+    CommissionerSafe() = default;
 
     CommissionerSafe(const CommissionerSafe &aCommissioner) = delete;
     const CommissionerSafe &operator=(const CommissionerSafe &aCommissioner) = delete;
 
-    Error Init(const Config &aConfig);
+    Error Init(CommissionerHandler & aHandler, const Config &aConfig);
 
     ~CommissionerSafe() override;
 
@@ -210,7 +210,7 @@ private:
     // after any other members.
     EventBaseHolder mEventBase;
 
-    CommissionerImpl mImpl;
+    std::shared_ptr<CommissionerImpl> mImpl;
 
     // The event used to synchronize between the mEventThread
     // and user thread. It will be activated by user calls


### PR DESCRIPTION
This PR removes all `throws` but keep only `SuccessOrThrow` in `json.cpp`, since the json library uses `exception` exclusively.

By searching `throw` in `src`, it gives only one match in [json.cpp](https://github.com/openthread/ot-commissioner/blob/560e6025d30390999ead96f1f3deda78bf5e5ee1/src/app/json.cpp#L83) (called by `SuccessOrThrow`).

https://github.com/openthread/ot-commissioner/blob/560e6025d30390999ead96f1f3deda78bf5e5ee1/src/app/json.cpp#L78-L85