### PR TITLE
[socket] remove Socket::Reset() API

### DIFF
--- a/src/library/dtls.cpp
+++ b/src/library/dtls.cpp
@@ -329,7 +329,6 @@ void DtlsSession::Disconnect(Error aError)
     }
 
     // Reset to the initial state.
-    mSocket->Reset();
     Reset();
 
     LOG_DEBUG(LOG_REGION_DTLS, "session={} disconnected", static_cast<void *>(this));

--- a/src/library/socket.cpp
+++ b/src/library/socket.cpp
@@ -115,7 +115,8 @@ int UdpSocket::Connect(const std::string &aHost, uint16_t aPort)
 {
     auto portStr = std::to_string(aPort);
 
-    if (mNetCtx.fd >= 0) {
+    if (mNetCtx.fd >= 0)
+    {
         mbedtls_net_free(&mNetCtx);
     }
 
@@ -145,7 +146,8 @@ int UdpSocket::Bind(const std::string &aBindIp, uint16_t aPort)
 {
     auto portStr = std::to_string(aPort);
 
-    if (mNetCtx.fd >= 0) {
+    if (mNetCtx.fd >= 0)
+    {
         mbedtls_net_free(&mNetCtx);
     }
 

--- a/src/library/socket.cpp
+++ b/src/library/socket.cpp
@@ -115,10 +115,8 @@ int UdpSocket::Connect(const std::string &aHost, uint16_t aPort)
 {
     auto portStr = std::to_string(aPort);
 
-    if (mNetCtx.fd >= 0)
-    {
-        mbedtls_net_free(&mNetCtx);
-    }
+    // Free the fd if already opened.
+    mbedtls_net_free(&mNetCtx);
 
     // Connect
     int rval = mbedtls_net_connect(&mNetCtx, aHost.c_str(), portStr.c_str(), MBEDTLS_NET_PROTO_UDP);
@@ -146,10 +144,8 @@ int UdpSocket::Bind(const std::string &aBindIp, uint16_t aPort)
 {
     auto portStr = std::to_string(aPort);
 
-    if (mNetCtx.fd >= 0)
-    {
-        mbedtls_net_free(&mNetCtx);
-    }
+    // Free the fd if already opened.
+    mbedtls_net_free(&mNetCtx);
 
     // Bind
     int rval = mbedtls_net_bind(&mNetCtx, aBindIp.c_str(), portStr.c_str(), MBEDTLS_NET_PROTO_UDP);

--- a/src/library/socket.hpp
+++ b/src/library/socket.hpp
@@ -74,8 +74,6 @@ public:
 
     bool IsConnected() const { return mIsConnected; }
 
-    virtual void Reset();
-
     virtual int Send(const uint8_t *aBuf, size_t aLen) = 0;
 
     virtual int Receive(uint8_t *aBuf, size_t aMaxLen) = 0;
@@ -120,8 +118,6 @@ public:
     Address  GetLocalAddr() const override;
     uint16_t GetPeerPort() const override;
     Address  GetPeerAddr() const override;
-
-    void Reset() override;
 
     int Send(const uint8_t *aBuf, size_t aLen) override;
 


### PR DESCRIPTION
## Problem
The `DtlsSession` was trying to reset the `Socket` when disconnected but it shouldn't. Because the socket is not connected/bound by `DtlsSession`, so it should not be reset by `DtlsSession` as well.

## Solution
- removes resetting socket in `DtlsSession::Disconnect()` and remove `Socket::Reset()`.
- Frees socket fd when before connecting and binding to allow multiple calls to `Connect` and `Bind`.