### PR TITLE
[event] fix ading user triggered events

### DIFF
--- a/src/library/joiner_session.cpp
+++ b/src/library/joiner_session.cpp
@@ -232,7 +232,7 @@ JoinerSession::RelaySocket::RelaySocket(JoinerSession &aJoinerSession,
 
     mIsConnected = true;
 
-    fail = event_assign(&mEvent, mEventBase, -1, EV_PERSIST | EV_READ | EV_WRITE | EV_ET, HandleEvent, this);
+    fail = event_assign(&mEvent, mEventBase, -1, EV_PERSIST, HandleEvent, this);
     VerifyOrDie(fail == 0);
     VerifyOrDie((fail = event_add(&mEvent, nullptr)) == 0);
 }

--- a/src/library/socket_test.cpp
+++ b/src/library/socket_test.cpp
@@ -144,7 +144,7 @@ int MockSocket::Connect(MockSocketPtr aPeerSocket)
     mIsConnected = true;
 
     // Setup Event
-    int rval = event_assign(&mEvent, mEventBase, -1, EV_PERSIST | EV_READ | EV_WRITE | EV_ET, HandleEvent, this);
+    int rval = event_assign(&mEvent, mEventBase, -1, EV_PERSIST, HandleEvent, this);
     VerifyOrExit(rval == 0);
     VerifyOrExit((rval = event_add(&mEvent, nullptr)) == 0);
 


### PR DESCRIPTION
This PR has two small fixes
1. Add a timeout value for the async call event so that the event loop will not exit because of no events.
2. User triggered event struct (with fd equals -1) should not listen on READ, WRITE events.