### PR TITLE
[doc] remove build & configuration instructions from CLI readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To learn more about OpenThread, visit [openthread.io](https://openthread.io).
 
 ## Getting started
 
-See [OT Commissioner guides](https://openthread.io/guides/commissioner) to get started. Reference to [OT Commissioner CLI document](src/app/cli/README.md) for all CLI commands.
+See [OT Commissioner guide](https://openthread.io/guides/commissioner) to get started. Reference to [OT Commissioner CLI documentation](src/app/cli/README.md) for all CLI commands.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To learn more about OpenThread, visit [openthread.io](https://openthread.io).
 
 ## Getting started
 
-See [OT Commissioner guide](https://openthread.io/guides/commissioner) to get started. Reference to [OT Commissioner CLI documentation](src/app/cli/README.md) for all CLI commands.
+See [OT Commissioner guide](https://openthread.io/guides/commissioner) to get started. See OT [Commissioner CLI documentation](src/app/cli/README.md) for a reference of all CLI commands.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To learn more about OpenThread, visit [openthread.io](https://openthread.io).
 
 ## Getting started
 
-See [OT Commissioner CLI](src/app/cli/README.md) to get started.
+See [OT Commissioner guides](https://openthread.io/guides/commissioner) to get started. Reference to [OT Commissioner CLI document](src/app/cli/README.md) for all CLI commands.
 
 ## Contributing
 

--- a/src/app/cli/README.md
+++ b/src/app/cli/README.md
@@ -8,8 +8,10 @@ Use the OT Commissioner CLI to configure and manage OT Commissioner.
 ot-commissioner $ ./script/bootstrap.sh
 ot-commissioner $ mkdir build && cd build
 build $ cmake -GNinja -DCMAKE_BUILD_TYPE=Release ..
-build $ ninja -j16
+build $ ninja
 ```
+
+_Note: For Raspberry Pi, please build with `ninja -j1` to avoid memory exhaustion._
 
 ## Configuration
 

--- a/src/app/cli/README.md
+++ b/src/app/cli/README.md
@@ -2,39 +2,9 @@
 
 Use the OT Commissioner CLI to configure and manage OT Commissioner.
 
-## Build
+## Build & Configuration
 
-```shell
-ot-commissioner $ ./script/bootstrap.sh
-ot-commissioner $ mkdir build && cd build
-build $ cmake -GNinja -DCMAKE_BUILD_TYPE=Release ..
-build $ ninja
-```
-
-_Note: For Raspberry Pi, please build with `ninja -j1` to avoid memory exhaustion._
-
-## Configuration
-
-OT Commissioner requires a JSON configuration file. There are two configuration templates to choose from:
-
-- Commercial Commissioning Mode (CCM) — [src/app/etc/commissioner/ccm-config.json](../etc/commissioner/ccm-config.json)
-- Non-CCM — [src/app/etc/commissioner/non-ccm-config.json](../etc/commissioner/non-ccm-config.json)
-
-Make a copy of your desired configuration file and modify it as needed for your system.
-
-For the CCM configuration file, you need to change `DomainName` to the Thread domain you want to connect to. You also need to change `PrivateKeyFile`, `CertificateFile` and `TrustAnchorFile` to credentials you are going to use (default credentials are available in [src/app/etc/commissioner/credentials](../etc/commissioner/credentials) for testing).
-
-For the non-CCM configuration file, you need to set `PSKc`.
-
-## Start
-
-When started, the CLI enters an interactive mode and waits for user commands.
-
-```shell
-## Example of starting a non-CCM Commissioner.
-build $ ./src/app/cli/commissioner-cli ../src/app/etc/commissioner/non-ccm-config.json
->
-```
+Please follow the guide at https://openthread.google.cn/guides/commissioner/build to build and configure OT Commissioner.
 
 ## Commands
 

--- a/src/app/cli/README.md
+++ b/src/app/cli/README.md
@@ -2,10 +2,6 @@
 
 Use the OT Commissioner CLI to configure and manage OT Commissioner.
 
-## Build & Configuration
-
-Please follow the guide at https://openthread.google.cn/guides/commissioner/build to build and configure OT Commissioner.
-
 ## Commands
 
 Type `help` to get a command list:


### PR DESCRIPTION
We have the build and configuration steps in the CLI readme document before we have the page at [openthread.io](https://openthread.google.cn/guides/commissioner).

This PR points OT Commissioner CLI build and configuration to the page at [openthread.io](https://openthread.google.cn/guides/commissioner/build).
