### PR TITLE
[coap] fix retransmission of confirmable CoAP requests

### DIFF
--- a/src/library/coap.cpp
+++ b/src/library/coap.cpp
@@ -412,8 +412,6 @@ void Coap::CancelRequests()
         mRequestsCache.Front().mRequest->GetUriPath(uri).IgnoreError();
         FinalizeTransaction(mRequestsCache.Front(), nullptr, ERROR_CANCELLED("request to {} was cancelled", uri));
     }
-
-    mRequestsCache.StopTimer();
 }
 
 Error Coap::AddResource(const Resource &aResource)
@@ -863,6 +861,11 @@ void Coap::RequestsCache::Eliminate(const RequestHolder &aRequestHolder)
             mContainer.erase(holder);
             break;
         }
+    }
+
+    if (mContainer.empty())
+    {
+        mRetransmissionTimer.Stop();
     }
 }
 

--- a/src/library/coap.cpp
+++ b/src/library/coap.cpp
@@ -821,17 +821,7 @@ void Coap::RequestsCache::Put(const RequestPtr aRequest, ResponseHandler aHandle
 void Coap::RequestsCache::Put(const RequestHolder &aRequestHolder)
 {
     mContainer.emplace(aRequestHolder);
-    if (mRetransmissionTimer.IsRunning())
-    {
-        if (Earliest() < mRetransmissionTimer.GetFireTime())
-        {
-            mRetransmissionTimer.Start(Earliest());
-        }
-    }
-    else
-    {
-        mRetransmissionTimer.Start(Earliest());
-    }
+    UpdateTimer();
 }
 
 Coap::RequestHolder Coap::RequestsCache::Eliminate()
@@ -840,15 +830,8 @@ Coap::RequestHolder Coap::RequestsCache::Eliminate()
     auto ret = *mContainer.begin();
 
     mContainer.erase(mContainer.begin());
+    UpdateTimer();
 
-    if (IsEmpty())
-    {
-        // No more requests pending, stop the timer.
-        mRetransmissionTimer.Stop();
-    }
-
-    // No need to worry that the earliest pending message was removed -
-    // the timer would just shoot earlier and then it'd be setup again.
     return ret;
 }
 

--- a/src/library/coap.cpp
+++ b/src/library/coap.cpp
@@ -687,7 +687,7 @@ void Coap::Retransmit(Timer &)
         }
     }
 
-    mRequestsCache.TryStartTimer();
+    mRequestsCache.UpdateTimer();
 }
 
 Error Coap::SendHeaderResponse(Code aCode, const Request &aRequest)
@@ -863,15 +863,16 @@ void Coap::RequestsCache::Eliminate(const RequestHolder &aRequestHolder)
         }
     }
 
-    if (mContainer.empty())
+    UpdateTimer();
+}
+
+void Coap::RequestsCache::UpdateTimer()
+{
+    if (IsEmpty())
     {
         mRetransmissionTimer.Stop();
     }
-}
-
-void Coap::RequestsCache::TryStartTimer()
-{
-    if (!mRetransmissionTimer.IsRunning() && !IsEmpty())
+    else if (!mRetransmissionTimer.IsRunning())
     {
         mRetransmissionTimer.Start(Earliest());
     }

--- a/src/library/coap.cpp
+++ b/src/library/coap.cpp
@@ -872,7 +872,14 @@ void Coap::RequestsCache::UpdateTimer()
     {
         mRetransmissionTimer.Stop();
     }
-    else if (!mRetransmissionTimer.IsRunning())
+    else if (mRetransmissionTimer.IsRunning())
+    {
+        if (Earliest() < mRetransmissionTimer.GetFireTime())
+        {
+            mRetransmissionTimer.Start(Earliest());
+        }
+    }
+    else
     {
         mRetransmissionTimer.Start(Earliest());
     }

--- a/src/library/coap.cpp
+++ b/src/library/coap.cpp
@@ -855,14 +855,7 @@ void Coap::RequestsCache::UpdateTimer()
     {
         mRetransmissionTimer.Stop();
     }
-    else if (mRetransmissionTimer.IsRunning())
-    {
-        if (Earliest() < mRetransmissionTimer.GetFireTime())
-        {
-            mRetransmissionTimer.Start(Earliest());
-        }
-    }
-    else
+    else if (!mRetransmissionTimer.IsRunning() || Earliest() < mRetransmissionTimer.GetFireTime())
     {
         mRetransmissionTimer.Start(Earliest());
     }

--- a/src/library/coap.cpp
+++ b/src/library/coap.cpp
@@ -412,6 +412,8 @@ void Coap::CancelRequests()
         mRequestsCache.Front().mRequest->GetUriPath(uri).IgnoreError();
         FinalizeTransaction(mRequestsCache.Front(), nullptr, ERROR_CANCELLED("request to {} was cancelled", uri));
     }
+
+    mRequestsCache.StopTimer();
 }
 
 Error Coap::AddResource(const Resource &aResource)
@@ -686,6 +688,8 @@ void Coap::Retransmit(Timer &)
             FinalizeTransaction(requestHolder, nullptr, ERROR_TIMEOUT("request to {} timeout", uri));
         }
     }
+
+    mRequestsCache.TryStartTimer();
 }
 
 Error Coap::SendHeaderResponse(Code aCode, const Request &aRequest)
@@ -862,14 +866,7 @@ void Coap::RequestsCache::Eliminate(const RequestHolder &aRequestHolder)
     }
 }
 
-void Coap::RequestsCache::Clear()
-{
-    mRetransmissionTimer.Stop();
-
-    mContainer.clear();
-}
-
-void Coap::RequestsCache::TryRetartTimer()
+void Coap::RequestsCache::TryStartTimer()
 {
     if (!mRetransmissionTimer.IsRunning() && !IsEmpty())
     {

--- a/src/library/coap.hpp
+++ b/src/library/coap.hpp
@@ -689,8 +689,6 @@ private:
             return *mContainer.begin();
         }
 
-        void StopTimer() { mRetransmissionTimer.Stop(); }
-
         // Try starting the retransmit timer if it is not running
         // and there is pending requests.
         void TryStartTimer();

--- a/src/library/coap.hpp
+++ b/src/library/coap.hpp
@@ -690,8 +690,9 @@ private:
         }
 
         // Try starting the retransmit timer if it is not running
-        // and there is pending requests.
-        void TryStartTimer();
+        // and there is pending requests. Try stopping the retransmit
+        // timer if there is no more pending requests.
+        void UpdateTimer();
 
     private:
         Timer                        mRetransmissionTimer;

--- a/src/library/coap.hpp
+++ b/src/library/coap.hpp
@@ -689,12 +689,11 @@ private:
             return *mContainer.begin();
         }
 
-        // Clear all requests and stop retransmission timer.
-        void Clear();
+        void StopTimer() { mRetransmissionTimer.Stop(); }
 
-        // Try restart the retransmit timer if it is not running and there is
-        // pending requests.
-        void TryRetartTimer();
+        // Try starting the retransmit timer if it is not running
+        // and there is pending requests.
+        void TryStartTimer();
 
     private:
         Timer                        mRetransmissionTimer;


### PR DESCRIPTION
This PR has two fixes to the CoAP retransmission of confirmable requests:
1. Stop the retransmission timer when all requests are cleared.
2. Start the retransmission timer when there are queueing requests that are waiting for responses.