### PR TITLE
[api] rename API AbortRequests to CancelRequests

### DIFF
--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -434,10 +434,10 @@ public:
     virtual const std::string &GetDomainName() const = 0;
 
     /**
-     * @brief Abort all outstanding requests.
+     * @brief Cancel all outstanding requests.
      *
      */
-    virtual void AbortRequests() = 0;
+    virtual void CancelRequests() = 0;
 
     /**
      * @brief Asynchronously petition to a Thread network.

--- a/src/app/cli/README.md
+++ b/src/app/cli/README.md
@@ -68,7 +68,7 @@ type 'help <command>' for help of specific command.
 
 All commands are synchronous, which means the command will not return until success, an error occurs, or a time out.
 
-To abort a command, send signal `Interrupt` to OT Commissioner, which is `CTRL + C` for a Linux machine.
+To cancel a command, send signal `Interrupt` to OT Commissioner, which is `CTRL + C` for a Linux machine.
 
 ### Help
 

--- a/src/app/cli/interpreter.cpp
+++ b/src/app/cli/interpreter.cpp
@@ -197,11 +197,11 @@ exit:
     return;
 }
 
-void Interpreter::AbortCommand()
+void Interpreter::CancelCommand()
 {
     if (mCommissioner->IsActive())
     {
-        mCommissioner->AbortRequests();
+        mCommissioner->CancelRequests();
     }
     else
     {

--- a/src/app/cli/interpreter.hpp
+++ b/src/app/cli/interpreter.hpp
@@ -54,7 +54,7 @@ public:
 
     void Run();
 
-    void AbortCommand();
+    void CancelCommand();
 
 private:
     /**

--- a/src/app/cli/main.cpp
+++ b/src/app/cli/main.cpp
@@ -79,7 +79,7 @@ static Interpreter gInterpreter;
 
 static void HandleSignalInterrupt(int)
 {
-    gInterpreter.AbortCommand();
+    gInterpreter.CancelCommand();
 }
 
 int main(int argc, const char *argv[])

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -111,9 +111,9 @@ void CommissionerApp::Stop()
     mBbrDataset     = BbrDataset();
 }
 
-void CommissionerApp::AbortRequests()
+void CommissionerApp::CancelRequests()
 {
-    mCommissioner->AbortRequests();
+    mCommissioner->CancelRequests();
 }
 
 bool CommissionerApp::IsActive() const

--- a/src/app/commissioner_app.hpp
+++ b/src/app/commissioner_app.hpp
@@ -126,7 +126,7 @@ public:
     Error Start(std::string &aExistingCommissionerId, const std::string &aBorderAgentAddr, uint16_t aBorderAgentPort);
     void  Stop();
 
-    void AbortRequests();
+    void CancelRequests();
 
     // Returns if current commissioner is in active state.
     // Should always be true if starting the commissioner app has succeed.

--- a/src/library/coap.cpp
+++ b/src/library/coap.cpp
@@ -400,11 +400,11 @@ Coap::Coap(struct event_base *aEventBase, Endpoint &aEndpoint)
 
 void Coap::ClearRequestsAndResponses(void)
 {
-    AbortRequests();
+    CancelRequests();
     mResponsesCache.Clear();
 }
 
-void Coap::AbortRequests()
+void Coap::CancelRequests()
 {
     while (!mRequestsCache.IsEmpty())
     {

--- a/src/library/coap.hpp
+++ b/src/library/coap.hpp
@@ -598,10 +598,10 @@ public:
     Coap(struct event_base *aEventBase, Endpoint &aEndpoint);
     virtual ~Coap() = default;
 
-    // Abort all outstanding requests
-    void AbortRequests();
+    // Cancel all outstanding requests
+    void CancelRequests();
 
-    // Clear/Abort requests and clear response caches.
+    // Clear/Cancel requests and clear response caches.
     void ClearRequestsAndResponses(void);
 
     size_t GetPendingRequestsNum() const { return mRequestsCache.Count(); }

--- a/src/library/coap_secure.hpp
+++ b/src/library/coap_secure.hpp
@@ -121,7 +121,7 @@ public:
 
     const DtlsSession &GetDtlsSession() const { return mDtlsSession; }
 
-    void AbortRequests() { mCoap.AbortRequests(); }
+    void CancelRequests() { mCoap.CancelRequests(); }
 
 private:
     UdpSocketPtr mSocket;

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -345,15 +345,15 @@ const std::string &CommissionerImpl::GetDomainName() const
     return mConfig.mDomainName;
 }
 
-void CommissionerImpl::AbortRequests()
+void CommissionerImpl::CancelRequests()
 {
-    mProxyClient.AbortRequests();
-    mBrClient.AbortRequests();
+    mProxyClient.CancelRequests();
+    mBrClient.CancelRequests();
 
 #if OT_COMM_CONFIG_CCM_ENABLE
     if (IsCcmMode())
     {
-        mTokenManager.AbortRequests();
+        mTokenManager.CancelRequests();
     }
 #endif
 }

--- a/src/library/commissioner_impl.hpp
+++ b/src/library/commissioner_impl.hpp
@@ -89,7 +89,7 @@ public:
 
     const std::string &GetDomainName() const override;
 
-    void AbortRequests() override;
+    void CancelRequests() override;
 
     void  Connect(ErrorHandler aHandler, const std::string &aAddr, uint16_t aPort) override;
     Error Connect(const std::string &, uint16_t) override { return ERROR_UNIMPLEMENTED(""); }

--- a/src/library/commissioner_safe.cpp
+++ b/src/library/commissioner_safe.cpp
@@ -169,9 +169,9 @@ const std::string &CommissionerSafe::GetDomainName() const
     return mImpl->GetDomainName();
 }
 
-void CommissionerSafe::AbortRequests()
+void CommissionerSafe::CancelRequests()
 {
-    PushAsyncRequest([=]() { mImpl->AbortRequests(); });
+    PushAsyncRequest([=]() { mImpl->CancelRequests(); });
 }
 
 void CommissionerSafe::Petition(PetitionHandler aHandler, const std::string &aAddr, uint16_t aPort)

--- a/src/library/commissioner_safe.hpp
+++ b/src/library/commissioner_safe.hpp
@@ -90,7 +90,7 @@ public:
 
     const std::string &GetDomainName() const override;
 
-    void AbortRequests() override;
+    void CancelRequests() override;
 
     void  Connect(ErrorHandler aHandler, const std::string &aAddr, uint16_t aPort) override;
     Error Connect(const std::string &aAddr, uint16_t aPort) override;

--- a/src/library/joiner_session.cpp
+++ b/src/library/joiner_session.cpp
@@ -87,11 +87,6 @@ exit:
     }
 }
 
-void JoinerSession::Disconnect()
-{
-    mDtlsSession->Disconnect(ERROR_ABORTED("the joiner session was aborted"));
-}
-
 ByteArray JoinerSession::GetJoinerIid() const
 {
     auto joinerIid = mJoinerId;

--- a/src/library/joiner_session.hpp
+++ b/src/library/joiner_session.hpp
@@ -89,8 +89,6 @@ public:
 
     void Connect();
 
-    void Disconnect();
-
     DtlsSession::State GetState() const { return mDtlsSession->GetState(); }
 
     bool Disabled() const { return mDtlsSession->GetState() == DtlsSession::State::kOpen; }

--- a/src/library/token_manager.hpp
+++ b/src/library/token_manager.hpp
@@ -64,7 +64,7 @@ public:
 
     const std::string &GetDomainName() const;
 
-    void AbortRequests() { mRegistrarClient.AbortRequests(); }
+    void CancelRequests() { mRegistrarClient.CancelRequests(); }
 
     // Request Commissioner Token from registrar.
     // The protocol is described in `doc/registrar-connector.md`.

--- a/src/library/udp_proxy.hpp
+++ b/src/library/udp_proxy.hpp
@@ -94,7 +94,7 @@ public:
 
     void HandleUdpRx(const coap::Request &aUdpRx);
 
-    void AbortRequests() { mCoap.AbortRequests(); }
+    void CancelRequests() { mCoap.CancelRequests(); }
 
 private:
     ProxyEndpoint mEndpoint;


### PR DESCRIPTION
This PR rename the API `AbortRequests` to `CancelRequests`, it season to be more reasonable to name it `CANCEL` than `ABORT` when it is the user invoking it:

```C++
 /**
     * The operation was cancelled (typically by the caller).
     */
    kCancelled = 1,

/**
     * The operation, transaction or message exchange was aborted.
     */
    kAborted = 14,
```