### PR TITLE
[java] ignore async GetRawActiveDataset API for java binding

### DIFF
--- a/src/java/commissioner.i
+++ b/src/java/commissioner.i
@@ -113,6 +113,7 @@ namespace commissioner {
     %ignore Commissioner::SetCommissionerDataset(ErrorHandler aHandler, const CommissionerDataset &aDataset);
     %ignore Commissioner::SetBbrDataset(ErrorHandler aHandler, const BbrDataset &aDataset);
     %ignore Commissioner::GetBbrDataset(Handler<BbrDataset> aHandler, uint16_t aDatasetFlags);
+    %ignore Commissioner::GetRawActiveDataset(Handler<ByteArray> aHandler, uint16_t aDatasetFlags);
     %ignore Commissioner::GetActiveDataset(Handler<ActiveOperationalDataset> aHandler, uint16_t aDatasetFlags);
     %ignore Commissioner::SetActiveDataset(ErrorHandler aHandler, const ActiveOperationalDataset &aActiveDataset);
     %ignore Commissioner::GetPendingDataset(Handler<PendingOperationalDataset> aHandler, uint16_t aDatasetFlags);


### PR DESCRIPTION
We forgot to ignore the async version of the `GetRawActiveDataset()` API introduced by https://github.com/openthread/ot-commissioner/pull/142, this PR fixes this.

Background: we currently supports only the sync version of all OT Commissioner APIs.