### PR TITLE
[tests] fix CCM unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,11 +90,12 @@ jobs:
           ./tests/commissioner-test
 
   clang-build:
-    name: clang-${{ matrix.clang_ver }}
+    name: clang-${{ matrix.clang_ver }}-${{ matrix.build_type }}
     runs-on: ubuntu-18.04
     strategy:
       matrix:
         clang_ver: [5, 6, 7, 8, 9]
+        build_type: ["Debug", "Release"]
     steps:
       - uses: actions/checkout@v2
       - name: Bootstrap
@@ -104,12 +105,12 @@ jobs:
         run: |
           clang --version
           mkdir build && cd build
-          cmake -GNinja                           \
-                -DBUILD_SHARED_LIBS=ON            \
-                -DCMAKE_CXX_STANDARD=11           \
-                -DCMAKE_CXX_STANDARD_REQUIRED=ON  \
-                -DCMAKE_BUILD_TYPE=Release        \
-                -DCMAKE_INSTALL_PREFIX=/usr/local \
+          cmake -GNinja                                     \
+                -DBUILD_SHARED_LIBS=ON                      \
+                -DCMAKE_CXX_STANDARD=11                     \
+                -DCMAKE_CXX_STANDARD_REQUIRED=ON            \
+                -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+                -DCMAKE_INSTALL_PREFIX=/usr/local           \
                 ..
           ninja
           sudo ninja install

--- a/src/library/cbor.cpp
+++ b/src/library/cbor.cpp
@@ -70,7 +70,7 @@ void CborValue::Move(CborValue &dst, CborValue &src)
 
 Error CborValue::Serialize(uint8_t *aBuf, size_t &aLength, size_t aMaxLength) const
 {
-    ASSERT(mIsRoot && mCbor != nullptr);
+    ASSERT(mCbor != nullptr);
     ssize_t written = cn_cbor_encoder_write(aBuf, 0, aMaxLength, mCbor);
     if (written == -1)
     {


### PR DESCRIPTION
The issue is not revealed in GitHub Actions because `assert` is disabled in `Release` mode.
This PR also adds `Debug` mode build to GitHub Action flows.