### PR TITLE
[tests] add CCM tests

### DIFF
--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -780,9 +780,6 @@ Error CommissionerApp::GetTriHostname(std::string &aHostname) const
 {
     Error error;
 
-    VerifyOrExit(IsActive(), error = ERROR_INVALID_STATE("the commissioner is not active"));
-    VerifyOrExit(IsCcmMode(), error = ERROR_INVALID_STATE("the commissioner is not in CCM Mode"));
-
     VerifyOrExit(mBbrDataset.mPresentFlags & BbrDataset::kTriHostnameBit,
                  error = ERROR_NOT_FOUND("cannot find valid TRI Hostname in BBR Dataset"));
     aHostname = mBbrDataset.mTriHostname;
@@ -795,9 +792,6 @@ Error CommissionerApp::SetTriHostname(const std::string &aHostname)
 {
     Error      error;
     BbrDataset bbrDataset;
-
-    VerifyOrExit(IsActive(), error = ERROR_INVALID_STATE("the commissioner is not active"));
-    VerifyOrExit(IsCcmMode(), error = ERROR_INVALID_STATE("the commissioner is not in CCM Mode"));
 
     bbrDataset.mTriHostname = aHostname;
     bbrDataset.mPresentFlags |= BbrDataset::kTriHostnameBit;
@@ -814,9 +808,6 @@ Error CommissionerApp::GetRegistrarHostname(std::string &aHostname) const
 {
     Error error;
 
-    VerifyOrExit(IsActive(), error = ERROR_INVALID_STATE("the commissioner is not active"));
-    VerifyOrExit(IsCcmMode(), error = ERROR_INVALID_STATE("the commissioner is not in CCM Mode"));
-
     VerifyOrExit(mBbrDataset.mPresentFlags & BbrDataset::kRegistrarHostnameBit,
                  error = ERROR_NOT_FOUND("cannot find valid Registrar Hostname in BBR Dataset"));
     aHostname = mBbrDataset.mRegistrarHostname;
@@ -829,9 +820,6 @@ Error CommissionerApp::SetRegistrarHostname(const std::string &aHostname)
 {
     Error      error;
     BbrDataset bbrDataset;
-
-    VerifyOrExit(IsActive(), error = ERROR_INVALID_STATE("the commissioner is not active"));
-    VerifyOrExit(IsCcmMode(), error = ERROR_INVALID_STATE("the commissioner is not in CCM Mode"));
 
     bbrDataset.mRegistrarHostname = aHostname;
     bbrDataset.mPresentFlags |= BbrDataset::kRegistrarHostnameBit;
@@ -847,9 +835,6 @@ exit:
 Error CommissionerApp::GetRegistrarIpv6Addr(std::string &aIpv6Addr) const
 {
     Error error;
-
-    VerifyOrExit(IsActive(), error = ERROR_INVALID_STATE("the commissioner is not active"));
-    VerifyOrExit(IsCcmMode(), error = ERROR_INVALID_STATE("the commissioner is not in CCM Mode"));
 
     VerifyOrExit(mBbrDataset.mPresentFlags & BbrDataset::kRegistrarIpv6AddrBit,
                  error = ERROR_NOT_FOUND("cannot find valid Registrar IPv6 Address in BBR Dataset"));

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -883,15 +883,7 @@ exit:
 
 Error CommissionerApp::Reenroll(const std::string &aDstAddr)
 {
-    Error error;
-
-    VerifyOrExit(IsActive(), error = ERROR_INVALID_STATE("the commissioner is not active"));
-    VerifyOrExit(IsCcmMode(), error = ERROR_INVALID_STATE("the commissioner is not in CCM Mode"));
-
-    SuccessOrExit(error = mCommissioner->CommandReenroll(aDstAddr));
-
-exit:
-    return error;
+    return mCommissioner->CommandReenroll(aDstAddr);
 }
 
 Error CommissionerApp::DomainReset(const std::string &aDstAddr)

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -888,28 +888,12 @@ Error CommissionerApp::Reenroll(const std::string &aDstAddr)
 
 Error CommissionerApp::DomainReset(const std::string &aDstAddr)
 {
-    Error error;
-
-    VerifyOrExit(IsActive(), error = ERROR_INVALID_STATE("the commissioner is not active"));
-    VerifyOrExit(IsCcmMode(), error = ERROR_INVALID_STATE("the commissioner is not in CCM Mode"));
-
-    SuccessOrExit(error = mCommissioner->CommandDomainReset(aDstAddr));
-
-exit:
-    return error;
+    return mCommissioner->CommandDomainReset(aDstAddr);
 }
 
 Error CommissionerApp::Migrate(const std::string &aDstAddr, const std::string &aDesignatedNetwork)
 {
-    Error error;
-
-    VerifyOrExit(IsActive(), error = ERROR_INVALID_STATE("the commissioner is not active"));
-    VerifyOrExit(IsCcmMode(), error = ERROR_INVALID_STATE("the commissioner is not in CCM Mode"));
-
-    SuccessOrExit(error = mCommissioner->CommandMigrate(aDstAddr, aDesignatedNetwork));
-
-exit:
-    return error;
+    return mCommissioner->CommandMigrate(aDstAddr, aDesignatedNetwork);
 }
 
 Error CommissionerApp::RegisterMulticastListener(const std::vector<std::string> &aMulticastAddrList, Seconds aTimeout)

--- a/src/app/commissioner_app.hpp
+++ b/src/app/commissioner_app.hpp
@@ -226,11 +226,16 @@ public:
     Error SetBbrDataset(const BbrDataset &aDataset);
 
     /*
-     * Command APIs
+     * Commercial Commissioning features
      */
-    Error Reenroll(const std::string &aDstAddr);
-    Error DomainReset(const std::string &aDstAddr);
-    Error Migrate(const std::string &aDstAddr, const std::string &aDesignatedNetwork);
+
+    Error            Reenroll(const std::string &aDstAddr);
+    Error            DomainReset(const std::string &aDstAddr);
+    Error            Migrate(const std::string &aDstAddr, const std::string &aDesignatedNetwork);
+    const ByteArray &GetToken() const;
+    Error            RequestToken(const std::string &aAddr, uint16_t aPort);
+    Error            SetToken(const ByteArray &aSignedToken, const ByteArray &aSignerCert);
+
     Error RegisterMulticastListener(const std::vector<std::string> &aMulticastAddrList, Seconds aTimeout);
     Error AnnounceBegin(uint32_t aChannelMask, uint8_t aCount, MilliSeconds aPeriod, const std::string &aDtsAddr);
     Error PanIdQuery(uint32_t aChannelMask, uint16_t aPanId, const std::string &aDstAddr);
@@ -243,15 +248,8 @@ public:
     const EnergyReport *   GetEnergyReport(const Address &aDstAddr) const;
     const EnergyReportMap &GetAllEnergyReports() const;
 
-    /*
-     * Others
-     */
-    // Get current domain name.
     const std::string &GetDomainName() const;
     Error              GetPrimaryBbrAddr(std::string &aAddr);
-    const ByteArray &  GetToken() const;
-    Error              RequestToken(const std::string &aAddr, uint16_t aPort);
-    Error              SetToken(const ByteArray &aSignedToken, const ByteArray &aSignerCert);
 
 private:
     CommissionerApp() = default;

--- a/src/library/commissioner_impl.hpp
+++ b/src/library/commissioner_impl.hpp
@@ -126,26 +126,6 @@ public:
     void  SetPendingDataset(ErrorHandler aHandler, const PendingOperationalDataset &aPendingDataset) override;
     Error SetPendingDataset(const PendingOperationalDataset &) override { return ERROR_UNIMPLEMENTED(""); }
 
-    void  SetSecurePendingDataset(ErrorHandler                     aHandler,
-                                  const std::string &              aPbbrAddr,
-                                  uint32_t                         aMaxRetrievalTimer,
-                                  const PendingOperationalDataset &aDataset) override;
-    Error SetSecurePendingDataset(const std::string &, uint32_t, const PendingOperationalDataset &) override
-    {
-        return ERROR_UNIMPLEMENTED("");
-    }
-
-    void  CommandReenroll(ErrorHandler aHandler, const std::string &aDstAddr) override;
-    Error CommandReenroll(const std::string &) override { return ERROR_UNIMPLEMENTED(""); }
-
-    void  CommandDomainReset(ErrorHandler aHandler, const std::string &aDstAddr) override;
-    Error CommandDomainReset(const std::string &) override { return ERROR_UNIMPLEMENTED(""); }
-
-    void  CommandMigrate(ErrorHandler       aHandler,
-                         const std::string &aDstAddr,
-                         const std::string &aDstNetworkName) override;
-    Error CommandMigrate(const std::string &, const std::string &) override { return ERROR_UNIMPLEMENTED(""); }
-
     void  RegisterMulticastListener(Handler<uint8_t>                aHandler,
                                     const std::string &             aPbbrAddr,
                                     const std::vector<std::string> &aMulticastAddrList,
@@ -178,6 +158,28 @@ public:
     {
         return ERROR_UNIMPLEMENTED("");
     }
+
+    // Commercial Commissioning features.
+
+    void  SetSecurePendingDataset(ErrorHandler                     aHandler,
+                                  const std::string &              aPbbrAddr,
+                                  uint32_t                         aMaxRetrievalTimer,
+                                  const PendingOperationalDataset &aDataset) override;
+    Error SetSecurePendingDataset(const std::string &, uint32_t, const PendingOperationalDataset &) override
+    {
+        return ERROR_UNIMPLEMENTED("");
+    }
+
+    void  CommandReenroll(ErrorHandler aHandler, const std::string &aDstAddr) override;
+    Error CommandReenroll(const std::string &) override { return ERROR_UNIMPLEMENTED(""); }
+
+    void  CommandDomainReset(ErrorHandler aHandler, const std::string &aDstAddr) override;
+    Error CommandDomainReset(const std::string &) override { return ERROR_UNIMPLEMENTED(""); }
+
+    void  CommandMigrate(ErrorHandler       aHandler,
+                         const std::string &aDstAddr,
+                         const std::string &aDstNetworkName) override;
+    Error CommandMigrate(const std::string &, const std::string &) override { return ERROR_UNIMPLEMENTED(""); }
 
     void  RequestToken(Handler<ByteArray> aHandler, const std::string &aAddr, uint16_t aPort) override;
     Error RequestToken(ByteArray &, const std::string &, uint16_t) override { return ERROR_UNIMPLEMENTED(""); }

--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -139,7 +139,11 @@ stop_commissioner() {
 }
 
 ## Send command to commissioner.
-## Args: $1: the command.
+## Args:
+##   $1: the command.
+##   $2: the expected error (optional). The command
+##       is expected to success if this argument is
+##       not specified.
 send_command_to_commissioner() {
     set -e
     local command=$1
@@ -149,7 +153,11 @@ send_command_to_commissioner() {
     echo "${result}"
     [ -n "${result}" ] || return 1
 
-    echo "${result}" | grep -q "\[done\]" || return 1
+    if [ -z "${expect_error}" ]; then
+        echo "${result}" | grep -q "\[done\]" || return 1
+    else
+        echo "${result}" | grep -q "${expect_error}" || return 1
+    fi
 }
 
 ## Start a joiner

--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -53,8 +53,8 @@ readonly COMMISSIONER_CTL=/usr/local/bin/commissioner_ctl.py
 readonly COMMISSIONER_DAEMON_LOG=${RUNTIME_DIR}/commissioner-daemon.log
 readonly COMMISSIONER_LOG=./commissioner.log
 
-readonly CCM_TOKEN=/usr/local/etc/commissioner/token.hex
-readonly CCM_CA_CERT=/usr/local/etc/commissioner/trust-anchor.pem
+readonly CCM_TOKEN=/usr/local/etc/commissioner/credentials/token.hex
+readonly CCM_CA_CERT=/usr/local/etc/commissioner/credentials/trust-anchor.pem
 readonly NON_CCM_CONFIG=/usr/local/etc/commissioner/non-ccm-config.json
 
 readonly JOINER_NODE_ID=2

--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -147,6 +147,7 @@ stop_commissioner() {
 send_command_to_commissioner() {
     set -e
     local command=$1
+    local expect_error=$2
     local result
     result=$(${COMMISSIONER_CTL} execute "${command}")
 

--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -53,7 +53,9 @@ readonly COMMISSIONER_CTL=/usr/local/bin/commissioner_ctl.py
 readonly COMMISSIONER_DAEMON_LOG=${RUNTIME_DIR}/commissioner-daemon.log
 readonly COMMISSIONER_LOG=./commissioner.log
 
-readonly NON_CCM_CONFIG=${TEST_ROOT_DIR}/../../src/app/etc/commissioner/non-ccm-config.json
+readonly CCM_TOKEN=/usr/local/etc/commissioner/token.hex
+readonly CCM_CA_CERT=/usr/local/etc/commissioner/trust-anchor.pem
+readonly NON_CCM_CONFIG=/usr/local/etc/commissioner/non-ccm-config.json
 
 readonly JOINER_NODE_ID=2
 readonly JOINER_EUI64=0x18b4300000000002
@@ -132,6 +134,7 @@ init_commissioner() {
 ## Stop commissioner
 stop_commissioner() {
     set -e
+    send_command_to_commissioner "stop"
     ${COMMISSIONER_CTL} exit || true
 }
 

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -38,6 +38,7 @@
 ##
 
 . "$(dirname "$0")"/test_announce_begin.sh
+. "$(dirname "$0")"/test_ccm.sh
 . "$(dirname "$0")"/test_cli.sh
 . "$(dirname "$0")"/test_discover.sh
 . "$(dirname "$0")"/test_energy_scan.sh

--- a/tests/integration/test_ccm.sh
+++ b/tests/integration/test_ccm.sh
@@ -51,13 +51,15 @@ test_ccm_bbr_dataset()
     start_commissioner "${NON_CCM_CONFIG}"
 
     ## Expect UNIMPLEMENTED error since we turned off CCM features in integration tests.
-    send_command_to_commissioner "bbrdataset get trihostname" "UNIMPLEMENTED"
     send_command_to_commissioner "bbrdataset set trihostname [fdaa:bb::de6]" "UNIMPLEMENTED"
-    send_command_to_commissioner "bbrdataset get reghostname" "UNIMPLEMENTED"
     send_command_to_commissioner "bbrdataset set reghostname [fdaa:bb::de6]" "UNIMPLEMENTED"
-    send_command_to_commissioner "bbrdataset get regaddr" "UNIMPLEMENTED"
-    send_command_to_commissioner "bbrdataset get" "UNIMPLEMENTED"
     send_command_to_commissioner "bbrdataset set '{\"trihostname\":\"[fdaa:bb::de6]\"}'" "UNIMPLEMENTED"
+    send_command_to_commissioner "bbrdataset get" "UNIMPLEMENTED"
+
+    send_command_to_commissioner "bbrdataset get trihostname" "NOT_FOUND"
+    send_command_to_commissioner "bbrdataset get reghostname" "NOT_FOUND"
+    send_command_to_commissioner "bbrdataset get regaddr" "NOT_FOUND"
+
     send_command_to_commissioner "bbrdataset invalid-command" "INVALID_COMMAND"
 
     stop_commissioner

--- a/tests/integration/test_ccm.sh
+++ b/tests/integration/test_ccm.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+#
+#  Copyright (c) 2020, The OpenThread Commissioner Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+[ -z "${TEST_ROOT_DIR}" ] && . "$(dirname "$0")"/common.sh
+
+test_ccm_token()
+{
+    set -e
+
+    start_commissioner "${NON_CCM_CONFIG}"
+
+    ## Expect UNIMPLEMENTED error since we turned off CCM features in integration tests.
+    send_command_to_commissioner "token request :: 5684" "UNIMPLEMENTED"
+    send_command_to_commissioner "token print" "NOT_FOUND"
+    send_command_to_commissioner "token set ${CCM_TOKEN} ${CCM_CA_CERT}" "UNIMPLEMENTED"
+    send_command_to_commissioner "token invalid-command" "INVALID_COMMAND"
+
+    stop_commissioner
+}
+
+test_ccm_bbr_dataset()
+{
+    set -e
+
+    start_commissioner "${NON_CCM_CONFIG}"
+
+    ## Expect UNIMPLEMENTED error since we turned off CCM features in integration tests.
+    send_command_to_commissioner "bbrdataset get trihostname" "UNIMPLEMENTED"
+    send_command_to_commissioner "bbrdataset set trihostname [fdaa:bb::de6]" "UNIMPLEMENTED"
+    send_command_to_commissioner "bbrdataset get reghostname" "UNIMPLEMENTED"
+    send_command_to_commissioner "bbrdataset set reghostname [fdaa:bb::de6]" "UNIMPLEMENTED"
+    send_command_to_commissioner "bbrdataset get regaddr" "UNIMPLEMENTED"
+    send_command_to_commissioner "bbrdataset get" "UNIMPLEMENTED"
+    send_command_to_commissioner "bbrdataset set '{\"trihostname\":\"[fdaa:bb::de6]\"}'" "UNIMPLEMENTED"
+    send_command_to_commissioner "bbrdataset invalid-command" "INVALID_COMMAND"
+
+    stop_commissioner
+}
+
+test_ccm_reenroll()
+{
+    set -e
+
+    start_commissioner "${NON_CCM_CONFIG}"
+
+    ## Expect UNIMPLEMENTED error since we turned off CCM features in integration tests.
+    send_command_to_commissioner "reenroll fdde:ad00:beef:0:0:ff:fe00:fc00" "UNIMPLEMENTED"
+    send_command_to_commissioner "reenroll invalid-command" "INVALID_COMMAND"
+
+    stop_commissioner
+}
+
+test_ccm_domainreset()
+{
+    set -e
+
+    start_commissioner "${NON_CCM_CONFIG}"
+
+    ## Expect UNIMPLEMENTED error since we turned off CCM features in integration tests.
+    send_command_to_commissioner "domainreset fdde:ad00:beef:0:0:ff:fe00:fc00" "UNIMPLEMENTED"
+    send_command_to_commissioner "domainreset invalid-command" "INVALID_COMMAND"
+
+    stop_commissioner
+}
+
+test_ccm_migrate()
+{
+    set -e
+
+    start_commissioner "${NON_CCM_CONFIG}"
+
+    ## Expect UNIMPLEMENTED error since we turned off CCM features in integration tests.
+    send_command_to_commissioner "migrate fdde:ad00:beef:0:0:ff:fe00:fc00 second-net" "UNIMPLEMENTED"
+    send_command_to_commissioner "migrate invalid-command" "INVALID_COMMAND"
+
+    stop_commissioner
+}

--- a/tests/integration/test_ccm.sh
+++ b/tests/integration/test_ccm.sh
@@ -71,7 +71,6 @@ test_ccm_reenroll()
 
     ## Expect UNIMPLEMENTED error since we turned off CCM features in integration tests.
     send_command_to_commissioner "reenroll fdde:ad00:beef:0:0:ff:fe00:fc00" "UNIMPLEMENTED"
-    send_command_to_commissioner "reenroll invalid-command" "INVALID_COMMAND"
 
     stop_commissioner
 }
@@ -84,7 +83,6 @@ test_ccm_domainreset()
 
     ## Expect UNIMPLEMENTED error since we turned off CCM features in integration tests.
     send_command_to_commissioner "domainreset fdde:ad00:beef:0:0:ff:fe00:fc00" "UNIMPLEMENTED"
-    send_command_to_commissioner "domainreset invalid-command" "INVALID_COMMAND"
 
     stop_commissioner
 }
@@ -97,7 +95,6 @@ test_ccm_migrate()
 
     ## Expect UNIMPLEMENTED error since we turned off CCM features in integration tests.
     send_command_to_commissioner "migrate fdde:ad00:beef:0:0:ff:fe00:fc00 second-net" "UNIMPLEMENTED"
-    send_command_to_commissioner "migrate invalid-command" "INVALID_COMMAND"
 
     stop_commissioner
 }


### PR DESCRIPTION
This PR increases code coverage of CLI application:
1. Add CCM tests to cover CLI commands.
2. group CCM features together.
3. remove duplicate error checking in commissioner_app.