### PR TITLE
[test] replace ot-br with ot-daemon in integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,8 @@ jobs:
       - name: Bootstrap
         run: |
           script/bootstrap.sh
+          sudo apt-get update
+          sudo apt-get install avahi-daemon avahi-utils -y
       - name: Build
         run: |
           cmake -GNinja                           \

--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -218,3 +218,20 @@ form_network() {
 
     sleep 3
 }
+
+start_mdns_service() {
+    sudo service avahi-daemon restart
+    avahi-publish --domain=local \
+                  -s "A fake border agent" \
+                  _meshcop._udp \
+                  12345 \
+                  "nn=test-net" \
+                  "xp=01234567" &
+
+    ## Wait for the service to start.
+    sleep 3
+}
+
+stop_mdns_service() {
+    sudo killall avahi-publish
+}

--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -34,10 +34,6 @@ readonly TEST_ROOT_DIR=${CUR_DIR}
 
 readonly RUNTIME_DIR=/tmp/test-ot-commissioner
 
-readonly OTBR_REPO=https://github.com/openthread/ot-br-posix
-readonly OTBR_BRANCH=master
-readonly OTBR=${RUNTIME_DIR}/ot-br-posix
-
 readonly OPENTHREAD_REPO=https://github.com/openthread/openthread
 readonly OPENTHREAD_BRANCH=master
 readonly OPENTHREAD=${OT_COMM_OPENTHREAD:-"${RUNTIME_DIR}/openthread"}
@@ -45,9 +41,9 @@ readonly OPENTHREAD=${OT_COMM_OPENTHREAD:-"${RUNTIME_DIR}/openthread"}
 readonly NON_CCM_CLI=${RUNTIME_DIR}/ot-cli-ftd-non-ccm
 readonly NON_CCM_RCP=${RUNTIME_DIR}/ot-rcp-non-ccm
 readonly OT_CTL=${RUNTIME_DIR}/ot-ctl
+readonly OT_DAEMON=${RUNTIME_DIR}/ot-daemon
 
-readonly OTBR_SETTINGS_PATH=/var/lib/thread
-readonly OTBR_LOG=${RUNTIME_DIR}/otbr.log
+readonly OT_DAEMON_SETTINGS_PATH=${RUNTIME_DIR}/tmp
 
 ## '/usr/local' is the by default installing directory.
 readonly COMMISSIONER_CLI=/usr/local/bin/commissioner-cli
@@ -79,25 +75,27 @@ executable_or_die() {
   [ -x "$1" ] || die "Missing executable: $1"
 }
 
