### PR TITLE
[swig] revert changes to the minimum SWIG version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,10 +163,7 @@ jobs:
           ninja
 
   java-binding:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macos-10.15, ubuntu-18.04]
+    runs-on: macos-10.15
     steps:
       - uses: actions/checkout@v2
       - name: Bootstrap

--- a/include/commissioner/defines.hpp
+++ b/include/commissioner/defines.hpp
@@ -161,7 +161,7 @@ static constexpr uint8_t kRadioChannelPage2 = 2;
 /**
  * Type alias of raw byte array.
  */
-typedef std::vector<uint8_t> ByteArray;
+using ByteArray = std::vector<uint8_t>;
 
 } // namespace commissioner
 

--- a/include/commissioner/network_data.hpp
+++ b/include/commissioner/network_data.hpp
@@ -185,7 +185,7 @@ struct ChannelMaskEntry
     ByteArray mMasks;
 };
 
-typedef std::vector<ChannelMaskEntry> ChannelMask;
+using ChannelMask = std::vector<ChannelMaskEntry>;
 
 /**
  * A SecurityPolicy includes RotationTime and SecurityFlags.

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -94,7 +94,7 @@ elif [ "$(uname)" = "Darwin" ]; then
                  llvm@10 \
                  cmake \
                  ninja \
-                 swig \
+                 swig@4 \
                  lcov && true
 
     sudo ln -s "$(brew --prefix llvm@10)/bin/clang-format" /usr/local/bin/clang-format-10

--- a/src/java/CMakeLists.txt
+++ b/src/java/CMakeLists.txt
@@ -29,7 +29,7 @@
 set(JAVA_PACKAGE_NAME io.openthread.commissioner)
 set(JAVA_OUTFILE_DIR ${CMAKE_CURRENT_BINARY_DIR}/io/openthread/commissioner)
 
-find_package(SWIG 3.0 REQUIRED)
+find_package(SWIG 4.0 REQUIRED)
 find_package(Java REQUIRED)
 
 if (NOT OT_COMM_ANDROID)


### PR DESCRIPTION
This PR reverts our changes of downgrading minimum SWIG version to 3.0 in #152.

We did downgrade the minimum version for easy installation of SWIG on old Linux distributions. But the incoming Commissioner Android App relies on the Java methods generated by SWIG 4.0. Unfortunately, we didn't have a GH job to test the SWIG-generated Java code for now, but it will come with the Android App PR.