### PR TITLE
[scripts] misc fixes in bootstrap script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,13 +163,15 @@ jobs:
           ninja
 
   java-binding:
-    runs-on: macos-10.15
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-10.15, ubuntu-18.04]
     steps:
       - uses: actions/checkout@v2
       - name: Bootstrap
         run: |
           script/bootstrap.sh
-          brew install swig@4
       - name: Build
         run: |
           mkdir build && cd build

--- a/include/commissioner/defines.hpp
+++ b/include/commissioner/defines.hpp
@@ -161,7 +161,7 @@ static constexpr uint8_t kRadioChannelPage2 = 2;
 /**
  * Type alias of raw byte array.
  */
-typedef std::vector<uint8_t>  ByteArray;
+typedef std::vector<uint8_t> ByteArray;
 
 } // namespace commissioner
 

--- a/include/commissioner/defines.hpp
+++ b/include/commissioner/defines.hpp
@@ -161,7 +161,7 @@ static constexpr uint8_t kRadioChannelPage2 = 2;
 /**
  * Type alias of raw byte array.
  */
-using ByteArray = std::vector<uint8_t>;
+typedef std::vector<uint8_t>  ByteArray;
 
 } // namespace commissioner
 

--- a/include/commissioner/network_data.hpp
+++ b/include/commissioner/network_data.hpp
@@ -163,7 +163,9 @@ struct Timestamp
     uint64_t Encode() const;
 };
 
+#ifndef SWIG
 static_assert(sizeof(Timestamp) == sizeof(uint64_t), "wrong timestamp size");
+#endif
 
 /**
  * A Channel includes ChannelPage and ChannelNumber.
@@ -183,7 +185,7 @@ struct ChannelMaskEntry
     ByteArray mMasks;
 };
 
-using ChannelMask = std::vector<ChannelMaskEntry>;
+typedef std::vector<ChannelMaskEntry> ChannelMask;
 
 /**
  * A SecurityPolicy includes RotationTime and SecurityFlags.

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -69,15 +69,14 @@ if [ "$(uname)" = "Linux" ]; then
                          clang-format-10 \
                          cmake \
                          ninja-build \
-                         python-setuptools \
-                         python-pip \
+                         swig \
                          lcov
 
     ## Install newest CMake
     match_version "$(cmake --version | grep -E -o '[0-9].*')" "${MIN_CMAKE_VERSION}" || {
-        pip install -U pip
-        pip install -U scikit-build
-        pip install -U cmake
+        sudo apt-get install -y pytho3-setuptools python3-pip
+        pip3 install -U scikit-build
+        pip3 install -U cmake
     }
     match_version "$(cmake --version | grep -E -o '[0-9].*')" "${MIN_CMAKE_VERSION}" || {
         echo "error: cmake version($(cmake --version)) < ${MIN_CMAKE_VERSION}."
@@ -95,6 +94,7 @@ elif [ "$(uname)" = "Darwin" ]; then
                  llvm@10 \
                  cmake \
                  ninja \
+                 swig \
                  lcov && true
 
     sudo ln -s "$(brew --prefix llvm@10)/bin/clang-format" /usr/local/bin/clang-format-10

--- a/src/java/CMakeLists.txt
+++ b/src/java/CMakeLists.txt
@@ -29,7 +29,7 @@
 set(JAVA_PACKAGE_NAME io.openthread.commissioner)
 set(JAVA_OUTFILE_DIR ${CMAKE_CURRENT_BINARY_DIR}/io/openthread/commissioner)
 
-find_package(SWIG 4.0 REQUIRED)
+find_package(SWIG 3.0 REQUIRED)
 find_package(Java REQUIRED)
 
 if (NOT OT_COMM_ANDROID)

--- a/src/java/commissioner.i
+++ b/src/java/commissioner.i
@@ -44,7 +44,6 @@
 %}
 
 %include <std_string.i>
-%include <std_list.i>
 %include <std_shared_ptr.i>
 %include <std_vector.i>
 %include <stl.i>


### PR DESCRIPTION
This PR includes misc updates/fixes for bootstrapping:
1. downgrade required SWIG version to 3.0 since this is the default version that package tools have for Linux;
2. install SWIG in the bootstrap script;
3. install `python3` setup tools instead of `python2` since it is deprecated;