### PR TITLE
[cli] fix CLI commands output

### DIFF
--- a/src/app/cli/interpreter.cpp
+++ b/src/app/cli/interpreter.cpp
@@ -1017,7 +1017,7 @@ Interpreter::Value Interpreter::ProcessHelp(const Expression &aExpr)
         {
             data += kv.first + "\n";
         }
-        data += "\ntype 'help <command>' for help of specific command.";]
+        data += "\ntype 'help <command>' for help of specific command.";
         value = data;
     }
     else

--- a/src/app/cli/interpreter.cpp
+++ b/src/app/cli/interpreter.cpp
@@ -225,7 +225,7 @@ Interpreter::Value Interpreter::Eval(const Expression &aExpr)
     if (evaluator == mEvaluatorMap.end())
     {
         ExitNow(value =
-                    ERROR_INVALID_COMMAND("'{}' is not a valid command, type 'help' for all commands", aExpr.front()));
+                    ERROR_INVALID_COMMAND("'{}' is not a valid command, type 'help' to list all commands", aExpr.front()));
     }
 
     value = evaluator->second(this, aExpr);

--- a/src/app/cli/interpreter.cpp
+++ b/src/app/cli/interpreter.cpp
@@ -224,8 +224,8 @@ Interpreter::Value Interpreter::Eval(const Expression &aExpr)
     evaluator = mEvaluatorMap.find(ToLower(aExpr.front()));
     if (evaluator == mEvaluatorMap.end())
     {
-        ExitNow(value =
-                    ERROR_INVALID_COMMAND("'{}' is not a valid command, type 'help' to list all commands", aExpr.front()));
+        ExitNow(value = ERROR_INVALID_COMMAND("'{}' is not a valid command, type 'help' to list all commands",
+                                              aExpr.front()));
     }
 
     value = evaluator->second(this, aExpr);

--- a/src/app/cli/interpreter.cpp
+++ b/src/app/cli/interpreter.cpp
@@ -224,7 +224,8 @@ Interpreter::Value Interpreter::Eval(const Expression &aExpr)
     evaluator = mEvaluatorMap.find(ToLower(aExpr.front()));
     if (evaluator == mEvaluatorMap.end())
     {
-        ExitNow(value = ERROR_INVALID_ARGS("invalid commands: {}; type 'help' for all commands", aExpr.front()));
+        ExitNow(value =
+                    ERROR_INVALID_COMMAND("'{}' is not a valid command, type 'help' for all commands", aExpr.front()));
     }
 
     value = evaluator->second(this, aExpr);
@@ -1016,7 +1017,8 @@ Interpreter::Value Interpreter::ProcessHelp(const Expression &aExpr)
         {
             data += kv.first + "\n";
         }
-        data += "\ntype 'help <command>' for help of specific command.";
+        data += "\ntype 'help <command>' for help of specific command.";]
+        value = data;
     }
     else
     {


### PR DESCRIPTION
This PR
1. fixes the output of the `help` command (it gave no command list).
2. returns `INVALID_COMMAND` for invalid commands.