### PR TITLE
[active-dataset] returns raw Active Operational Dataset TLVs

### DIFF
--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -641,7 +641,7 @@ public:
      * It always returns immediately without waiting for the completion.
      *
      * @param[in, out] aHandler       A handler of the response and errors; Guaranteed to be called.
-     * @param[in]      aDatasetFlags  Active Operational Dataset flags indicate which TLVs are wanted.
+     * @param[in]      aDatasetFlags  Active Operational Dataset flags indicating which TLVs are wanted.
      */
     virtual void GetRawActiveDataset(Handler<ByteArray> aHandler, uint16_t aDatasetFlags) = 0;
 

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -632,6 +632,36 @@ public:
     virtual Error GetActiveDataset(ActiveOperationalDataset &aDataset, uint16_t aDatasetFlags) = 0;
 
     /**
+     * @brief Asynchronously get the raw Active Operational Dataset as a binary blob (in format of Thread TLV).
+     *
+     * Get the uninterpreted Active Operational Dataset in MGMT_ACTIVE_GET.rsp.
+     *
+     * This method request Active Operational Dataset of the Thread network
+     * by sending MGMT_ACTIVE_GET.req message.
+     * It always returns immediately without waiting for the completion.
+     *
+     * @param[in, out] aHandler       A handler of the response and errors; Guaranteed to be called.
+     * @param[in]      aDatasetFlags  Active Operational Dataset flags indicate which TLVs are wanted.
+     */
+    virtual void GetRawActiveDataset(Handler<ByteArray> aHandler, uint16_t aDatasetFlags) = 0;
+
+    /**
+     * @brief Synchronously get the raw Active Operational Dataset as a binary blob (in format of Thread TLV).
+     *
+     * Get the uninterpreted Active Operational Dataset in MGMT_ACTIVE_GET.rsp.
+     *
+     * This method request Active Operational Dataset of the Thread network
+     * by sending MGMT_ACTIVE_GET.req message.
+     * It will not return until errors happened, timeouted or succeed.
+     *
+     * @param[out] aDataset       A Active Operational Dataset returned by the leader.
+     * @param[in]  aDatasetFlags  Active Operational Dataset flags indicate which TLVs are wanted.
+     *
+     * @return Error::kNone, succeed; otherwise, failed;
+     */
+    virtual Error GetRawActiveDataset(ByteArray &aRawDataset, uint16_t aDatasetFlags) = 0;
+
+    /**
      * @brief Asynchronously set the Active Operational Dataset.
      *
      * This method set Active Operational Dataset of the Thread network

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -636,7 +636,7 @@ public:
      *
      * Get the uninterpreted Active Operational Dataset in MGMT_ACTIVE_GET.rsp.
      *
-     * This method request Active Operational Dataset of the Thread network
+     * This method requests Active Operational Dataset of the Thread network
      * by sending MGMT_ACTIVE_GET.req message.
      * It always returns immediately without waiting for the completion.
      *

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -650,7 +650,7 @@ public:
      *
      * Get the uninterpreted Active Operational Dataset in MGMT_ACTIVE_GET.rsp.
      *
-     * This method request Active Operational Dataset of the Thread network
+     * This method requests Active Operational Dataset of the Thread network
      * by sending MGMT_ACTIVE_GET.req message.
      * It will not return until errors happened, timeouted or succeed.
      *

--- a/include/commissioner/network_data.hpp
+++ b/include/commissioner/network_data.hpp
@@ -219,14 +219,6 @@ struct ActiveOperationalDataset
     SecurityPolicy mSecurityPolicy;
 
     /**
-     * The raw bytes represent the original Active Operational Dataset in Thread
-     * Network Data.
-     *
-     * This fields should be read-only.
-     */
-    ByteArray mRawTlvs;
-
-    /**
      * Indicates which fields are included in the dataset.
      */
     uint16_t mPresentFlags;

--- a/include/commissioner/network_data.hpp
+++ b/include/commissioner/network_data.hpp
@@ -219,6 +219,14 @@ struct ActiveOperationalDataset
     SecurityPolicy mSecurityPolicy;
 
     /**
+     * The raw bytes represent the original Active Operational Dataset in Thread
+     * Network Data.
+     *
+     * This fields should be read-only.
+     */
+    ByteArray mRawTlvs;
+
+    /**
      * Indicates which fields are included in the dataset.
      */
     uint16_t mPresentFlags;

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1510,7 +1510,8 @@ Error CommissionerImpl::DecodeActiveOperationalDataset(ActiveOperationalDataset 
         dataset.mPresentFlags |= ActiveOperationalDataset::kSecurityPolicyBit;
     }
 
