### PR TITLE
[library] fix commissioner state when sending keep-alive failed

### DIFF
--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -318,6 +318,7 @@ void CommissionerImpl::Connect(ErrorHandler aHandler, const std::string &aAddr, 
 void CommissionerImpl::Disconnect()
 {
     mBrClient.Disconnect(ERROR_CANCELLED("the CoAPs client was disconnected"));
+    mState = State::kDisabled;
 }
 
 uint16_t CommissionerImpl::GetSessionId() const
@@ -1315,6 +1316,7 @@ exit:
     if (error != ErrorCode::kNone)
     {
         LOG_WARN(LOG_REGION_MESHCOP, "sending keep alive message failed: {}", error.ToString());
+        Disconnect();
     }
 }
 


### PR DESCRIPTION
This PR fixes commissioner state transition when we failed to send the Keep-Alive message:
1. disconnect from the Border Agent.
2. Set the commissioner state to `kDisabled` when disconnected.

