### PR TITLE
[script] remove unused bootstrap dependencies

### DIFF
--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -55,17 +55,8 @@ if [ "$(uname)" = "Linux" ]; then
     ## Install packages
     sudo apt-get update
     sudo apt-get install -y \
-                         wget \
-                         libssl-dev \
                          build-essential \
-                         software-properties-common \
-                         libreadline7 \
                          libreadline-dev \
-                         libncurses5-dev \
-                         libncursesw5-dev \
-                         tcl \
-                         tk \
-                         expect \
                          cmake \
                          ninja-build \
                          swig \
@@ -92,7 +83,6 @@ elif [ "$(uname)" = "Darwin" ]; then
     ## Install packages
     brew install coreutils \
                  readline \
-                 ncurses \
                  cmake \
                  ninja \
                  swig@4 \

--- a/tests/integration/bootstrap.sh
+++ b/tests/integration/bootstrap.sh
@@ -58,6 +58,7 @@ setup_openthread() {
 
 setup_commissioner() {
     set -e
+    sudo apt-get install expect -y
     pip install --user -r "${TEST_ROOT_DIR}"/../../tools/commissioner_thci/requirements.txt
 }
 


### PR DESCRIPTION
This PR cleans stale dependencies that is no longer required to build the default OT Commissioner library and CLI.


Fixes #154 