### PR TITLE
[dataset] fix and relax dataset response check

### DIFF
--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -451,8 +451,6 @@ void CommissionerImpl::GetActiveDataset(Handler<ActiveOperationalDataset> aHandl
 
         SuccessOrExit(error = aError);
         SuccessOrExit(error = DecodeActiveOperationalDataset(dataset, *aRawDataset));
-        VerifyOrExit(dataset.mPresentFlags & ActiveOperationalDataset::kActiveTimestampBit,
-                     error = ERROR_BAD_FORMAT("Active Timestamp is not included in MGMT_ACTIVE_GET.rsp"));
 
         aHandler(&dataset, error);
     exit:
@@ -585,12 +583,11 @@ void CommissionerImpl::GetPendingDataset(Handler<PendingOperationalDataset> aHan
                      error = ERROR_BAD_FORMAT("expect CoAP::CHANGED for MGMT_PENDING_GET.rsp message"));
 
         SuccessOrExit(error = DecodePendingOperationalDataset(dataset, *aResponse));
-        VerifyOrExit(dataset.mPresentFlags | PendingOperationalDataset::kActiveTimestampBit,
-                     error = ERROR_BAD_FORMAT("Active Timestamp is not included in MGMT_PENDING_GET.rsp"));
-        VerifyOrExit(dataset.mPresentFlags | PendingOperationalDataset::kPendingTimestampBit,
-                     error = ERROR_BAD_FORMAT("Pending Timestamp is not included in MGMT_PENDING_GET.rsp"));
-        VerifyOrExit(dataset.mPresentFlags | PendingOperationalDataset::kDelayTimerBit,
-                     error = ERROR_BAD_FORMAT("Delay Timer is not included in MGMT_PENDING_GET.rsp"));
+        if (dataset.mPresentFlags != 0)
+        {
+            VerifyOrExit(dataset.mPresentFlags & PendingOperationalDataset::kDelayTimerBit,
+                         error = ERROR_BAD_FORMAT("Delay Timer is not included in MGMT_PENDING_GET.rsp"));
+        }
 
         aHandler(&dataset, error);
 


### PR DESCRIPTION
1. The Pending Dataset check is wrong: the bitwise or (`| `) should be bitwise and (`&`)
2. Both Pending and Active Dataset Get response checks are too restrict.

The Commissioner CLI always sends MGMT_ACTIVE/PENDING_GET.req for all TLVs even when only a single TLV is requested by the user and thus current implementation is working.