### PR TITLE
[java] output generated java source files to given directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ option(OT_COMM_APP              "Build the CLI App" ON)
 option(OT_COMM_CCM              "Build with Commercial Commissioning Mode" ON)
 option(OT_COMM_COVERAGE         "Enable coverage reporting" OFF)
 option(OT_COMM_JAVA_BINDING     "Build Java binding" OFF)
+set(OT_COMM_JAVA_BINDING_OUTDIR "" CACHE STRING "Specify output directory of generated Java source files")
 option(OT_COMM_TEST             "Build tests" ON)
 
 if (NOT CMAKE_BUILD_TYPE)

--- a/src/java/CMakeLists.txt
+++ b/src/java/CMakeLists.txt
@@ -40,7 +40,7 @@ endif()
 include(UseSWIG)
 include(UseJava)
 
-set(CMAKE_SWIG_OUTDIR ${CMAKE_CURRENT_SOURCE_DIR}/io/openthread/commissioner)
+set(CMAKE_SWIG_OUTDIR ${CMAKE_CURRENT_BINARY_DIR}/io/openthread/commissioner)
 
 list(APPEND CMAKE_SWIG_FLAGS "-package;${JAVA_PACKAGE_NAME}")
 
@@ -70,3 +70,14 @@ target_compile_options(commissioner-java
 install(TARGETS commissioner-java
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
+
+## It is useful that the output directory can be configured when
+## OT commissioner is integrated with an existing Android application.
+if (OT_COMM_JAVA_BINDING_OUTDIR)
+    add_custom_command(TARGET commissioner-java POST_BUILD
+        COMMAND mkdir -p ${OT_COMM_JAVA_BINDING_OUTDIR}/io/openthread/commissioner
+        COMMAND cp io/openthread/commissioner/*.java ${OT_COMM_JAVA_BINDING_OUTDIR}/io/openthread/commissioner
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMENT "packing generated Java source files..."
+    )
+endif()


### PR DESCRIPTION
This PR adds a new option `OT_COMM_JAVA_BINDING_OUTDIR` to allow the user specify the output directory of auto-generated java files. This eases integration with Android applications.
