### PR TITLE
[api] add missing header for definition of size_t

### DIFF
--- a/include/commissioner/defines.hpp
+++ b/include/commissioner/defines.hpp
@@ -36,6 +36,7 @@
 
 #include <vector>
 
+#include <stddef.h>
 #include <stdint.h>
 
 #if defined(__clang__)


### PR DESCRIPTION
`size_t` is not defined in some raspberry pi devices with gcc 6.

This PR includes `<stddef.h>` for definition of `size_t`.