### PR TITLE
[cmake] lower minimum cmake version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,11 @@ jobs:
       - uses: actions/checkout@v2
       - name: Bootstrap
         run: |
+          brew unlink cmake
+          brew install cmake@3.10.1
           script/bootstrap.sh
+      - name: CMake version
+          cmake --version
       - name: Build
         run: |
           cmake -G"Unix Makefiles"                \
@@ -148,7 +152,7 @@ jobs:
                 -DCMAKE_BUILD_TYPE=Release                                                          \
                 -DOT_COMM_ANDROID=ON                                                                \
                 -DOT_COMM_APP=OFF                                                                   \
-                -FOT_COMM_TEST=OFF                                                                  \
+                -DOT_COMM_TEST=OFF                                                                  \
                 -S . -B build
           cmake --build build
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,23 +64,33 @@ jobs:
         gcc_ver: [5, 6, 7, 8, 9]
     steps:
       - uses: actions/checkout@v2
+      - name: Install CMake 3.10.1
+        run: |
+          wget https://cmake.org/files/v3.10/cmake-3.10.1.zip
+          unzip cmake-3.10.1
+          cd cmake-3.10.1
+          cmake .
+          make -j4
+          sudo make install
+          cmake --version
       - name: Bootstrap
         run: |
           script/bootstrap.sh
       - name: Build
         run: |
           gcc --version
+          mkdir build && cd build
           cmake -GNinja                           \
                 -DBUILD_SHARED_LIBS=ON            \
                 -DCMAKE_CXX_STANDARD=11           \
                 -DCMAKE_CXX_STANDARD_REQUIRED=ON  \
                 -DCMAKE_BUILD_TYPE=Release        \
                 -DCMAKE_INSTALL_PREFIX=/usr/local \
-                -S . -B build
-          cmake --build build
-          sudo cmake --install build
+                ..
+          ninja
+          sudo ninja install
           commissioner-cli -v
-          ./build/tests/commissioner-test
+          ./tests/commissioner-test
 
   clang-build:
     name: clang-${{ matrix.clang_ver }}
@@ -96,17 +106,18 @@ jobs:
       - name: Build
         run: |
           clang --version
+          mkdir build && cd build
           cmake -GNinja                           \
                 -DBUILD_SHARED_LIBS=ON            \
                 -DCMAKE_CXX_STANDARD=11           \
                 -DCMAKE_CXX_STANDARD_REQUIRED=ON  \
                 -DCMAKE_BUILD_TYPE=Release        \
                 -DCMAKE_INSTALL_PREFIX=/usr/local \
-                -S . -B build
-          cmake --build build
-          sudo cmake --install build
+                ..
+          ninja
+          sudo ninja install
           commissioner-cli -v
-          ./build/tests/commissioner-test
+          ./tests/commissioner-test
 
   macos:
     runs-on: macos-10.15
@@ -114,24 +125,20 @@ jobs:
       - uses: actions/checkout@v2
       - name: Bootstrap
         run: |
-          brew unlink cmake
-          brew install cmake@3.10.1
           script/bootstrap.sh
-      - name: CMake version
-        run: |
-          cmake --version
       - name: Build
         run: |
+          mkdir build && cd build
           cmake -G"Unix Makefiles"                \
                 -DCMAKE_CXX_STANDARD=11           \
                 -DCMAKE_CXX_STANDARD_REQUIRED=ON  \
                 -DCMAKE_BUILD_TYPE=Release        \
                 -DCMAKE_INSTALL_PREFIX=/usr/local \
-                -S . -B build
-          cmake --build build -j2
-          sudo cmake --install build
+                ..
+          make -j2
+          sudo make install
           commissioner-cli -v
-          ./build/tests/commissioner-test
+          ./tests/commissioner-test
 
   android-ndk:
     runs-on: ubuntu-18.04
@@ -142,6 +149,7 @@ jobs:
           script/bootstrap.sh
       - name: Build
         run: |
+          mkdir build && cd build
           cmake -GNinja                                                                             \
                 -DCMAKE_TOOLCHAIN_FILE=$ANDROID_HOME/ndk-bundle/build/cmake/android.toolchain.cmake \
                 -DANDROID_ABI="armeabi-v7a"                                                         \
@@ -154,8 +162,8 @@ jobs:
                 -DOT_COMM_ANDROID=ON                                                                \
                 -DOT_COMM_APP=OFF                                                                   \
                 -DOT_COMM_TEST=OFF                                                                  \
-                -S . -B build
-          cmake --build build
+                ..
+          ninja
 
   java-binding:
     runs-on: macos-10.15
@@ -167,14 +175,15 @@ jobs:
           brew install swig@4
       - name: Build
         run: |
