### PR TITLE
[test] use provided openthread repo for otbr

### DIFF
--- a/tests/integration/bootstrap.sh
+++ b/tests/integration/bootstrap.sh
@@ -44,11 +44,10 @@ setup_otbr() {
 
     cd "${OTBR}"
 
-    export OTBR_OPTIONS="-DOTBR_COVERAGE=ON -DOT_COVERAGE=ON"
     ./script/bootstrap
     rm -rf "${OTBR}/third_party/openthread/repo"
     ln -s "${OPENTHREAD}" "${OTBR}/third_party/openthread/repo"
-    ./script/setup
+    OTBR_OPTIONS="-DOTBR_COVERAGE=ON -DOT_COVERAGE=ON" ./script/setup
 
     ## Stop otbr-agent
     sudo service otbr-agent stop

--- a/tests/integration/bootstrap.sh
+++ b/tests/integration/bootstrap.sh
@@ -44,7 +44,10 @@ setup_otbr() {
 
     cd "${OTBR}"
 
+    export OTBR_OPTIONS="-DOTBR_COVERAGE=ON -DOT_COVERAGE=ON"
     ./script/bootstrap
+    rm -rf "${OTBR}/third_party/openthread/repo"
+    ln -s "${OPENTHREAD}" "${OTBR}/third_party/openthread/repo"
     ./script/setup
 
     ## Stop otbr-agent
@@ -71,7 +74,7 @@ setup_openthread() {
     cp ${ot_build_dir}/examples/apps/cli/ot-cli-ftd "${NON_CCM_CLI}"
 
     cmake -DOT_PLATFORM=posix -DOT_DAEMON=ON -DOT_COVERAGE=ON -S . -B build
-    cmake --build build
+    cmake --build build -j
     cp build/src/posix/ot-ctl "${OT_CTL}"
 
     cd -
@@ -86,11 +89,11 @@ main() {
     set -e
     mkdir -p "${RUNTIME_DIR}"
 
+    setup_openthread
+
     if (( SKIP_BUILDING_OTBR == 0 )) && [ ! -d "${OTBR}" ]; then
         setup_otbr
     fi
-
-    setup_openthread
 
     setup_commissioner
 }

--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -81,14 +81,23 @@ executable_or_die() {
 
 start_otbr() {
     set -e
-    sudo killall -9 otbr-agent || true
-    sleep 1
-    pidof otbr-agent && die "killing otbr-agent failed"
+
+    if pidof otbr-agent; then
+        stop_otbr
+    fi
 
     sudo rm -rf ${OTBR_SETTINGS_PATH}
     sudo otbr-agent -I wpan0 -d 7 -v "spinel+hdlc+forkpty://${NON_CCM_RCP}?forkpty-arg=1" > "${OTBR_LOG}" 2>&1 &
 
     sleep 10
+}
+
+stop_otbr() {
+    set -e
+
+    sudo killall otbr-agent || true
+    sleep 1
+    (pidof otbr-agent && die "killing otbr-agent failed") || true
 }
 
 ## Start commissioner daemon.

--- a/tests/integration/test_announce_begin.sh
+++ b/tests/integration/test_announce_begin.sh
@@ -40,4 +40,6 @@ test_announce_begin() {
     send_command_to_commissioner "active"
     send_command_to_commissioner "announce 0xffffffff 2 32 ff02::2"
     stop_commissioner
+
+    stop_otbr
 }

--- a/tests/integration/test_cli.sh
+++ b/tests/integration/test_cli.sh
@@ -40,6 +40,8 @@ test_network_sync()
     send_command_to_commissioner "start :: 49191"
     send_command_to_commissioner "network sync"
     stop_commissioner
+
+    stop_otbr
 }
 
 test_get_commissioner_dataset()
@@ -53,4 +55,6 @@ test_get_commissioner_dataset()
     send_command_to_commissioner "start :: 49191"
     send_command_to_commissioner "commdataset get"
     stop_commissioner
+
+    stop_otbr
 }

--- a/tests/integration/test_discover.sh
+++ b/tests/integration/test_discover.sh
@@ -41,4 +41,6 @@ test_discover() {
     send_command_to_commissioner "borderagent discover"
 
     stop_commissioner
+
+    stop_otbr
 }

--- a/tests/integration/test_energy_scan.sh
+++ b/tests/integration/test_energy_scan.sh
@@ -44,4 +44,6 @@ test_energy_scan() {
     # TODO(wgtdkp): verify the result
     send_command_to_commissioner "energy report"
     stop_commissioner
+
+    stop_otbr
 }

--- a/tests/integration/test_joining.sh
+++ b/tests/integration/test_joining.sh
@@ -45,6 +45,8 @@ test_joining() {
     start_joiner "meshcop"
 
     stop_commissioner
+
+    stop_otbr
 }
 
 test_joining_fail() {
@@ -59,4 +61,6 @@ test_joining_fail() {
     start_joiner "meshcop" && return 1
 
     stop_commissioner
+
+    stop_otbr
 }

--- a/tests/integration/test_operational_dataset.sh
+++ b/tests/integration/test_operational_dataset.sh
@@ -43,6 +43,8 @@ test_active_dataset_set_network_name() {
     ## TODO(wgtdkp): verify the result
     send_command_to_commissioner "opdataset get networkname"
     stop_commissioner
+
+    stop_otbr
 }
 
 test_pending_dataset_set_channel() {
@@ -59,6 +61,8 @@ test_pending_dataset_set_channel() {
     ## TODO(wgtdkp): wait and verify the result
     send_command_to_commissioner "opdataset get channel"
     stop_commissioner
+
+    stop_otbr
 }
 
 test_secure_pending_dataset() {

--- a/tests/integration/test_pan_id_query.sh
+++ b/tests/integration/test_pan_id_query.sh
@@ -44,4 +44,6 @@ test_pan_id_query() {
     ## TODO(wgtdkp): verify the result
     send_command_to_commissioner "panid conflict 0xaabb"
     stop_commissioner
+
+    stop_otbr
 }

--- a/tests/integration/test_petition.sh
+++ b/tests/integration/test_petition.sh
@@ -39,4 +39,6 @@ test_petition() {
     send_command_to_commissioner "start :: 49191"
     send_command_to_commissioner "active"
     stop_commissioner
+
+    stop_otbr
 }


### PR DESCRIPTION
When running tests, this makes the `otbr` to be built with `openthread` provided by environment variables so changes from `openthread` PRs can be correctly applied.
Also changes `killall -9` to `killall` to prevent the loss of coverage data.