### PR TITLE
[code] address LGTM.com comments

### DIFF
--- a/src/library/coap.cpp
+++ b/src/library/coap.cpp
@@ -228,7 +228,7 @@ exit:
 
 bool Message::Header::IsValid() const
 {
-    return mVersion == kVersion1 && mTokenLength >= 0 && mTokenLength <= kMaxTokenLength;
+    return mVersion == kVersion1 && mTokenLength <= kMaxTokenLength;
 }
 
 Error Message::Serialize(OptionType         aOptionNumber,

--- a/src/library/coap_test.cpp
+++ b/src/library/coap_test.cpp
@@ -190,7 +190,10 @@ TEST_CASE("coap-message-options", "[coap]")
         REQUIRE(contentFormat == ContentFormat::kCBOR);
     }
 
-    SECTION("single URI path option serialization & deserialization") {}
+    SECTION("single URI path option serialization & deserialization")
+    {
+        // TODO(wgtdkp):
+    }
 
     SECTION("multiple options serialization & deserialization")
     {

--- a/tools/commissioner_thci/commissioner_impl.py
+++ b/tools/commissioner_thci/commissioner_impl.py
@@ -30,7 +30,6 @@
 Thread 1.2 commissioner interface implementation
 """
 
-from abc import abstractmethod
 from future.utils import raise_
 
 import serial
@@ -43,7 +42,6 @@ import base64
 import logging
 import binascii
 import sys
-import os
 
 import commissioner
 


### PR DESCRIPTION
This PR addresses several LGTM.com comments:
1. remove meaningless unsigned comparison to zero.
2. remove unused python imports.
3. add TODO to URI path option unittest.