-    aDataset = dataset;
+    dataset.mRawTlvs = aResponse.GetPayload();
+    aDataset         = dataset;
 
 exit:
     return error;

--- a/src/library/commissioner_impl.hpp
+++ b/src/library/commissioner_impl.hpp
@@ -117,6 +117,9 @@ public:
     void  GetActiveDataset(Handler<ActiveOperationalDataset> aHandler, uint16_t aDatasetFlags) override;
     Error GetActiveDataset(ActiveOperationalDataset &, uint16_t) override { return ERROR_UNIMPLEMENTED(""); }
 
+    void  GetRawActiveDataset(Handler<ByteArray> aHandler, uint16_t aDatasetFlags) override;
+    Error GetRawActiveDataset(ByteArray &, uint16_t) override { return ERROR_UNIMPLEMENTED(""); }
+
     void  SetActiveDataset(ErrorHandler aHandler, const ActiveOperationalDataset &aActiveDataset) override;
     Error SetActiveDataset(const ActiveOperationalDataset &) override { return ERROR_UNIMPLEMENTED(""); }
 
@@ -199,7 +202,7 @@ private:
     static ByteArray GetActiveOperationalDatasetTlvs(uint16_t aDatasetFlags);
     static ByteArray GetPendingOperationalDatasetTlvs(uint16_t aDatasetFlags);
 
-    static Error DecodeActiveOperationalDataset(ActiveOperationalDataset &aDataset, const coap::Response &aResponse);
+    static Error DecodeActiveOperationalDataset(ActiveOperationalDataset &aDataset, const ByteArray &aPayload);
     static Error DecodePendingOperationalDataset(PendingOperationalDataset &aDataset, const coap::Response &aResponse);
     static Error DecodeChannelMask(ChannelMask &aChannelMask, const ByteArray &aBuf);
     static Error EncodeActiveOperationalDataset(coap::Request &aRequest, const ActiveOperationalDataset &aDataset);

--- a/src/library/commissioner_safe.cpp
+++ b/src/library/commissioner_safe.cpp
@@ -296,6 +296,26 @@ Error CommissionerSafe::GetActiveDataset(ActiveOperationalDataset &aDataset, uin
     return pro.get_future().get();
 }
 
+void CommissionerSafe::GetRawActiveDataset(Handler<ByteArray> aHandler, uint16_t aDatasetFlags)
+{
+    PushAsyncRequest([=]() { mImpl->GetRawActiveDataset(aHandler, aDatasetFlags); });
+}
+
+Error CommissionerSafe::GetRawActiveDataset(ByteArray &aRawDataset, uint16_t aDatasetFlags)
+{
+    std::promise<Error> pro;
+    auto                wait = [&pro, &aRawDataset](const ByteArray *rawDataset, Error error) {
+        if (rawDataset != nullptr)
+        {
+            aRawDataset = *rawDataset;
+        }
+        pro.set_value(error);
+    };
+
+    GetRawActiveDataset(wait, aDatasetFlags);
+    return pro.get_future().get();
+}
+
 void CommissionerSafe::SetActiveDataset(ErrorHandler aHandler, const ActiveOperationalDataset &aDataset)
 {
     PushAsyncRequest([=]() { mImpl->SetActiveDataset(aHandler, aDataset); });

--- a/src/library/commissioner_safe.hpp
+++ b/src/library/commissioner_safe.hpp
@@ -118,6 +118,9 @@ public:
     void  GetActiveDataset(Handler<ActiveOperationalDataset> aHandler, uint16_t aDatasetFlags) override;
     Error GetActiveDataset(ActiveOperationalDataset &aDataset, uint16_t aDatasetFlags) override;
 
+    void  GetRawActiveDataset(Handler<ByteArray> aHandler, uint16_t aDatasetFlags) override;
+    Error GetRawActiveDataset(ByteArray &aRawDataset, uint16_t aDatasetFlags) override;
+
     void  SetActiveDataset(ErrorHandler aHandler, const ActiveOperationalDataset &aDataset) override;
     Error SetActiveDataset(const ActiveOperationalDataset &aDataset) override;
 


### PR DESCRIPTION
Parsing the Active Operational Dataset into `struct ActiveOperationalDataset` is for manipulating each field of the dataset and the commissioner app doesn't need to write a decoder by their own. But the commissioner app may store or transfer Active Operational Dataset as a byte array. It would be convenient to have the raw TLV format of the dataset so that the commissioner app doesn't need to write an encoder by their own.

This PR adds a new APIs (`GetRawActiveDataset(...)`) to return raw Active Operational Dataset.