+          mkdir build && cd build
           cmake -GNinja                          \
                 -DBUILD_SHARED_LIBS=ON           \
                 -DCMAKE_CXX_STANDARD=11          \
                 -DCMAKE_CXX_STANDARD_REQUIRED=ON \
                 -DCMAKE_BUILD_TYPE=Release       \
                 -DOT_COMM_JAVA_BINDING=ON        \
-                -S . -B build
-          cmake --build build
+                ..
+          ninja
 
   fmt-format-check:
     runs-on: ubuntu-18.04
@@ -185,11 +194,12 @@ jobs:
           script/bootstrap.sh
       - name: Build
         run: |
+          mkdir build && cd build
           cmake -GNinja                           \
                 -DBUILD_SHARED_LIBS=ON            \
                 -DCMAKE_CXX_STANDARD=14           \
                 -DCMAKE_CXX_STANDARD_REQUIRED=ON  \
                 -DCMAKE_BUILD_TYPE=Release        \
                 -DCMAKE_INSTALL_PREFIX=/usr/local \
-                -S . -B build
-          cmake --build build
+                ..
+          ninja

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,7 @@ jobs:
           brew install cmake@3.10.1
           script/bootstrap.sh
       - name: CMake version
+        run: |
           cmake --version
       - name: Build
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,7 @@ jobs:
           sudo apt-get install avahi-daemon avahi-utils -y
       - name: Build
         run: |
+          mkdir build && cd build
           cmake -GNinja                           \
                 -DCMAKE_CXX_STANDARD=11           \
                 -DCMAKE_CXX_STANDARD_REQUIRED=ON  \
@@ -49,9 +50,9 @@ jobs:
                 -DCMAKE_INSTALL_PREFIX=/usr/local \
                 -DOT_COMM_COVERAGE=ON             \
                 -DOT_COMM_CCM=OFF                 \
-                -S . -B build
-          cmake --build build
-          sudo cmake --install build
+                ..
+          ninja
+          sudo ninja install
           commissioner-cli -v
       - name: Run unittests
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.10.1)
 project(ot-commissioner VERSION 0.1.0)
 
 option(OT_COMM_ANDROID          "Build with Android NDK" OFF)

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -29,7 +29,7 @@
 
 set -e
 
