### PR TITLE
[cert] dump MLR.rsp payload for 1.2 certification

### DIFF
--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -957,6 +957,11 @@ void CommissionerImpl::RegisterMulticastListener(Handler<uint8_t>               
         uint8_t     status;
 
         SuccessOrExit(error = aError);
+
+#if OT_COMM_CONFIG_REFERENCE_DEVICE_ENABLE
+        LOG_INFO(LOG_REGION_THCI, "received MLR.rsp: {}", utils::Hex(aResponse->GetPayload()));
+#endif
+
         VerifyOrExit(aResponse->GetCode() != coap::Code::kUnauthorized,
                      error = ERROR_SECURITY("response code is CoAP::UNAUTHORIZED"));
         VerifyOrExit(aResponse->GetCode() == coap::Code::kChanged,

--- a/tools/commissioner_thci/commissioner.py
+++ b/tools/commissioner_thci/commissioner.py
@@ -563,6 +563,15 @@ class ICommissioner(object):
         """
         pass
 
+    @abstractmethod
+    def getMlrLogs(self):
+        """Get MLR logs
+
+        Returns:
+           MLR logs
+        """
+        pass
+
     class Timestamp:
         """Timestamp class in operational dataset"""
 


### PR DESCRIPTION
This PR dumps `MLR.rsp` payload to the log and adds new THCI API (`getMlrLogs`) to query MLR logs for use of 1.2 certification.