### PR TITLE
[api] add API for getting commissioner version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,16 +57,16 @@ execute_process(
 )
 
 if(OT_COMM_GIT_REVISION)
-    set(OT_COMM_VERSION "${PROJECT_VERSION}-${OT_COMM_GIT_REVISION}")
+    set(OT_COMM_VERSION "${PROJECT_VERSION}+${OT_COMM_GIT_REVISION}")
 else()
     set(OT_COMM_VERSION "${PROJECT_VERSION}")
 endif()
 
 message(STATUS "Version: ${OT_COMM_VERSION}")
 
-add_library(commissioner-version INTERFACE)
-target_compile_definitions(commissioner-version
-    INTERFACE OT_COMM_VERSION="${PROJECT_VERSION}"
+add_library(commissioner-config INTERFACE)
+target_compile_definitions(commissioner-config
+    INTERFACE OT_COMM_VERSION="${OT_COMM_VERSION}"
 )
 
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@
 #
 
 cmake_minimum_required(VERSION 3.10.1)
-project(ot-commissioner VERSION 0.1.0)
+project(ot-commissioner VERSION 0.2.0)
 
 option(OT_COMM_ANDROID           "Build with Android NDK" OFF)
 option(OT_COMM_APP               "Build the CLI App" ON)
@@ -49,6 +49,25 @@ if(NOT "${CMAKE_CXX_STANDARD}")
 endif()
 
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+execute_process(
+    COMMAND git describe --dirty --always 2>/dev/null
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE OT_COMM_GIT_REVISION OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if(OT_COMM_GIT_REVISION)
+    set(OT_COMM_VERSION "${PROJECT_VERSION}-${OT_COMM_GIT_REVISION}")
+else()
+    set(OT_COMM_VERSION "${PROJECT_VERSION}")
+endif()
+
+message(STATUS "Version: ${OT_COMM_VERSION}")
+
+add_library(commissioner-version INTERFACE)
+target_compile_definitions(commissioner-version
+    INTERFACE OT_COMM_VERSION="${PROJECT_VERSION}"
+)
 
 add_subdirectory(src)
 add_subdirectory(tools)

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -1137,7 +1137,7 @@ public:
     /**
      * @brief Return the commissioner version.
      *
-     * @return A version string in format of <MAJOR>.<MINOR>.<PATCH>[-<GIT_REVISION>].
+     * @return A version string in format of <MAJOR>.<MINOR>.<PATCH>[+<GIT_REVISION>].
      *         The GIT_REVISION is included only when the commissioner is built in a
      *         git repository.
      */

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -1133,6 +1133,15 @@ public:
      * @param[in]      aJoinerId      A Joiner ID.
      */
     static void AddJoiner(ByteArray &aSteeringData, const ByteArray &aJoinerId);
+
+    /**
+     * @brief Return the commissioner version.
+     *
+     * @return A version string in format of <MAJOR>.<MINOR>.<PATCH>[-<GIT_REVISION>].
+     *         The GIT_REVISION is included only when the commissioner is built in a
+     *         git repository.
+     */
+    static std::string GetVersion(void);
 };
 
 } // namespace commissioner

--- a/src/app/cli/CMakeLists.txt
+++ b/src/app/cli/CMakeLists.txt
@@ -46,11 +46,6 @@ target_link_libraries(commissioner-cli
         readline
 )
 
-target_compile_definitions(commissioner-cli
-    PUBLIC
-        OT_COMM_VERSION="${PROJECT_VERSION}"
-)
-
 install(TARGETS commissioner-cli
         RUNTIME DESTINATION bin
 )

--- a/src/app/cli/main.cpp
+++ b/src/app/cli/main.cpp
@@ -38,10 +38,6 @@
 #include "app/cli/interpreter.hpp"
 #include "common/utils.hpp"
 
-#ifndef OT_COMM_VERSION
-#error "OT_COMM_VERSION not defined"
-#endif
-
 using namespace ot::commissioner;
 
 /**
@@ -74,7 +70,7 @@ static void PrintUsage(const std::string &aProgram)
 
 static void PrintVersion()
 {
-    Console::Write(OT_COMM_VERSION, Console::Color::kWhite);
+    Console::Write(Commissioner::GetVersion(), Console::Color::kWhite);
 }
 
 static Interpreter gInterpreter;

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -85,6 +85,7 @@ target_link_libraries(commissioner
         event_pthreads
         $<$<NOT:$<BOOL:${OT_COMM_ANDROID}>>:pthread>
         commissioner-common
+        commissioner-version
 )
 
 target_compile_definitions(commissioner

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -85,7 +85,7 @@ target_link_libraries(commissioner
         event_pthreads
         $<$<NOT:$<BOOL:${OT_COMM_ANDROID}>>:pthread>
         commissioner-common
-        commissioner-version
+        commissioner-config
 )
 
 target_compile_definitions(commissioner

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -117,6 +117,11 @@ void Commissioner::AddJoiner(ByteArray &aSteeringData, const ByteArray &aJoinerI
     ComputeBloomFilter(aSteeringData, aJoinerId);
 }
 
+std::string Commissioner::GetVersion(void)
+{
+    return OT_COMM_VERSION;
+}
+
 CommissionerImpl::CommissionerImpl(CommissionerHandler &aHandler, struct event_base *aEventBase)
     : mState(State::kDisabled)
     , mSessionId(0)


### PR DESCRIPTION
This commit adds a new commissioner `API` that returns the commissioner version.
Also add git revision to the version string.