-readonly MIN_CMAKE_VERSION="3.13.1"
+readonly MIN_CMAKE_VERSION="3.10.1"
 
 ## Match the version to see if current version is greater than or euqal to required version.
 ## Args: $1 current version

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -107,7 +107,7 @@ elif [ "$(uname)" = "Darwin" ]; then
     ## Install latest cmake
     match_version "$(cmake --version | grep -E -o '[0-9].*')" "${MIN_CMAKE_VERSION}" || {
         brew unlink cmake
-        brew install cmake --HEAD
+        brew install cmake@3.10.1
     }
 else
     echo "platform $(uname) is not fully supported"

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -107,7 +107,7 @@ elif [ "$(uname)" = "Darwin" ]; then
     ## Install latest cmake
     match_version "$(cmake --version | grep -E -o '[0-9].*')" "${MIN_CMAKE_VERSION}" || {
         brew unlink cmake
-        brew install cmake@3.10.1
+        brew install cmake --HEAD
     }
 else
     echo "platform $(uname) is not fully supported"

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -26,20 +26,17 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-add_library(commissioner-app)
-
-target_sources(commissioner-app
-    PRIVATE
-        commissioner_app.cpp
-        commissioner_app.hpp
-        border_agent.cpp
-        border_agent.hpp
-        file_logger.cpp
-        file_logger.hpp
-        file_util.cpp
-        file_util.hpp
-        json.cpp
-        json.hpp
+add_library(commissioner-app
+    commissioner_app.cpp
+    commissioner_app.hpp
+    border_agent.cpp
+    border_agent.hpp
+    file_logger.cpp
+    file_logger.hpp
+    file_util.cpp
+    file_util.hpp
+    json.cpp
+    json.hpp
 )
 
 target_link_libraries(commissioner-app
@@ -70,25 +67,18 @@ if (BUILD_SHARED_LIBS)
 endif()
 
 if (OT_COMM_TEST)
-    add_library(commissioner-app-test OBJECT)
-
-    target_sources(commissioner-app-test
-        PRIVATE
-            commissioner_app.hpp
-            commissioner_app_test.cpp
-            json.hpp
-            json_test.cpp
+    add_library(commissioner-app-test OBJECT
+        commissioner_app.hpp
+        commissioner_app_test.cpp
+        json.hpp
+        json_test.cpp
     )
 
     target_include_directories(commissioner-app-test
         PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
             ${PROJECT_SOURCE_DIR}/src
-    )
-
-    target_link_libraries(commissioner-app-test
-        PRIVATE
-            Catch2::Catch2
-            commissioner-app
+            ${PROJECT_SOURCE_DIR}/third_party/Catch2/repo/single_include
     )
 endif()
 

--- a/src/app/cli/CMakeLists.txt
+++ b/src/app/cli/CMakeLists.txt
@@ -26,15 +26,12 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-add_executable(commissioner-cli)
-
-target_sources(commissioner-cli
-    PRIVATE
-        console.cpp
-        console.hpp
-        interpreter.cpp
-        interpreter.hpp
-        main.cpp
+add_executable(commissioner-cli
+    console.cpp
+    console.hpp
+    interpreter.cpp
+    interpreter.hpp
+    main.cpp
 )
 
 target_include_directories(commissioner-cli

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -26,18 +26,15 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-add_library(commissioner-common)
-
-target_sources(commissioner-common
-    PRIVATE
-        address.cpp
-        address.hpp
-        error.cpp
-        error_macros.hpp
-        time.cpp
-        time.hpp
-        utils.cpp
-        utils.hpp
+add_library(commissioner-common
+    address.cpp
+    address.hpp
+    error.cpp
+    error_macros.hpp
+    time.cpp
+    time.hpp
+    utils.cpp
+    utils.hpp
 )
 
 target_link_libraries(commissioner-common
@@ -58,24 +55,16 @@ if (BUILD_SHARED_LIBS)
 endif()
 
 if (OT_COMM_TEST)
-    add_library(commissioner-common-test OBJECT)
-
-    target_sources(commissioner-common-test
-        PRIVATE
-            address.hpp
-            address_test.cpp
-            error_test.cpp
+    add_library(commissioner-common-test OBJECT
+        address.hpp
+        address_test.cpp
+        error_test.cpp
     )
 
     target_include_directories(commissioner-common-test
         PRIVATE
             ${PROJECT_SOURCE_DIR}/include
             ${PROJECT_SOURCE_DIR}/src
-    )
-
-    target_link_libraries(commissioner-common-test
-        PRIVATE
-            Catch2::Catch2
-            commissioner-common
+            ${PROJECT_SOURCE_DIR}/third_party/Catch2/repo/single_include
     )
 endif()

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -66,5 +66,6 @@ if (OT_COMM_TEST)
             ${PROJECT_SOURCE_DIR}/include
             ${PROJECT_SOURCE_DIR}/src
             ${PROJECT_SOURCE_DIR}/third_party/Catch2/repo/single_include
+            ${PROJECT_SOURCE_DIR}/third_party/fmtlib/repo/include
     )
 endif()

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -167,7 +167,6 @@ if (OT_COMM_TEST)
             Catch2::Catch2
             $<$<BOOL:${OT_COMM_CCM}>:cn-cbor::cn-cbor>
             $<$<BOOL:${OT_COMM_CCM}>:cose>
-            mdns
             mbedtls
             mbedx509
             mbedcrypto

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -80,7 +80,6 @@ target_link_libraries(commissioner
     PRIVATE
         $<$<BOOL:${OT_COMM_CCM}>:cn-cbor::cn-cbor>
         $<$<BOOL:${OT_COMM_CCM}>:cose>
-        mdns
         mbedtls
         mbedx509
         mbedcrypto
@@ -120,7 +119,7 @@ if (BUILD_SHARED_LIBS)
     install(FILES
             $<$<BOOL:${OT_COMM_CCM}>:$<TARGET_FILE:cn-cbor::cn-cbor>>
             $<$<BOOL:${OT_COMM_CCM}>:$<TARGET_FILE:cose>>
-            $<TARGET_FILE:mdns>
+            $<$<BOOL:${OT_COMM_APP}>:$<TARGET_FILE:mdns>>
             $<TARGET_FILE:mbedtls>
             $<TARGET_FILE:mbedx509>
             $<TARGET_FILE:mbedcrypto>

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -26,54 +26,51 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-add_library(commissioner)
-
-target_sources(commissioner
-    PRIVATE
-        cbor.cpp
-        cbor.hpp
-        coap.cpp
-        coap.hpp
-        coap_secure.hpp
-        commissioner_impl.cpp
-        commissioner_impl.hpp
-        commissioner_safe.cpp
-        commissioner_safe.hpp
-        cose.cpp
-        cose.hpp
-        cwt.hpp
-        dtls.cpp
-        dtls.hpp
-        endpoint.hpp
-        event.hpp
-        joiner_session.cpp
-        joiner_session.hpp
-        logging.cpp
-        logging.hpp
-        mbedtls_error.cpp
-        mbedtls_error.hpp
-        message.hpp
-        network_data.cpp
-        openthread/bloom_filter.cpp
-        openthread/bloom_filter.hpp
-        openthread/crc16.cpp
-        openthread/crc16.hpp
-        openthread/pbkdf2_cmac.cpp
-        openthread/pbkdf2_cmac.hpp
-        openthread/random.cpp
-        openthread/random.hpp
-        openthread/sha256.cpp
-        openthread/sha256.hpp
-        socket.cpp
-        socket.hpp
-        timer.hpp
-        tlv.cpp
-        tlv.hpp
-        token_manager.cpp
-        token_manager.hpp
-        udp_proxy.cpp
-        udp_proxy.hpp
-        uri.hpp
+add_library(commissioner
+    cbor.cpp
+    cbor.hpp
+    coap.cpp
+    coap.hpp
+    coap_secure.hpp
+    commissioner_impl.cpp
+    commissioner_impl.hpp
+    commissioner_safe.cpp
+    commissioner_safe.hpp
+    cose.cpp
+    cose.hpp
+    cwt.hpp
+    dtls.cpp
+    dtls.hpp
+    endpoint.hpp
+    event.hpp
+    joiner_session.cpp
+    joiner_session.hpp
+    logging.cpp
+    logging.hpp
+    mbedtls_error.cpp
+    mbedtls_error.hpp
+    message.hpp
+    network_data.cpp
+    openthread/bloom_filter.cpp
+    openthread/bloom_filter.hpp
+    openthread/crc16.cpp
+    openthread/crc16.hpp
+    openthread/pbkdf2_cmac.cpp
+    openthread/pbkdf2_cmac.hpp
+    openthread/random.cpp
+    openthread/random.hpp
+    openthread/sha256.cpp
+    openthread/sha256.hpp
+    socket.cpp
+    socket.hpp
+    timer.hpp
+    tlv.cpp
+    tlv.hpp
+    token_manager.cpp
+    token_manager.hpp
+    udp_proxy.cpp
+    udp_proxy.hpp
+    uri.hpp
 )
 
 target_link_libraries(commissioner
@@ -138,28 +135,25 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/commissioner
 )
 
 if (OT_COMM_TEST)
-    add_executable(commissioner-test)
-
-    target_sources(commissioner-test
-        PRIVATE
-            coap_secure.hpp
-            coap_secure_test.cpp
-            coap.hpp
-            coap_test.cpp
-            commissioner_impl.hpp
-            commissioner_impl_test.cpp
-            commissioner_safe.hpp
-            commissioner_safe_test.cpp
-            cose.hpp
-            cose_test.cpp
-            dtls.hpp
-            dtls_test.cpp
-            socket.hpp
-            socket_test.cpp
-            token_manager.hpp
-            token_manager_test.cpp
-            $<$<BOOL:${OT_COMM_APP}>:$<TARGET_OBJECTS:commissioner-app-test>>
-            $<TARGET_OBJECTS:commissioner-common-test>
+    add_executable(commissioner-test
+        coap_secure.hpp
+        coap_secure_test.cpp
+        coap.hpp
+        coap_test.cpp
+        commissioner_impl.hpp
+        commissioner_impl_test.cpp
+        commissioner_safe.hpp
+        commissioner_safe_test.cpp
+        cose.hpp
+        cose_test.cpp
+        dtls.hpp
+        dtls_test.cpp
+        socket.hpp
+        socket_test.cpp
+        token_manager.hpp
+        token_manager_test.cpp
+        $<$<BOOL:${OT_COMM_APP}>:$<TARGET_OBJECTS:commissioner-app-test>>
+        $<TARGET_OBJECTS:commissioner-common-test>
     )
 
     target_link_libraries(commissioner-test

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -26,7 +26,9 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-add_subdirectory(Catch2/repo)
+if (OT_COMM_TEST)
+    add_subdirectory(Catch2/repo)
+endif()
 
 if (OT_COMM_CCM)
     set(CN_CBOR_FATAL_WARNINGS OFF CACHE BOOL "Disable -Werror and /W4")
@@ -38,9 +40,15 @@ if (OT_COMM_CCM)
 endif()
 
 add_subdirectory(fmtlib/repo)
-add_subdirectory(json/repo)
+
+if (OT_COMM_APP)
+    add_subdirectory(json/repo)
+endif()
 
 add_subdirectory(libevent)
 
 add_subdirectory(mbedtls)
-add_subdirectory(mdns/repo)
+
+if (OT_COMM_APP)
+    add_subdirectory(mdns/repo)
+endif()


### PR DESCRIPTION
This PR
1. changes the minimum required CMake version from `3.13.1` to `3.10.1` since many platforms (ubuntu, android studio) have 3.10.X as the default CMake version
2. submodule `mdns` is updated to support this change
3. avoid inclusion of unnecessary third parties