### PR TITLE
[ccm] add compile-time option to exclude CCM features

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,6 +46,7 @@ jobs:
                 -DCMAKE_BUILD_TYPE=Release        \
                 -DCMAKE_INSTALL_PREFIX=/usr/local \
                 -DOT_COMM_COVERAGE=ON             \
+                -DOT_COMM_CCM=OFF                 \
                 -S . -B build
           cmake --build build
           sudo cmake --install build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ project(ot-commissioner VERSION 1.0.0)
 
 option(OT_COMM_ANDROID          "Build with Android NDK" OFF)
 option(OT_COMM_APP              "Build the CLI App" ON)
+option(OT_COMM_CCM              "Build with Commercial Commissioning Mode" ON)
 option(OT_COMM_COVERAGE         "Enable coverage reporting" OFF)
 option(OT_COMM_TEST             "Build tests" ON)
 

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -77,8 +77,8 @@ target_sources(commissioner
 
 target_link_libraries(commissioner
     PRIVATE
-        cn-cbor::cn-cbor
-        cose
+        $<$<BOOL:${OT_COMM_CCM}>:cn-cbor::cn-cbor>
+        $<$<BOOL:${OT_COMM_CCM}>:cose>
         mdns
         mbedtls
         mbedx509
@@ -117,8 +117,8 @@ install(TARGETS commissioner
 ## disabled for them (intended).
 if (BUILD_SHARED_LIBS)
     install(FILES
-            $<TARGET_FILE:cn-cbor::cn-cbor>
-            $<TARGET_FILE:cose>
+            $<$<BOOL:${OT_COMM_CCM}>:$<TARGET_FILE:cn-cbor::cn-cbor>>
+            $<$<BOOL:${OT_COMM_CCM}>:$<TARGET_FILE:cose>>
             $<TARGET_FILE:mdns>
             $<TARGET_FILE:mbedtls>
             $<TARGET_FILE:mbedx509>
@@ -165,8 +165,8 @@ if (OT_COMM_TEST)
     target_link_libraries(commissioner-test
         PRIVATE
             Catch2::Catch2
-            cn-cbor::cn-cbor
-            cose
+            $<$<BOOL:${OT_COMM_CCM}>:cn-cbor::cn-cbor>
+            $<$<BOOL:${OT_COMM_CCM}>:cose>
             mdns
             mbedtls
             mbedx509

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -93,7 +93,7 @@ target_link_libraries(commissioner
 
 target_compile_definitions(commissioner
     PRIVATE
-        $<IF:$<BOOL:${OT_COMM_CCM}>, OT_COMM_CCM_ENABLE=1, OT_COMM_CCM_ENABLE=0>
+        $<IF:$<BOOL:${OT_COMM_CCM}>, OT_COMM_CONFIG_CCM_ENABLE=1, OT_COMM_CONFIG_CCM_ENABLE=0>
 )
 
 target_include_directories(commissioner
@@ -182,7 +182,7 @@ if (OT_COMM_TEST)
 
     target_compile_definitions(commissioner-test
         PRIVATE
-            $<IF:$<BOOL:${OT_COMM_CCM}>, OT_COMM_CCM_ENABLE=1, OT_COMM_CCM_ENABLE=0>
+            $<IF:$<BOOL:${OT_COMM_CCM}>, OT_COMM_CONFIG_CCM_ENABLE=1, OT_COMM_CONFIG_CCM_ENABLE=0>
     )
 
     target_include_directories(commissioner-test

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -90,6 +90,11 @@ target_link_libraries(commissioner
         commissioner-common
 )
 
+target_compile_definitions(commissioner
+    PRIVATE
+        $<IF:$<BOOL:${OT_COMM_CCM}>, OT_COMM_CCM_ENABLE=1, OT_COMM_CCM_ENABLE=0>
+)
+
 target_include_directories(commissioner
     PUBLIC
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
@@ -172,6 +177,11 @@ if (OT_COMM_TEST)
             commissioner
             $<$<BOOL:${OT_COMM_APP}>:commissioner-app>
             commissioner-common
+    )
+
+    target_compile_definitions(commissioner-test
+        PRIVATE
+            $<IF:$<BOOL:${OT_COMM_CCM}>, OT_COMM_CCM_ENABLE=1, OT_COMM_CCM_ENABLE=0>
     )
 
     target_include_directories(commissioner-test

--- a/src/library/cbor.cpp
+++ b/src/library/cbor.cpp
@@ -31,7 +31,7 @@
  *   This file implements CBOR.
  */
 
-#if OT_COMM_CCM_ENABLE
+#if OT_COMM_CONFIG_CCM_ENABLE
 
 #include "library/cbor.hpp"
 
@@ -185,4 +185,4 @@ Error CborMap::Get(int aKey, const char *&aStr, size_t &aLength) const
 
 } // namespace ot
 
-#endif // OT_COMM_CCM_ENABLE
+#endif // OT_COMM_CONFIG_CCM_ENABLE

--- a/src/library/cbor.cpp
+++ b/src/library/cbor.cpp
@@ -31,6 +31,8 @@
  *   This file implements CBOR.
  */
 
+#if OT_COMM_CCM_ENABLE
+
 #include "library/cbor.hpp"
 
 #include <assert.h>
@@ -162,3 +164,5 @@ Error CborMap::Get(int aKey, const char *&aStr, size_t &aLength) const
 } // namespace commissioner
 
 } // namespace ot
+
+#endif // OT_COMM_CCM_ENABLE

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -153,7 +153,7 @@ CommissionerImpl::CommissionerImpl(CommissionerHandler &aHandler, struct event_b
     , mProxyClient(mEventBase, mBrClient)
 #if OT_COMM_CONFIG_CCM_ENABLE
     , mTokenManager(mEventBase)
-#endif // OT_COMM_CONFIG_CCM_ENABLE
+#endif
     , mResourceDatasetChanged(uri::kMgmtDatasetChanged,
                               [this](const coap::Request &aRequest) { HandleDatasetChanged(aRequest); })
     , mResourcePanIdConflict(uri::kMgmtPanidConflict,
@@ -186,7 +186,7 @@ Error CommissionerImpl::Init(const Config &aConfig)
         // TODO(wgtdkp): create TokenManager only in CCM Mode.
         SuccessOrExit(error = mTokenManager.Init(mConfig));
     }
-#endif // OT_COMM_CONFIG_CCM_ENABLE
+#endif
 
 exit:
     return error;
@@ -355,7 +355,7 @@ void CommissionerImpl::AbortRequests()
     {
         mTokenManager.AbortRequests();
     }
-#endif // OT_COMM_CONFIG_CCM_ENABLE
+#endif
 }
 
 void CommissionerImpl::GetCommissionerDataset(Handler<CommissionerDataset> aHandler, uint16_t aDatasetFlags)
@@ -431,7 +431,7 @@ void CommissionerImpl::SetCommissionerDataset(ErrorHandler aHandler, const Commi
     {
         SuccessOrExit(error = SignRequest(request));
     }
-#endif // OT_COMM_CONFIG_CCM_ENABLE
+#endif
 
     mBrClient.SendRequest(request, onResponse);
 
@@ -578,7 +578,7 @@ void CommissionerImpl::GetActiveDataset(Handler<ActiveOperationalDataset> aHandl
     {
         SuccessOrExit(error = SignRequest(request));
     }
-#endif // OT_COMM_CONFIG_CCM_ENABLE
+#endif
 
     mBrClient.SendRequest(request, onResponse);
 
@@ -626,7 +626,7 @@ void CommissionerImpl::SetActiveDataset(ErrorHandler aHandler, const ActiveOpera
     {
         SuccessOrExit(error = SignRequest(request));
     }
-#endif // OT_COMM_CONFIG_CCM_ENABLE
+#endif
 
     mBrClient.SendRequest(request, onResponse);
 
@@ -681,7 +681,7 @@ void CommissionerImpl::GetPendingDataset(Handler<PendingOperationalDataset> aHan
     {
         SuccessOrExit(error = SignRequest(request));
     }
-#endif // OT_COMM_CONFIG_CCM_ENABLE
+#endif
 
     mBrClient.SendRequest(request, onResponse);
 
@@ -720,7 +720,7 @@ void CommissionerImpl::SetPendingDataset(ErrorHandler aHandler, const PendingOpe
     {
         SuccessOrExit(error = SignRequest(request));
     }
-#endif // OT_COMM_CONFIG_CCM_ENABLE
+#endif
 
     mBrClient.SendRequest(request, onResponse);
 
@@ -941,7 +941,7 @@ void CommissionerImpl::RegisterMulticastListener(Handler<uint8_t>               
     {
         SuccessOrExit(error = SignRequest(request));
     }
-#endif // OT_COMM_CONFIG_CCM_ENABLE
+#endif
 
     mProxyClient.SendRequest(request, onResponse, dstAddr, kDefaultMmPort);
 
@@ -997,7 +997,7 @@ void CommissionerImpl::AnnounceBegin(ErrorHandler       aHandler,
     {
         SuccessOrExit(error = SignRequest(request));
     }
-#endif // OT_COMM_CONFIG_CCM_ENABLE
+#endif
 
     mProxyClient.SendRequest(request, onResponse, dstAddr, kDefaultMmPort);
 
@@ -1049,7 +1049,7 @@ void CommissionerImpl::PanIdQuery(ErrorHandler       aHandler,
     {
         SuccessOrExit(error = SignRequest(request));
     }
-#endif // OT_COMM_CONFIG_CCM_ENABLE
+#endif
 
     mProxyClient.SendRequest(request, onResponse, dstAddr, kDefaultMmPort);
 
@@ -1105,7 +1105,7 @@ void CommissionerImpl::EnergyScan(ErrorHandler       aHandler,
     {
         SuccessOrExit(error = SignRequest(request));
     }
-#endif // OT_COMM_CONFIG_CCM_ENABLE
+#endif
 
     mProxyClient.SendRequest(request, onResponse, dstAddr, kDefaultMmPort);
 
@@ -1219,7 +1219,7 @@ void CommissionerImpl::SendPetition(PetitionHandler aHandler)
     {
         SuccessOrExit(error = SignRequest(request));
     }
-#endif // OT_COMM_CONFIG_CCM_ENABLE
+#endif
 
     mState = State::kPetitioning;
 
@@ -1271,7 +1271,7 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
     {
         SuccessOrExit(error = SignRequest(request));
     }
-#endif // OT_COMM_CONFIG_CCM_ENABLE
+#endif
 
     mKeepAliveTimer.Start(GetKeepAliveInterval());
 
@@ -1931,7 +1931,7 @@ void CommissionerImpl::SendProxyMessage(ErrorHandler aHandler, const std::string
     {
         SuccessOrExit(error = SignRequest(request));
     }
-#endif // OT_COMM_CONFIG_CCM_ENABLE
+#endif
 
     mProxyClient.SendRequest(request, onResponse, dstAddr, kDefaultMmPort);
 

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -42,6 +42,8 @@
 #include "library/openthread/sha256.hpp"
 #include "library/uri.hpp"
 
+#define CCM_NOT_IMPLEMENTED "CCM features not implemented"
+
 namespace ot {
 
 namespace commissioner {
@@ -211,7 +213,7 @@ Error CommissionerImpl::ValidateConfig(const Config &aConfig)
         tlv::Tlv domainNameTlv{tlv::Type::kDomainName, aConfig.mDomainName};
 
 #if !OT_COMM_CONFIG_CCM_ENABLE
-        ExitNow(error = ERROR_INVALID_ARGS("CCM teatures not supported"));
+        ExitNow(error = ERROR_INVALID_ARGS(CCM_NOT_IMPLEMENTED));
 #endif
 
         VerifyOrExit(!aConfig.mDomainName.empty(), error = ERROR_INVALID_ARGS("missing Domain Name for CCM network"));
@@ -480,7 +482,7 @@ exit:
 void CommissionerImpl::SetBbrDataset(ErrorHandler aHandler, const BbrDataset &aDataset)
 {
     (void)aDataset;
-    aHandler(ERROR_UNIMPLEMENTED("CCM features not implemented"));
+    aHandler(ERROR_UNIMPLEMENTED(CCM_NOT_IMPLEMENTED));
 }
 #endif // OT_COMM_CONFIG_CCM_ENABLE
 
@@ -534,7 +536,7 @@ exit:
 void CommissionerImpl::GetBbrDataset(Handler<BbrDataset> aHandler, uint16_t aDatasetFlags)
 {
     (void)aDatasetFlags;
-    aHandler(nullptr, ERROR_UNIMPLEMENTED("CCM features not implemented"));
+    aHandler(nullptr, ERROR_UNIMPLEMENTED(CCM_NOT_IMPLEMENTED));
 }
 #endif // OT_COMM_CONFIG_CCM_ENABLE
 
@@ -790,7 +792,7 @@ void CommissionerImpl::SetSecurePendingDataset(ErrorHandler                     
     (void)aPbbrAddr;
     (void)aMaxRetrievalTimer;
     (void)aDataset;
-    aHandler(ERROR_UNIMPLEMENTED("CCM features not implemented"));
+    aHandler(ERROR_UNIMPLEMENTED(CCM_NOT_IMPLEMENTED));
 }
 #endif // OT_COMM_CONFIG_CCM_ENABLE
 
@@ -800,7 +802,7 @@ void CommissionerImpl::CommandReenroll(ErrorHandler aHandler, const std::string 
     SendProxyMessage(aHandler, aDstAddr, uri::kMgmtReenroll);
 #else
     (void)aDstAddr;
-    aHandler(ERROR_UNIMPLEMENTED("CCM features not implemented"));
+    aHandler(ERROR_UNIMPLEMENTED(CCM_NOT_IMPLEMENTED));
 #endif
 }
 
@@ -810,7 +812,7 @@ void CommissionerImpl::CommandDomainReset(ErrorHandler aHandler, const std::stri
     SendProxyMessage(aHandler, aDstAddr, uri::kMgmtDomainReset);
 #else
     (void)aDstAddr;
-    aHandler(ERROR_UNIMPLEMENTED("CCM features not implemented"));
+    aHandler(ERROR_UNIMPLEMENTED(CCM_NOT_IMPLEMENTED));
 #endif
 }
 
@@ -877,7 +879,7 @@ void CommissionerImpl::CommandMigrate(ErrorHandler       aHandler,
 {
     (void)aDstAddr;
     (void)aDstNetworkName;
-    aHandler(ERROR_UNIMPLEMENTED("CCM features not implemented"));
+    aHandler(ERROR_UNIMPLEMENTED(CCM_NOT_IMPLEMENTED));
 }
 #endif // OT_COMM_CONFIG_CCM_ENABLE
 
@@ -1131,7 +1133,7 @@ void CommissionerImpl::RequestToken(Handler<ByteArray> aHandler, const std::stri
 {
     (void)aAddr;
     (void)aPort;
-    aHandler(nullptr, ERROR_UNIMPLEMENTED("CCM features not implemented"));
+    aHandler(nullptr, ERROR_UNIMPLEMENTED(CCM_NOT_IMPLEMENTED));
 }
 #endif // OT_COMM_CONFIG_CCM_ENABLE
 
@@ -1151,7 +1153,7 @@ Error CommissionerImpl::SetToken(const ByteArray &aSignedToken, const ByteArray 
 {
     (void)aSignedToken;
     (void)aSignerCert;
-    return ERROR_UNIMPLEMENTED("CCM features not implemented");
+    return ERROR_UNIMPLEMENTED(CCM_NOT_IMPLEMENTED);
 }
 #endif // OT_COMM_CONFIG_CCM_ENABLE
 

--- a/src/library/commissioner_impl.hpp
+++ b/src/library/commissioner_impl.hpp
@@ -208,7 +208,7 @@ private:
     static Error     DecodeBbrDataset(BbrDataset &aDataset, const coap::Response &aResponse);
     static Error     EncodeBbrDataset(coap::Request &aRequest, const BbrDataset &aDataset);
     static ByteArray GetBbrDatasetTlvs(uint16_t aDatasetFlags);
-#endif // OT_COMM_CONFIG_CCM_ENABLE
+#endif
 
     static Error     DecodeCommissionerDataset(CommissionerDataset &aDataset, const coap::Response &aResponse);
     static Error     EncodeCommissionerDataset(coap::Request &aRequest, const CommissionerDataset &aDataset);

--- a/src/library/commissioner_impl.hpp
+++ b/src/library/commissioner_impl.hpp
@@ -204,9 +204,11 @@ private:
     static Error EncodePendingOperationalDataset(coap::Request &aRequest, const PendingOperationalDataset &aDataset);
     static Error EncodeChannelMask(ByteArray &aBuf, const ChannelMask &aChannelMask);
 
+#if OT_COMM_CONFIG_CCM_ENABLE
     static Error     DecodeBbrDataset(BbrDataset &aDataset, const coap::Response &aResponse);
     static Error     EncodeBbrDataset(coap::Request &aRequest, const BbrDataset &aDataset);
     static ByteArray GetBbrDatasetTlvs(uint16_t aDatasetFlags);
+#endif // OT_COMM_CONFIG_CCM_ENABLE
 
     static Error     DecodeCommissionerDataset(CommissionerDataset &aDataset, const coap::Response &aResponse);
     static Error     EncodeCommissionerDataset(coap::Request &aRequest, const CommissionerDataset &aDataset);
@@ -217,7 +219,9 @@ private:
     // Set @p aKeepAlive to false to resign the commissioner role.
     void SendKeepAlive(Timer &aTimer, bool aKeepAlive = true);
 
+#if OT_COMM_CONFIG_CCM_ENABLE
     Error SignRequest(coap::Request &aRequest, tlv::Scope aScope = tlv::Scope::kMeshCoP);
+#endif
 
     Duration GetKeepAliveInterval() const { return std::chrono::seconds(mConfig.mKeepAliveInterval); };
 

--- a/src/library/commissioner_impl.hpp
+++ b/src/library/commissioner_impl.hpp
@@ -265,7 +265,9 @@ private:
 
     ProxyClient mProxyClient;
 
+#if OT_COMM_CCM_ENABLE
     TokenManager mTokenManager;
+#endif
 
     coap::Resource mResourceDatasetChanged;
     coap::Resource mResourcePanIdConflict;

--- a/src/library/commissioner_impl.hpp
+++ b/src/library/commissioner_impl.hpp
@@ -259,7 +259,7 @@ private:
 
     ProxyClient mProxyClient;
 
-#if OT_COMM_CCM_ENABLE
+#if OT_COMM_CONFIG_CCM_ENABLE
     TokenManager mTokenManager;
 #endif
 

--- a/src/library/cose.cpp
+++ b/src/library/cose.cpp
@@ -31,7 +31,7 @@
  *   This file implements COSE.
  */
 
-#if OT_COMM_CCM_ENABLE
+#if OT_COMM_CONFIG_CCM_ENABLE
 
 #include "library/cose.hpp"
 
@@ -343,4 +343,4 @@ exit:
 
 } // namespace ot
 
-#endif // OT_COMM_CCM_ENABLE
+#endif // OT_COMM_CONFIG_CCM_ENABLE

--- a/src/library/cose.cpp
+++ b/src/library/cose.cpp
@@ -31,6 +31,8 @@
  *   This file implements COSE.
  */
 
+#if OT_COMM_CCM_ENABLE
+
 #include "library/cose.hpp"
 
 #include <mbedtls/bignum.h>
@@ -318,3 +320,5 @@ exit:
 } // namespace commissioner
 
 } // namespace ot
+
+#endif // OT_COMM_CCM_ENABLE

--- a/src/library/cose.hpp
+++ b/src/library/cose.hpp
@@ -37,7 +37,7 @@
 #ifndef OT_COMM_LIBRARY_COSE_HPP_
 #define OT_COMM_LIBRARY_COSE_HPP_
 
-#if OT_COMM_CCM_ENABLE
+#if OT_COMM_CONFIG_CCM_ENABLE
 
 #include <stddef.h>
 #include <stdint.h>
@@ -123,6 +123,6 @@ Error MakeCoseKey(ByteArray &aEncodedCoseKey, const mbedtls_pk_context &aKey, co
 
 } // namespace ot
 
-#endif // OT_COMM_CCM_ENABLE
+#endif // OT_COMM_CONFIG_CCM_ENABLE
 
 #endif // OT_COMM_LIBRARY_COSE_HPP_

--- a/src/library/cose.hpp
+++ b/src/library/cose.hpp
@@ -37,6 +37,8 @@
 #ifndef OT_COMM_LIBRARY_COSE_HPP_
 #define OT_COMM_LIBRARY_COSE_HPP_
 
+#if OT_COMM_CCM_ENABLE
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -119,5 +121,7 @@ Error MakeCoseKey(ByteArray &aEncodedCoseKey, const mbedtls_pk_context &aKey, co
 } // namespace commissioner
 
 } // namespace ot
+
+#endif // OT_COMM_CCM_ENABLE
 
 #endif // OT_COMM_LIBRARY_COSE_HPP_

--- a/src/library/cose_test.cpp
+++ b/src/library/cose_test.cpp
@@ -31,6 +31,8 @@
  *   This file defines test cases for COSE.
  */
 
+#if OT_COMM_CCM_ENABLE
+
 #include "library/cose.hpp"
 
 #include <catch2/catch.hpp>
@@ -171,3 +173,5 @@ TEST_CASE("cose-sign-and-verify", "[cose]")
 } // namespace commissioner
 
 } // namespace ot
+
+#endif // OT_COMM_CCM_ENABLE

--- a/src/library/cose_test.cpp
+++ b/src/library/cose_test.cpp
@@ -31,7 +31,7 @@
  *   This file defines test cases for COSE.
  */
 
-#if OT_COMM_CCM_ENABLE
+#if OT_COMM_CONFIG_CCM_ENABLE
 
 #include "library/cose.hpp"
 
@@ -174,4 +174,4 @@ TEST_CASE("cose-sign-and-verify", "[cose]")
 
 } // namespace ot
 
-#endif // OT_COMM_CCM_ENABLE
+#endif // OT_COMM_CONFIG_CCM_ENABLE

--- a/src/library/cwt.hpp
+++ b/src/library/cwt.hpp
@@ -35,6 +35,8 @@
 #ifndef OT_COMM_LIBRARY_CWT_HPP_
 #define OT_COMM_LIBRARY_CWT_HPP_
 
+#if OT_COMM_CCM_ENABLE
+
 namespace ot {
 
 namespace commissioner {
@@ -57,5 +59,7 @@ static const int kCoseKey             = 1;
 } // namespace commissioner
 
 } // namespace ot
+
+#endif // OT_COMM_CCM_ENABLE
 
 #endif // OT_COMM_LIBRARY_CWT_HPP_

--- a/src/library/cwt.hpp
+++ b/src/library/cwt.hpp
@@ -35,7 +35,7 @@
 #ifndef OT_COMM_LIBRARY_CWT_HPP_
 #define OT_COMM_LIBRARY_CWT_HPP_
 
-#if OT_COMM_CCM_ENABLE
+#if OT_COMM_CONFIG_CCM_ENABLE
 
 namespace ot {
 
@@ -60,6 +60,6 @@ static const int kCoseKey             = 1;
 
 } // namespace ot
 
-#endif // OT_COMM_CCM_ENABLE
+#endif // OT_COMM_CONFIG_CCM_ENABLE
 
 #endif // OT_COMM_LIBRARY_CWT_HPP_

--- a/src/library/token_manager.cpp
+++ b/src/library/token_manager.cpp
@@ -31,6 +31,8 @@
  *   This file implements the Commissioner Token Manager.
  */
 
+#if OT_COMM_CCM_ENABLE
+
 #include "library/token_manager.hpp"
 
 #include <assert.h>
@@ -469,3 +471,5 @@ void TokenManager::MoveMbedtlsKey(mbedtls_pk_context &aDes, mbedtls_pk_context &
 } // namespace commissioner
 
 } // namespace ot
+
+#endif // OT_COMM_CCM_ENABLE

--- a/src/library/token_manager.cpp
+++ b/src/library/token_manager.cpp
@@ -31,7 +31,7 @@
  *   This file implements the Commissioner Token Manager.
  */
 
-#if OT_COMM_CCM_ENABLE
+#if OT_COMM_CONFIG_CCM_ENABLE
 
 #include "library/token_manager.hpp"
 
@@ -485,4 +485,4 @@ void TokenManager::MoveMbedtlsKey(mbedtls_pk_context &aDes, mbedtls_pk_context &
 
 } // namespace ot
 
-#endif // OT_COMM_CCM_ENABLE
+#endif // OT_COMM_CONFIG_CCM_ENABLE

--- a/src/library/token_manager.hpp
+++ b/src/library/token_manager.hpp
@@ -29,6 +29,8 @@
 #ifndef OT_COMM_LIBRARY_TOKEN_MANAGER_HPP_
 #define OT_COMM_LIBRARY_TOKEN_MANAGER_HPP_
 
+#if OT_COMM_CCM_ENABLE
+
 #include <mbedtls/pk.h>
 
 #include <commissioner/commissioner.hpp>
@@ -138,5 +140,7 @@ private:
 } // namespace commissioner
 
 } // namespace ot
+
+#endif // OT_COMM_CCM_ENABLE
 
 #endif // OT_COMM_LIBRARY_TOKEN_MANAGER_HPP_

--- a/src/library/token_manager.hpp
+++ b/src/library/token_manager.hpp
@@ -29,7 +29,7 @@
 #ifndef OT_COMM_LIBRARY_TOKEN_MANAGER_HPP_
 #define OT_COMM_LIBRARY_TOKEN_MANAGER_HPP_
 
-#if OT_COMM_CCM_ENABLE
+#if OT_COMM_CONFIG_CCM_ENABLE
 
 #include <mbedtls/pk.h>
 
@@ -141,6 +141,6 @@ private:
 
 } // namespace ot
 
-#endif // OT_COMM_CCM_ENABLE
+#endif // OT_COMM_CONFIG_CCM_ENABLE
 
 #endif // OT_COMM_LIBRARY_TOKEN_MANAGER_HPP_

--- a/src/library/token_manager_test.cpp
+++ b/src/library/token_manager_test.cpp
@@ -31,7 +31,7 @@
  *   This file defines test cases for token management.
  */
 
-#if OT_COMM_CCM_ENABLE
+#if OT_COMM_CONFIG_CCM_ENABLE
 
 #include "library/token_manager.hpp"
 
@@ -128,4 +128,4 @@ TEST_CASE("signing-message", "[token]")
 
 } // namespace ot
 
-#endif // OT_COMM_CCM_ENABLE
+#endif // OT_COMM_CONFIG_CCM_ENABLE

--- a/src/library/token_manager_test.cpp
+++ b/src/library/token_manager_test.cpp
@@ -31,6 +31,8 @@
  *   This file defines test cases for token management.
  */
 
+#if OT_COMM_CCM_ENABLE
+
 #include "library/token_manager.hpp"
 
 #include <catch2/catch.hpp>
@@ -125,3 +127,5 @@ TEST_CASE("signing-message", "[token]")
 } // namespace commissioner
 
 } // namespace ot
+
+#endif // OT_COMM_CCM_ENABLE

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -28,12 +28,15 @@
 
 add_subdirectory(Catch2/repo)
 
-set(CN_CBOR_FATAL_WARNINGS OFF CACHE BOOL "Disable -Werror and /W4")
-set(CN_CBOR_COVERALLS OFF CACHE BOOL "Disable generating coveralls data")
-set(CN_CBOR_BUILD_TESTS OFF CACHE BOOL "Disable compiling cbor tests")
-add_subdirectory(cn-cbor/repo)
+if (OT_COMM_CCM)
+    set(CN_CBOR_FATAL_WARNINGS OFF CACHE BOOL "Disable -Werror and /W4")
+    set(CN_CBOR_COVERALLS OFF CACHE BOOL "Disable generating coveralls data")
+    set(CN_CBOR_BUILD_TESTS OFF CACHE BOOL "Disable compiling cbor tests")
+    add_subdirectory(cn-cbor/repo)
 
-add_subdirectory(COSE-C)
+    add_subdirectory(COSE-C)
+endif()
+
 add_subdirectory(fmtlib/repo)
 add_subdirectory(json/repo)
 


### PR DESCRIPTION
This PR adds a CMake option `OT_COMM_CCM` and feature switch `OT_COMM_CONFIG_CCM_ENABLE` to turn off Commercial Commissioning Mode support. It has the benefits of increasing code coverage and remove unnecessary dependencies (cn-cbor, COSE-C) when `CCM` features is not needed.