### PR TITLE
[udp-proxy] track Mesh-Local prefix in UDP Proxy client

### DIFF
--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -504,19 +504,6 @@ public:
     virtual Error Resign() = 0;
 
     /**
-     * @brief Set the Mesh-local Prefix of current connected Thread network.
-     *
-     * The user should get the Mesh-local Prefix with `GetActiveDataset` and set the prefix
-     * with this method, before initiating any other MGMT commands.
-     *
-     * @param[in] aMeshLocalPrefix  The Mesh-local Prefix of current Thread network.
-     *
-     * @retval Error::kNone         Successfully set the Mesh-local Prefix.
-     * @retval Error::kInvalidArgs  The Mesh-local Prefix is not valid.
-     */
-    virtual Error SetMeshLocalPrefix(const ByteArray &aMeshLocalPrefix) = 0;
-
-    /**
      * @brief Asynchronously get the Commissioner Dataset.
      *
      * This method request Commissioner Dataset from the leader of the Thread network

--- a/include/commissioner/defines.hpp
+++ b/include/commissioner/defines.hpp
@@ -124,11 +124,6 @@ static constexpr uint16_t kDefaultAeUdpPort = 1001;
 static constexpr uint16_t kDefaultNmkpUdpPort = 1002;
 
 /**
- * The fixed primary backbone router anycast locator.
- */
-static constexpr uint16_t kPrimaryBbrAloc16 = 0xFC38;
-
-/**
  * If using radio 915Mhz. Default radio freq of Thread is 2.4Ghz.
  *
  * Used to encoding ChannelMask TLV.

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -151,7 +151,6 @@ Error CommissionerApp::SyncNetworkData(void)
     BbrDataset                bbrDataset;
 
     SuccessOrExit(error = mCommissioner->GetActiveDataset(activeDataset, 0xFFFF));
-    SuccessOrExit(error = mCommissioner->SetMeshLocalPrefix(activeDataset.mMeshLocalPrefix));
     SuccessOrExit(error = mCommissioner->GetPendingDataset(pendingDataset, 0xFFFF));
     SuccessOrExit(error = mCommissioner->SetCommissionerDataset(mCommDataset));
     if (IsCcmMode())
@@ -535,7 +534,7 @@ Error CommissionerApp::GetMeshLocalPrefix(std::string &aPrefix)
     SuccessOrExit(error = mCommissioner->GetActiveDataset(mActiveDataset, 0xFFFF));
 
     VerifyOrExit(mActiveDataset.mPresentFlags & ActiveOperationalDataset::kMeshLocalPrefixBit,
-                 error = ERROR_NOT_FOUND("cannot find valid Mesh-local Prefix in Active Operational Dataset"));
+                 error = ERROR_NOT_FOUND("cannot find valid Mesh-Local Prefix in Active Operational Dataset"));
     aPrefix = Ipv6PrefixToString(mActiveDataset.mMeshLocalPrefix);
 
 exit:

--- a/src/library/commissioner_impl.hpp
+++ b/src/library/commissioner_impl.hpp
@@ -102,8 +102,6 @@ public:
     void  Resign(ErrorHandler aHandler) override;
     Error Resign() override { return ERROR_UNIMPLEMENTED(""); }
 
-    Error SetMeshLocalPrefix(const ByteArray &aMeshLocalPrefix) override;
-
     void  GetCommissionerDataset(Handler<CommissionerDataset> aHandler, uint16_t aDatasetFlags) override;
     Error GetCommissionerDataset(CommissionerDataset &, uint16_t) override { return ERROR_UNIMPLEMENTED(""); }
 
@@ -222,10 +220,6 @@ private:
 
     void SendPetition(PetitionHandler aHandler);
 
-    Address GetAnycastLocator(uint16_t aAloc16) const;
-    Address GetLeaderLocator(void) const;
-    Address GetPrimaryBbrLocator(void) const;
-
     // Set @p aKeepAlive to false to resign the commissioner role.
     void SendKeepAlive(Timer &aTimer, bool aKeepAlive = true);
 
@@ -264,7 +258,6 @@ private:
     Timer mKeepAliveTimer;
 
     coap::CoapSecure mBrClient;
-    ByteArray        mMeshLocalPrefix;
 
     std::map<ByteArray, JoinerSession> mJoinerSessions;
     Timer                              mJoinerSessionTimer;

--- a/src/library/commissioner_safe.cpp
+++ b/src/library/commissioner_safe.cpp
@@ -208,14 +208,6 @@ Error CommissionerSafe::Resign()
     return pro.get_future().get();
 }
 
-Error CommissionerSafe::SetMeshLocalPrefix(const ByteArray &aMeshLocalPrefix)
-{
-    std::promise<Error> pro;
-
-    PushAsyncRequest([&]() { pro.set_value(mImpl->SetMeshLocalPrefix(aMeshLocalPrefix)); });
-    return pro.get_future().get();
-}
-
 void CommissionerSafe::GetCommissionerDataset(Handler<CommissionerDataset> aHandler, uint16_t aDatasetFlags)
 {
     PushAsyncRequest([=]() { mImpl->GetCommissionerDataset(aHandler, aDatasetFlags); });

--- a/src/library/commissioner_safe.hpp
+++ b/src/library/commissioner_safe.hpp
@@ -103,8 +103,6 @@ public:
     void  Resign(ErrorHandler aHandler) override;
     Error Resign() override;
 
-    Error SetMeshLocalPrefix(const ByteArray &aMeshLocalPrefix) override;
-
     void  GetCommissionerDataset(Handler<CommissionerDataset> aHandler, uint16_t aDatasetFlags) override;
     Error GetCommissionerDataset(CommissionerDataset &aDataset, uint16_t aDatasetFlags) override;
 

--- a/src/library/udp_proxy.hpp
+++ b/src/library/udp_proxy.hpp
@@ -44,6 +44,8 @@ namespace ot {
 
 namespace commissioner {
 
+class CommissionerImpl;
+
 // The UDP proxy endpoint that sends UDP data by encapsulating
 // it in the UDP_TX.ntf message.
 class ProxyEndpoint : public Endpoint
@@ -75,11 +77,12 @@ private:
 class ProxyClient
 {
 public:
-    ProxyClient(struct event_base *aEventBase, coap::CoapSecure &aBrClient)
-        : mEndpoint(aBrClient)
-        , mCoap(aEventBase, mEndpoint)
-    {
-    }
+    ProxyClient(CommissionerImpl &aCommissioner, coap::CoapSecure &aBrClient);
+
+    void SendRequest(const coap::Request & aRequest,
+                     coap::ResponseHandler aHandler,
+                     uint16_t              aPeerAloc16,
+                     uint16_t              aPeerPort);
 
     void SendRequest(const coap::Request & aRequest,
                      coap::ResponseHandler aHandler,
@@ -96,9 +99,23 @@ public:
 
     void CancelRequests() { mCoap.CancelRequests(); }
 
+    void FetchMeshLocalPrefix(Commissioner::ErrorHandler aHandler);
+
+    const ByteArray &GetMeshLocalPrefix(void) const { return mMeshLocalPrefix; }
+    void             ClearMeshLocalPrefix(void) { mMeshLocalPrefix.clear(); }
+
+    Error SetMeshLocalPrefix(const ByteArray &aMeshLocalPrefix);
+
+    Address GetAnycastLocator(uint16_t aAloc16) const;
+
 private:
-    ProxyEndpoint mEndpoint;
-    coap::Coap    mCoap;
+    CommissionerImpl &mCommissioner;
+    ProxyEndpoint     mEndpoint;
+    coap::Coap        mCoap;
+
+    // The Mesh-Local prefix of current connected Thread network.
+    // Used to compute Mesh-Local address of UDP_TX.ntf peer.
+    ByteArray mMeshLocalPrefix;
 };
 
 } // namespace commissioner


### PR DESCRIPTION
Previous implementation requires the caller of the Commissioner library to set Mesh-Local prefix before
initiating `MGMT` commands. it is error-prone and breaks backward compatibility: we need to first fetch
the Active Operational Dataset and set the Mesh-Local Prefix to the commissioner library before sending
other `MGMT_*` commands:
https://github.com/openthread/ot-commissioner/blob/1b5dd47875fdd52e86dd6334973c36fa9e1ba899/src/app/commissioner_app.cpp#L151-L155

This PR refactors the UDP Proxy to have it manage the Mesh-Local prefix inside the `ProxyClient` class.
1. The Mesh-Local prefix is lazily requested from the Border Agent  before sending the first `MGMT` command (if no Mesh-Local prefix is cached).
2. The cached Mesh-Local prefix is cleared when the commissioner receives `MGMT_DATASET_CHANGED.ntf` so that the latest Mesh-Local prefix will be fetched before next `MGMT` command.
3. The cached Mesh-Local prefix is cleared when the commissioner is disconnected.

In this way, the user doesn't need to be aware of the Mesh-Local prefix and no changes are required.