### PR TITLE
[cmake] install with static library dependencies

### DIFF
--- a/src/app/cli/CMakeLists.txt
+++ b/src/app/cli/CMakeLists.txt
@@ -42,7 +42,6 @@ target_include_directories(commissioner-cli
 target_link_libraries(commissioner-cli
     PRIVATE
         commissioner-app
-        ncurses
         pthread
         readline
 )

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -47,12 +47,10 @@ target_include_directories(commissioner-common
         ${PROJECT_SOURCE_DIR}/src
 )
 
-if (BUILD_SHARED_LIBS)
-    install(TARGETS commissioner-common
-            LIBRARY DESTINATION lib
-            ARCHIVE DESTINATION lib
-    )
-endif()
+install(TARGETS commissioner-common
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+)
 
 if (OT_COMM_TEST)
     add_library(commissioner-common-test OBJECT

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -109,27 +109,34 @@ install(TARGETS commissioner
 ## Install third-party shared libraries. We need to install
 ## those shared libraries to enable commissioner-cli.
 ##
-## We here install the built .so files directly
+## We here install the .a/.so files directly
 ## because those third-party libraries are included
 ## as EXCLUDE_FROM_ALL, which means `install()` is
 ## disabled for them (intended).
-if (BUILD_SHARED_LIBS)
-    install(FILES
-            $<$<BOOL:${OT_COMM_CCM}>:$<TARGET_FILE:cn-cbor::cn-cbor>>
-            $<$<BOOL:${OT_COMM_CCM}>:$<TARGET_FILE:cose>>
-            $<$<BOOL:${OT_COMM_APP}>:$<TARGET_FILE:mdns>>
-            $<TARGET_FILE:mbedtls>
-            $<TARGET_FILE:mbedx509>
-            $<TARGET_FILE:mbedcrypto>
-            $<TARGET_FILE:fmt::fmt>
-            $<TARGET_FILE:event_core_shared>
-            $<TARGET_FILE:event_pthreads_shared>
-            DESTINATION lib
-    )
 
-    ## Update ldconfig links and caches.
-    install(CODE "execute_process(COMMAND sudo ldconfig)")
+if (BUILD_SHARED_LIBS)
+    set(EVENT_CORE event_core_shared)
+    set(EVENT_PTHREADS event_pthreads_shared)
+else()
+    set(EVENT_CORE event_core_static)
+    set(EVENT_PTHREADS event_pthreads_static)
 endif()
+
+install(FILES
+        $<$<BOOL:${OT_COMM_CCM}>:$<TARGET_FILE:cn-cbor::cn-cbor>>
+        $<$<BOOL:${OT_COMM_CCM}>:$<TARGET_FILE:cose>>
+        $<$<BOOL:${OT_COMM_APP}>:$<TARGET_FILE:mdns>>
+        $<TARGET_FILE:mbedtls>
+        $<TARGET_FILE:mbedx509>
+        $<TARGET_FILE:mbedcrypto>
+        $<TARGET_FILE:fmt::fmt>
+        $<TARGET_FILE:${EVENT_CORE}>
+        $<TARGET_FILE:${EVENT_PTHREADS}>
+        DESTINATION lib
+)
+
+## Update ldconfig links and caches.
+install(CODE "execute_process(COMMAND sudo ldconfig)")
 
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/commissioner
         DESTINATION include


### PR DESCRIPTION
This commit includes two small changes:
1. Install static library dependencies
2. Install `commissioner-common`: applications need to link against both `commissioner` and `commissioner-common`.
3. remove unused linking of `ncurses`.