### PR TITLE
[tests] fix integration tests with OTBR 0.2

### DIFF
--- a/tests/integration/bootstrap.sh
+++ b/tests/integration/bootstrap.sh
@@ -47,9 +47,8 @@ setup_otbr() {
     ./script/bootstrap
     ./script/setup
 
-    ## Stop otbr-agent and wpantund
+    ## Stop otbr-agent
     sudo service otbr-agent stop
-    sudo service wpantund stop
 
     cd -
 }
@@ -63,35 +62,16 @@ setup_openthread() {
     git clean -xfd
     ./bootstrap
 
-    make -f examples/Makefile-simulation \
-        COAP=1 \
-        COAPS=1 \
-        ECDSA=1 \
-        BORDER_ROUTER=1 \
-        SERVICE=1 \
-        DHCP6_CLIENT=1 \
-        DHCP6_SERVER=1 \
-        JOINER=1 \
-        COMMISSIONER=1 \
-        MAC_FILTER=1 \
-        REFERENCE_DEVICE=1 \
-        THREAD_VERSION=1.2 \
-        CSL_RECEIVER=1 \
-        CSL_TRANSMITTER=1 \
-        LINK_PROBE=1 \
-        DUA=1 \
-        MLR=1 \
-        BBR=1 \
-        MTD=0 \
-        BORDER_AGENT=1 \
-        UDP_FORWARD=1 \
-        DEBUG=1
+    local ot_build_dir=$(VIRTUAL_TIME=0 ./script/test clean build | grep 'Build files have been written to: ' | cut -d: -f2 | tr -d ' ')
 
-    cp output/x86_64-unknown-linux-gnu/bin/ot-cli-ftd "${NON_CCM_CLI}"
-    cp output/x86_64-unknown-linux-gnu/bin/ot-ncp-ftd "${NON_CCM_NCP}"
+    cp ${ot_build_dir}/examples/apps/ncp/ot-rcp "${NON_CCM_RCP}"
+    cp ${ot_build_dir}/examples/apps/cli/ot-cli-ftd "${NON_CCM_CLI}"
 
-    executable_or_die "${NON_CCM_CLI}"
-    executable_or_die "${NON_CCM_NCP}"
+    rm -rf build
+
+    cmake -DOT_PLATFORM=posix -DOT_DAEMON=ON -S . -B build
+    cmake --build build
+    cp build/src/posix/ot-ctl "${OT_CTL}"
 
     cd -
 }

--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -43,11 +43,10 @@ readonly OPENTHREAD_BRANCH=master
 readonly OPENTHREAD=${RUNTIME_DIR}/openthread
 
 readonly NON_CCM_CLI=${RUNTIME_DIR}/ot-cli-ftd-non-ccm
-readonly NON_CCM_NCP=${RUNTIME_DIR}/ot-ncp-ftd-non-ccm
+readonly NON_CCM_RCP=${RUNTIME_DIR}/ot-rcp-non-ccm
+readonly OT_CTL=${RUNTIME_DIR}/ot-ctl
 
-readonly WPANTUND_CONF=/etc/wpantund.conf
-
-readonly WPANTUND_LOG=${RUNTIME_DIR}/wpantund.log
+readonly OTBR_SETTINGS_PATH=/var/lib/thread
 readonly OTBR_LOG=${RUNTIME_DIR}/otbr.log
 
 ## '/usr/local' is the by default installing directory.
@@ -80,36 +79,16 @@ executable_or_die() {
   [ -x "$1" ] || die "Missing executable: $1"
 }
 
-## Start otbr agent.
-## Args: $1: the NCP firmware.
-##       $2: the backbone interface.
 start_otbr() {
     set -e
-    sudo killall -9 wpantund || true
     sudo killall -9 otbr-agent || true
-
     sleep 1
-    pidof wpantund && die "killing wpantund failed"
     pidof otbr-agent && die "killing otbr-agent failed"
 
-    local ncp=$1
+    sudo rm -rf ${OTBR_SETTINGS_PATH}
+    sudo otbr-agent -I wpan0 -d 7 -v "${NON_CCM_RCP}" 1 > "${OTBR_LOG}" 2>&1 &
 
-    sudo chmod 777 ${WPANTUND_CONF}
-    sudo echo "Config:NCP:SocketPath \"system:${ncp} 1\"" > ${WPANTUND_CONF}
-
-    ## Run wpantund in different directory, because it creates
-    ## intermediate sub-directory leading to permission issue when
-    ## creating flash file of CLI nodes which are started without
-    ## root privilege.
-    mkdir -p wpantund-tmp && cd wpantund-tmp
-    sudo wpantund -c ${WPANTUND_CONF} -d 7 > "${WPANTUND_LOG}" 2>&1 &
-    cd -
-
-    sleep 1
-
-    sudo otbr-agent -I wpan0 -d 7 -v > "${OTBR_LOG}" 2>&1 &
-
-    sleep 1
+    sleep 10
 }
 
 ## Start commissioner daemon.
