### PR TITLE
[script] downgrade to clang-format-9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Bootstrap
         run: |
           sudo apt update
-          sudo apt --no-install-recommends install -y clang-format-10
+          sudo apt --no-install-recommends install -y clang-format-9
           python3 -m pip install yapf==0.29.0
       - name: Check
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ This will open up a text editor where you can specify which commits to squash.
 
 #### Coding conventions and style
 
-OT Commissioner uses and enforces the [OpenThread code format](./.clang-format) on all code, except for code located in [third_party](third_party). Use `script/make-pretty` and `script/make-pretty check` to automatically reformat code and check for code-style compliance, respectively. OpenThread currently requires [clang-format v10.0.0](http://releases.llvm.org/download.html#10.0.0) for C/C++ and [yapf v0.29.0](https://github.com/google/yapf) for Python.
+OT Commissioner uses and enforces the [OpenThread code format](./.clang-format) on all code, except for code located in [third_party](third_party). Use `script/make-pretty` and `script/make-pretty check` to automatically reformat code and check for code-style compliance, respectively. OpenThread currently requires [clang-format v9.0.0](http://releases.llvm.org/download.html#10.0.0) for C/C++ and [yapf v0.29.0](https://github.com/google/yapf) for Python.
 
 As part of the cleanup process, also run `script/make-pretty check` to ensure that your code passes the baseline code style checks.
 

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -66,11 +66,13 @@ if [ "$(uname)" = "Linux" ]; then
                          tcl \
                          tk \
                          expect \
-                         clang-format-10 \
                          cmake \
                          ninja-build \
                          swig \
                          lcov
+
+    sudo apt-get --no-install-recommends install -y clang-format-9 || echo 'WARNING: could not install clang-format-9, which is useful if you plan to contribute C/C++ code to the OpenThread project.'
+    python3 -m pip install yapf==0.29.0 || echo 'WARNING: could not install yapf, which is useful if you plan to contribute python code to the OpenThread project.'
 
     ## Install newest CMake
     match_version "$(cmake --version | grep -E -o '[0-9].*')" "${MIN_CMAKE_VERSION}" || {
@@ -91,13 +93,13 @@ elif [ "$(uname)" = "Darwin" ]; then
     brew install coreutils \
                  readline \
                  ncurses \
-                 llvm@10 \
                  cmake \
                  ninja \
                  swig@4 \
                  lcov && true
 
-    sudo ln -s "$(brew --prefix llvm@10)/bin/clang-format" /usr/local/bin/clang-format-10
+    brew install llvm@9 && sudo ln -s "$(brew --prefix llvm@9)/bin/clang-format" /usr/local/bin/clang-format-9 \
+    || echo 'WARNING: could not install clang-format-9, which is useful if you plan to contribute C/C++ code to the OpenThread project.'
 
     ## Install latest cmake
     match_version "$(cmake --version | grep -E -o '[0-9].*')" "${MIN_CMAKE_VERSION}" || {

--- a/script/clang-format
+++ b/script/clang-format
@@ -27,7 +27,7 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-CLANG_FORMAT_VERSION="clang-format version 10.0"
+CLANG_FORMAT_VERSION="clang-format version 9.0"
 
 die()
 {
@@ -39,18 +39,18 @@ die()
 # expand_aliases shell option is set using shopt.
 shopt -s expand_aliases
 
-if command -v clang-format-10 >/dev/null; then
-    alias clang-format=clang-format-10
+if command -v clang-format-9 >/dev/null; then
+    alias clang-format=clang-format-9
 elif command -v clang-format >/dev/null; then
     case "$(clang-format --version)" in
         "$CLANG_FORMAT_VERSION"*) ;;
 
         *)
-            die "$(clang-format --version); clang-format 10.0 required"
+            die "$(clang-format --version); clang-format 9.0 required"
             ;;
     esac
 else
-    die "clang-format 10.0 required"
+    die "clang-format 9.0 required"
 fi
 
 clang-format "$@" || die


### PR DESCRIPTION
This PR downgrades `clang-format` to `9.0` given that `llvm@10` is not available in brew repository. Instead of failing the bootstrap script, we changed to tolerate failure of installing `clang-format`.

related issue: https://github.com/openthread/openthread/issues/5724