-start_otbr() {
+start_daemon() {
     set -e
 
-    if pidof otbr-agent; then
-        stop_otbr
+    cd "${RUNTIME_DIR}"
+
+    if pidof ot-daemon; then
+        stop_daemon
     fi
 
-    sudo rm -rf ${OTBR_SETTINGS_PATH}
-    sudo otbr-agent -I wpan0 -d 7 -v "spinel+hdlc+forkpty://${NON_CCM_RCP}?forkpty-arg=1" > "${OTBR_LOG}" 2>&1 &
+    sudo rm -rf ${OT_DAEMON_SETTINGS_PATH}
+    sudo "${OT_DAEMON}" "spinel+hdlc+uart://${NON_CCM_RCP}?forkpty-arg=1" &
 
     sleep 10
 }
 
-stop_otbr() {
+stop_daemon() {
     set -e
 
-    sudo killall otbr-agent || true
+    sudo killall ot-daemon || true
     sleep 1
-    (pidof otbr-agent && die "killing otbr-agent failed") || true
+    (pidof ot-daemon && die "killing ot-daemon failed") || true
 }
 
 ## Start commissioner daemon.
@@ -176,7 +174,7 @@ start_joiner() {
     fi
 
     echo "starting ${joiner_type} joiner..."
-    expect -f-  <<EOF || return 1
+    sudo expect -f-  <<EOF || return 1
 spawn ${joiner_binary} ${JOINER_NODE_ID}
 
 send "factoryreset\r\n"

--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -44,6 +44,7 @@ readonly OT_CTL=${RUNTIME_DIR}/ot-ctl
 readonly OT_DAEMON=${RUNTIME_DIR}/ot-daemon
 
 readonly OT_DAEMON_SETTINGS_PATH=${RUNTIME_DIR}/tmp
+readonly OT_DAEMON_LOG=${RUNTIME_DIR}/ot-daemon.log
 
 ## '/usr/local' is the by default installing directory.
 readonly COMMISSIONER_CLI=/usr/local/bin/commissioner-cli
@@ -85,7 +86,7 @@ start_daemon() {
     fi
 
     sudo rm -rf ${OT_DAEMON_SETTINGS_PATH}
-    sudo "${OT_DAEMON}" "spinel+hdlc+uart://${NON_CCM_RCP}?forkpty-arg=1" &
+    sudo "${OT_DAEMON}" "spinel+hdlc+uart://${NON_CCM_RCP}?forkpty-arg=1" > "${OT_DAEMON_LOG}" 2>&1 &
 
     sleep 10
 }

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -74,6 +74,10 @@ run_test_case() {
         echo "${output}"
         echo "------ test output end ------"
 
+        echo "------ ot-daemon log begin ------"
+        cat "${OT_DAEMON_LOG}"
+        echo "------ ot-daemon log end ------"
+
         echo "------ commissioner daemon log begin ------"
         cat "${COMMISSIONER_DAEMON_LOG}"
         echo "------ commissioner daemon log end ------"

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -74,10 +74,6 @@ run_test_case() {
         echo "${output}"
         echo "------ test output end ------"
 
-        echo "------ otbr log begin ------"
-        cat "${OTBR_LOG}"
-        echo "------ otbr log end ------"
-
         echo "------ commissioner daemon log begin ------"
         cat "${COMMISSIONER_DAEMON_LOG}"
         echo "------ commissioner daemon log end ------"

--- a/tests/integration/test_announce_begin.sh
+++ b/tests/integration/test_announce_begin.sh
@@ -32,7 +32,7 @@
 test_announce_begin() {
     set -e
 
-    start_otbr
+    start_daemon
     form_network "${PSKC}"
 
     start_commissioner "${NON_CCM_CONFIG}"
@@ -41,5 +41,5 @@ test_announce_begin() {
     send_command_to_commissioner "announce 0xffffffff 2 32 ff02::2"
     stop_commissioner
 
-    stop_otbr
+    stop_daemon
 }

--- a/tests/integration/test_cli.sh
+++ b/tests/integration/test_cli.sh
@@ -33,7 +33,7 @@ test_network_sync()
 {
     set -e
 
-    start_otbr
+    start_daemon
     form_network "${PSKC}"
 
     start_commissioner "${NON_CCM_CONFIG}"
@@ -41,14 +41,14 @@ test_network_sync()
     send_command_to_commissioner "network sync"
     stop_commissioner
 
-    stop_otbr
+    stop_daemon
 }
 
 test_get_commissioner_dataset()
 {
     set -e
 
-    start_otbr
+    start_daemon
     form_network "${PSKC}"
 
     start_commissioner "${NON_CCM_CONFIG}"
@@ -56,5 +56,5 @@ test_get_commissioner_dataset()
     send_command_to_commissioner "commdataset get"
     stop_commissioner
 
-    stop_otbr
+    stop_daemon
 }

--- a/tests/integration/test_discover.sh
+++ b/tests/integration/test_discover.sh
@@ -32,15 +32,12 @@
 test_discover() {
     set -e
 
-    start_daemon
-    form_network "${PSKC}"
-
+    start_mdns_service
     start_commissioner "${NON_CCM_CONFIG}"
 
     ## TODO(wgtdkp): verify the output
     send_command_to_commissioner "borderagent discover"
 
     stop_commissioner
-
-    stop_daemon
+    stop_mdns_service
 }

--- a/tests/integration/test_discover.sh
+++ b/tests/integration/test_discover.sh
@@ -32,7 +32,7 @@
 test_discover() {
     set -e
 
-    start_otbr
+    start_daemon
     form_network "${PSKC}"
 
     start_commissioner "${NON_CCM_CONFIG}"
@@ -42,5 +42,5 @@ test_discover() {
 
     stop_commissioner
 
-    stop_otbr
+    stop_daemon
 }

--- a/tests/integration/test_energy_scan.sh
+++ b/tests/integration/test_energy_scan.sh
@@ -32,7 +32,7 @@
 test_energy_scan() {
     set -e
 
-    start_otbr
+    start_daemon
     form_network "${PSKC}"
 
     start_commissioner "${NON_CCM_CONFIG}"
@@ -45,5 +45,5 @@ test_energy_scan() {
     send_command_to_commissioner "energy report"
     stop_commissioner
 
-    stop_otbr
+    stop_daemon
 }

--- a/tests/integration/test_joining.sh
+++ b/tests/integration/test_joining.sh
@@ -32,7 +32,7 @@
 test_joining() {
     set -e
 
-    start_otbr
+    start_daemon
     form_network "${PSKC}"
 
     start_commissioner "${NON_CCM_CONFIG}"
@@ -46,11 +46,11 @@ test_joining() {
 
     stop_commissioner
 
-    stop_otbr
+    stop_daemon
 }
 
 test_joining_fail() {
-    start_otbr
+    start_daemon
     form_network "${PSKC}"
 
     start_commissioner "${NON_CCM_CONFIG}"
@@ -62,5 +62,5 @@ test_joining_fail() {
 
     stop_commissioner
 
-    stop_otbr
+    stop_daemon
 }

--- a/tests/integration/test_operational_dataset.sh
+++ b/tests/integration/test_operational_dataset.sh
@@ -32,7 +32,7 @@
 test_active_dataset_set_network_name() {
     set -e
 
-    start_otbr
+    start_daemon
     form_network "${PSKC}"
 
     start_commissioner "${NON_CCM_CONFIG}"
@@ -44,13 +44,13 @@ test_active_dataset_set_network_name() {
     send_command_to_commissioner "opdataset get networkname"
     stop_commissioner
 
-    stop_otbr
+    stop_daemon
 }
 
 test_pending_dataset_set_channel() {
     set -e
 
-    start_otbr
+    start_daemon
     form_network "${PSKC}"
 
     start_commissioner "${NON_CCM_CONFIG}"
@@ -62,7 +62,7 @@ test_pending_dataset_set_channel() {
     send_command_to_commissioner "opdataset get channel"
     stop_commissioner
 
-    stop_otbr
+    stop_daemon
 }
 
 test_secure_pending_dataset() {

--- a/tests/integration/test_pan_id_query.sh
+++ b/tests/integration/test_pan_id_query.sh
@@ -32,7 +32,7 @@
 test_pan_id_query() {
     set -e
 
-    start_otbr
+    start_daemon
     form_network "${PSKC}"
 
     start_commissioner "${NON_CCM_CONFIG}"
@@ -45,5 +45,5 @@ test_pan_id_query() {
     send_command_to_commissioner "panid conflict 0xaabb"
     stop_commissioner
 
-    stop_otbr
+    stop_daemon
 }

--- a/tests/integration/test_petition.sh
+++ b/tests/integration/test_petition.sh
@@ -32,7 +32,7 @@
 test_petition() {
     set -e
 
-    start_otbr
+    start_daemon
     form_network "${PSKC}"
 
     start_commissioner "${NON_CCM_CONFIG}"
@@ -40,5 +40,5 @@ test_petition() {
     send_command_to_commissioner "active"
     stop_commissioner
 
-    stop_otbr
+    stop_daemon
 }


### PR DESCRIPTION
This removes the dependency of `ot-br` in integration tests.