@@ -221,15 +200,13 @@ form_network() {
     set -e
     local pskc=$1
 
-    sudo wpanctl leave
+    sudo "${OT_CTL}" channel "${CHANNEL}"
+    sudo "${OT_CTL}" panid "${PANID}"
+    sudo "${OT_CTL}" extpanid "${XPANID}"
+    sudo "${OT_CTL}" pskc "${pskc}"
+    sudo "${OT_CTL}" masterkey "${MASTERKEY}"
+    sudo "${OT_CTL}" ifconfig up
+    sudo "${OT_CTL}" thread start
 
-    sudo wpanctl -I wpan0 setprop Daemon:AutoAssociateAfterReset false
-    sudo wpanctl -I wpan0 setprop Network:PSKc --data ${pskc}
-    sudo wpanctl -I wpan0 setprop Network:Key --data ${MASTERKEY}
-    sudo wpanctl -I wpan0 setprop Network:XPANID ${XPANID}
-    sudo wpanctl -I wpan0 setprop Network:PANID ${PANID}
-    sudo wpanctl -I wpan0 form ${NETWORK_NAME} -c ${CHANNEL}
-
-    echo "======================================"
-    sudo wpanctl status
+    sleep 3
 }

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -54,6 +54,8 @@ run_test_case() {
 
     echo "====== test case: [ ${test_case} ] ======"
 
+    ## Clean intermediate states.
+    sudo rm -rf tmp
     rm -rf "${COMMISSIONER_LOG}"
 
     ## we cannot declare output with `local`,
@@ -71,10 +73,6 @@ run_test_case() {
         echo "------ test output begin ------"
         echo "${output}"
         echo "------ test output end ------"
-
-        echo "------ wpantund log begin ------"
-        cat "${WPANTUND_LOG}"
-        echo "------ wpantund log end ------"
 
         echo "------ otbr log begin ------"
         cat "${OTBR_LOG}"

--- a/tests/integration/test_announce_begin.sh
+++ b/tests/integration/test_announce_begin.sh
@@ -32,7 +32,7 @@
 test_announce_begin() {
     set -e
 
-    start_otbr "${NON_CCM_NCP}" "eth0"
+    start_otbr
     form_network "${PSKC}"
 
     start_commissioner "${NON_CCM_CONFIG}"

--- a/tests/integration/test_cli.sh
+++ b/tests/integration/test_cli.sh
@@ -33,7 +33,7 @@ test_network_sync()
 {
     set -e
 
-    start_otbr "${NON_CCM_NCP}" "eth0"
+    start_otbr
     form_network "${PSKC}"
 
     start_commissioner "${NON_CCM_CONFIG}"
@@ -46,7 +46,7 @@ test_get_commissioner_dataset()
 {
     set -e
 
-    start_otbr "${NON_CCM_NCP}" "eth0"
+    start_otbr
     form_network "${PSKC}"
 
     start_commissioner "${NON_CCM_CONFIG}"

--- a/tests/integration/test_discover.sh
+++ b/tests/integration/test_discover.sh
@@ -32,7 +32,7 @@
 test_discover() {
     set -e
 
-    start_otbr "${NON_CCM_NCP}" "eth0"
+    start_otbr
     form_network "${PSKC}"
 
     start_commissioner "${NON_CCM_CONFIG}"

--- a/tests/integration/test_energy_scan.sh
+++ b/tests/integration/test_energy_scan.sh
@@ -32,7 +32,7 @@
 test_energy_scan() {
     set -e
 
-    start_otbr "${NON_CCM_NCP}" "eth0"
+    start_otbr
     form_network "${PSKC}"
 
     start_commissioner "${NON_CCM_CONFIG}"

--- a/tests/integration/test_joining.sh
+++ b/tests/integration/test_joining.sh
@@ -32,7 +32,7 @@
 test_joining() {
     set -e
 
-    start_otbr "${NON_CCM_NCP}" "eth0"
+    start_otbr
     form_network "${PSKC}"
 
     start_commissioner "${NON_CCM_CONFIG}"
@@ -48,7 +48,7 @@ test_joining() {
 }
 
 test_joining_fail() {
-    start_otbr "${NON_CCM_NCP}" "eth0"
+    start_otbr
     form_network "${PSKC}"
 
     start_commissioner "${NON_CCM_CONFIG}"

--- a/tests/integration/test_operational_dataset.sh
+++ b/tests/integration/test_operational_dataset.sh
@@ -32,7 +32,7 @@
 test_active_dataset_set_network_name() {
     set -e
 
-    start_otbr "${NON_CCM_NCP}" "eth0"
+    start_otbr
     form_network "${PSKC}"
 
     start_commissioner "${NON_CCM_CONFIG}"
@@ -48,7 +48,7 @@ test_active_dataset_set_network_name() {
 test_pending_dataset_set_channel() {
     set -e
 
-    start_otbr "${NON_CCM_NCP}" "eth0"
+    start_otbr
     form_network "${PSKC}"
 
     start_commissioner "${NON_CCM_CONFIG}"

--- a/tests/integration/test_pan_id_query.sh
+++ b/tests/integration/test_pan_id_query.sh
@@ -32,7 +32,7 @@
 test_pan_id_query() {
     set -e
 
-    start_otbr "${NON_CCM_NCP}" "eth0"
+    start_otbr
     form_network "${PSKC}"
 
     start_commissioner "${NON_CCM_CONFIG}"

--- a/tests/integration/test_petition.sh
+++ b/tests/integration/test_petition.sh
@@ -32,7 +32,7 @@
 test_petition() {
     set -e
 
-    start_otbr "${NON_CCM_NCP}" "eth0"
+    start_otbr
     form_network "${PSKC}"
 
     start_commissioner "${NON_CCM_CONFIG}"


### PR DESCRIPTION
This PR fixes integration tests with OTBR 0.2 which deprecated wpantund.