### PR TITLE
[test] enable custom OpenThread path

### DIFF
--- a/tests/integration/bootstrap.sh
+++ b/tests/integration/bootstrap.sh
@@ -55,7 +55,10 @@ setup_otbr() {
 
 setup_openthread() {
     set -e
-    git clone "${OPENTHREAD_REPO}" "${OPENTHREAD}" --branch "${OPENTHREAD_BRANCH}" --depth=1
+
+    if [[ ! -d ${OPENTHREAD} ]]; then
+        git clone "${OPENTHREAD_REPO}" "${OPENTHREAD}" --branch "${OPENTHREAD_BRANCH}" --depth=1
+    fi
 
     cd "${OPENTHREAD}"
 
@@ -67,9 +70,7 @@ setup_openthread() {
     cp ${ot_build_dir}/examples/apps/ncp/ot-rcp "${NON_CCM_RCP}"
     cp ${ot_build_dir}/examples/apps/cli/ot-cli-ftd "${NON_CCM_CLI}"
 
-    rm -rf build
-
-    cmake -DOT_PLATFORM=posix -DOT_DAEMON=ON -S . -B build
+    cmake -DOT_PLATFORM=posix -DOT_DAEMON=ON -DOT_COVERAGE=ON -S . -B build
     cmake --build build
     cp build/src/posix/ot-ctl "${OT_CTL}"
 
@@ -89,9 +90,7 @@ main() {
         setup_otbr
     fi
 
-    if [ ! -d "${OPENTHREAD}" ]; then
-        setup_openthread
-    fi
+    setup_openthread
 
     setup_commissioner
 }

--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -40,7 +40,7 @@ readonly OTBR=${RUNTIME_DIR}/ot-br-posix
 
 readonly OPENTHREAD_REPO=https://github.com/openthread/openthread
 readonly OPENTHREAD_BRANCH=master
-readonly OPENTHREAD=${OPENTHREAD:-"${RUNTIME_DIR}/openthread"}
+readonly OPENTHREAD=${OT_COMM_OPENTHREAD:-"${RUNTIME_DIR}/openthread"}
 
 readonly NON_CCM_CLI=${RUNTIME_DIR}/ot-cli-ftd-non-ccm
 readonly NON_CCM_RCP=${RUNTIME_DIR}/ot-rcp-non-ccm

--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -40,7 +40,7 @@ readonly OTBR=${RUNTIME_DIR}/ot-br-posix
 
 readonly OPENTHREAD_REPO=https://github.com/openthread/openthread
 readonly OPENTHREAD_BRANCH=master
-readonly OPENTHREAD=${RUNTIME_DIR}/openthread
+readonly OPENTHREAD=${OPENTHREAD:-"${RUNTIME_DIR}/openthread"}
 
 readonly NON_CCM_CLI=${RUNTIME_DIR}/ot-cli-ftd-non-ccm
 readonly NON_CCM_RCP=${RUNTIME_DIR}/ot-rcp-non-ccm


### PR DESCRIPTION
This allows users to specify a custom OpenThread directory so that we can include external commissioner tests as a part of OpenThread CI.