### PR TITLE
[dtls] handle events when disconnected

### DIFF
--- a/src/library/dtls.cpp
+++ b/src/library/dtls.cpp
@@ -403,7 +403,7 @@ void DtlsSession::HandleEvent(short aFlags)
     default:
         // Ignore incoming data when the DTLS session is disconnected.
 
-        LOG_DEBUG(LOG_REGION_DTLS, "session(={}) received event %x in state {}", static_cast<void *>(this), aFlags,
+        LOG_DEBUG(LOG_REGION_DTLS, "session(={}) received event {:X} in state {}", static_cast<void *>(this), aFlags,
                   GetStateString());
         break;
     }

--- a/src/library/dtls.cpp
+++ b/src/library/dtls.cpp
@@ -401,7 +401,7 @@ void DtlsSession::HandleEvent(short aFlags)
         break;
 
     default:
-        VerifyOrDie(false);
+        // Ignore incoming data when the DTLS session is disconnected.
         break;
     }
 

--- a/src/library/dtls.cpp
+++ b/src/library/dtls.cpp
@@ -402,6 +402,9 @@ void DtlsSession::HandleEvent(short aFlags)
 
     default:
         // Ignore incoming data when the DTLS session is disconnected.
+
+        LOG_DEBUG(LOG_REGION_DTLS, "session(={}) received event %x in state {}", static_cast<void *>(this), aFlags,
+                  GetStateString());
         break;
     }
 


### PR DESCRIPTION
This PR fixes DTLS events handling when the session is disconnected. Previous implementation has the assumption that the underlying socket will be closed when the session is disconnected. But with PR https://github.com/openthread/ot-commissioner/pull/110,  the socket now may be open in this case.

This PR ignores the incoming data when the DTLS session is disconnected.