### PR TITLE
[cmake] reset version to 0.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 
 cmake_minimum_required(VERSION 3.13.1)
-project(ot-commissioner VERSION 1.0.0)
+project(ot-commissioner VERSION 0.1.0)
 
 option(OT_COMM_ANDROID          "Build with Android NDK" OFF)
 option(OT_COMM_APP              "Build the CLI App" ON)


### PR DESCRIPTION
According to https://semver.org/, version `1.0.0` defines the stable public API. But we are currently changing the public API frequently and this situation may continue before we finishing building Commissioner Service with ot-commissioner.

This PR resets the version to `0.1.0` to indicates that the public API is not stable.
> Major version zero (0.y.z) is for initial development. Anything MAY change at any time. The public API SHOULD NOT be considered stable.
Version 1.0.0 defines the public API. The way in which the version number is incremented after this release is dependent on this public API and how it changes.