### PR TITLE
[cli] fix signal handling

### DIFF
--- a/src/app/cli/CMakeLists.txt
+++ b/src/app/cli/CMakeLists.txt
@@ -45,8 +45,9 @@ target_include_directories(commissioner-cli
 target_link_libraries(commissioner-cli
     PRIVATE
         commissioner-app
-        readline
         ncurses
+        pthread
+        readline
 )
 
 target_compile_definitions(commissioner-cli

--- a/src/app/cli/main.cpp
+++ b/src/app/cli/main.cpp
@@ -31,6 +31,8 @@
  *   The file is the entrance of the commissioner CLI.
  */
 
+#include <thread>
+
 #include <signal.h>
 
 #include "app/cli/interpreter.hpp"
@@ -76,30 +78,41 @@ static void PrintVersion()
 }
 
 static Interpreter gInterpreter;
+static sigset_t    gSignalSet;
 
-static void HandleSignalInterrupt(int)
+static void HandleSignalInterrupt()
 {
-    gInterpreter.AbortCommand();
+    int signalNum = 0;
+
+    while (true)
+    {
+        sigwait(&gSignalSet, &signalNum);
+        gInterpreter.AbortCommand();
+    }
 }
 
 int main(int argc, const char *argv[])
 {
-    Error error;
-
+    Error  error;
     Config config;
 
     if (argc < 2 || ToLower(argv[1]) == "-h" || ToLower(argv[1]) == "--help")
     {
         PrintUsage(argv[0]);
-        return 0;
+        ExitNow();
     }
     else if (ToLower(argv[1]) == "-v" || ToLower(argv[1]) == "--version")
     {
         PrintVersion();
-        return 0;
+        ExitNow();
     }
 
-    signal(SIGINT, HandleSignalInterrupt);
+    // Block signals in this thread and subsequently spawned threads.
+    sigemptyset(&gSignalSet);
+    sigaddset(&gSignalSet, SIGINT);
+    pthread_sigmask(SIG_BLOCK, &gSignalSet, nullptr);
+
+    std::thread(HandleSignalInterrupt).detach();
 
     Console::Write(kLogo, Console::Color::kBlue);
 


### PR DESCRIPTION
Synchronization primitives (std::mutex, std::future) in namespace `std` are used to synchronize calls to the commissioner API. Unfortunately, those synchronization primitives are not [signal-safe](https://man7.org/linux/man-pages/man7/signal-safety.7.html) and will result in deadlock.

This PR fixes this by using a dedicated thread to wait for the signal.