### PR TITLE
[cli] support default config without specifying a config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ endif()
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 execute_process(
-    COMMAND git describe --dirty --always 2>/dev/null
+    COMMAND git describe HEAD --always
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     OUTPUT_VARIABLE OT_COMM_GIT_REVISION OUTPUT_STRIP_TRAILING_WHITESPACE
 )

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -37,6 +37,9 @@ add_library(commissioner-app
     file_util.hpp
     json.cpp
     json.hpp
+    logger_util.hpp
+    sys_logger.cpp
+    sys_logger.hpp
 )
 
 target_link_libraries(commissioner-app

--- a/src/app/cli/interpreter.cpp
+++ b/src/app/cli/interpreter.cpp
@@ -37,6 +37,7 @@
 
 #include "app/file_util.hpp"
 #include "app/json.hpp"
+#include "app/sys_logger.hpp"
 #include "common/error_macros.hpp"
 #include "common/utils.hpp"
 
@@ -45,29 +46,22 @@ namespace ot {
 namespace commissioner {
 
 const std::map<std::string, Interpreter::Evaluator> &Interpreter::mEvaluatorMap = *new std::map<std::string, Evaluator>{
-    {"start", &Interpreter::ProcessStart},
-    {"stop", &Interpreter::ProcessStop},
-    {"active", &Interpreter::ProcessActive},
-    {"token", &Interpreter::ProcessToken},
-    {"network", &Interpreter::ProcessNetwork},
-    {"sessionid", &Interpreter::ProcessSessionId},
-    {"borderagent", &Interpreter::ProcessBorderAgent},
-    {"joiner", &Interpreter::ProcessJoiner},
-    {"commdataset", &Interpreter::ProcessCommDataset},
-    {"opdataset", &Interpreter::ProcessOpDataset},
-    {"bbrdataset", &Interpreter::ProcessBbrDataset},
-    {"reenroll", &Interpreter::ProcessReenroll},
-    {"domainreset", &Interpreter::ProcessDomainReset},
-    {"migrate", &Interpreter::ProcessMigrate},
-    {"mlr", &Interpreter::ProcessMlr},
-    {"announce", &Interpreter::ProcessAnnounce},
-    {"panid", &Interpreter::ProcessPanId},
-    {"energy", &Interpreter::ProcessEnergy},
-    {"exit", &Interpreter::ProcessExit},
+    {"config", &Interpreter::ProcessConfig},       {"start", &Interpreter::ProcessStart},
+    {"stop", &Interpreter::ProcessStop},           {"active", &Interpreter::ProcessActive},
+    {"token", &Interpreter::ProcessToken},         {"network", &Interpreter::ProcessNetwork},
+    {"sessionid", &Interpreter::ProcessSessionId}, {"borderagent", &Interpreter::ProcessBorderAgent},
+    {"joiner", &Interpreter::ProcessJoiner},       {"commdataset", &Interpreter::ProcessCommDataset},
+    {"opdataset", &Interpreter::ProcessOpDataset}, {"bbrdataset", &Interpreter::ProcessBbrDataset},
+    {"reenroll", &Interpreter::ProcessReenroll},   {"domainreset", &Interpreter::ProcessDomainReset},
+    {"migrate", &Interpreter::ProcessMigrate},     {"mlr", &Interpreter::ProcessMlr},
+    {"announce", &Interpreter::ProcessAnnounce},   {"panid", &Interpreter::ProcessPanId},
+    {"energy", &Interpreter::ProcessEnergy},       {"exit", &Interpreter::ProcessExit},
     {"help", &Interpreter::ProcessHelp},
 };
 
 const std::map<std::string, std::string> &Interpreter::mUsageMap = *new std::map<std::string, std::string>{
+    {"config", "config get pskc\n"
+               "config set pskc <pskc-hex-string>"},
     {"start", "start <border-agent-addr> <border-agent-port>"},
     {"stop", "stop"},
     {"active", "active"},
@@ -171,11 +165,20 @@ Error Interpreter::Init(const std::string &aConfigFile)
     Error error;
 
     std::string configJson;
-    Config      config;
 
-    SuccessOrExit(error = ReadFile(configJson, aConfigFile));
-    SuccessOrExit(error = ConfigFromJson(config, configJson));
-    SuccessOrExit(error = CommissionerApp::Create(mCommissioner, config));
+    if (!aConfigFile.empty())
+    {
+        SuccessOrExit(error = ReadFile(configJson, aConfigFile));
+        SuccessOrExit(error = ConfigFromJson(mConfig, configJson));
+    }
+    else
+    {
+        // Default to Non-CCM mode if no configuration file is provided.
+        mConfig.mEnableCcm = false;
+        mConfig.mPSKc.assign(kMaxPSKcLength, 0xff);
+        mConfig.mLogger = SysLogger::Create(LogLevel::kDebug);
+    }
+    SuccessOrExit(error = CommissionerApp::Create(mCommissioner, mConfig));
 
 exit:
     return error;
@@ -303,6 +306,48 @@ Interpreter::Expression Interpreter::ParseExpression(const std::string &aLiteral
     }
 
     return expr;
+}
+
+Interpreter::Value Interpreter::ProcessConfig(const Expression &aExpr)
+{
+    Value value;
+
+    VerifyOrExit(aExpr.size() >= 3, value = ERROR_INVALID_ARGS("two few arguments"));
+    VerifyOrExit(aExpr[2] == "pskc", value = ERROR_INVALID_ARGS("{} is not a valid property", aExpr[2]));
+    if (aExpr[1] == "get")
+    {
+        value = utils::Hex(mConfig.mPSKc);
+    }
+    else if (aExpr[1] == "set")
+    {
+        ByteArray pskc;
+
+        VerifyOrExit(aExpr.size() >= 4, value = ERROR_INVALID_ARGS("two few arguments"));
+        SuccessOrExit(value = utils::Hex(pskc, aExpr[3]));
+        SuccessOrExit(value = UpdateConfig(pskc));
+    }
+    else
+    {
+        ExitNow(value = ERROR_INVALID_COMMAND("{} is not a valid sub-command", aExpr[1]));
+    }
+
+exit:
+    return value;
+}
+
+Error Interpreter::UpdateConfig(const ByteArray &aPSKc)
+{
+    Error error;
+
+    VerifyOrExit(aPSKc.size() <= kMaxPSKcLength, error = ERROR_INVALID_ARGS("invalid PSKc length"));
+    VerifyOrExit(!mCommissioner->IsActive(),
+                 error = ERROR_INVALID_STATE("cannot set PSKc when the commissioner is active"));
+
+    mConfig.mPSKc = aPSKc;
+    CommissionerApp::Create(mCommissioner, mConfig).IgnoreError();
+
+exit:
+    return error;
 }
 
 Interpreter::Value Interpreter::ProcessStart(const Expression &aExpr)

--- a/src/app/cli/interpreter.hpp
+++ b/src/app/cli/interpreter.hpp
@@ -101,6 +101,7 @@ private:
 
     Expression ParseExpression(const std::string &aLiteral);
 
+    Value ProcessConfig(const Expression &aExpr);
     Value ProcessStart(const Expression &aExpr);
     Value ProcessStop(const Expression &aExpr);
     Value ProcessActive(const Expression &aExpr);
@@ -121,6 +122,8 @@ private:
     Value ProcessEnergy(const Expression &aExpr);
     Value ProcessExit(const Expression &aExpr);
     Value ProcessHelp(const Expression &aExpr);
+
+    Error UpdateConfig(const ByteArray &aPSKc);
 
     static void BorderAgentHandler(const BorderAgent *aBorderAgent, const Error &aError);
 

--- a/src/app/cli/main.cpp
+++ b/src/app/cli/main.cpp
@@ -63,7 +63,7 @@ static void PrintUsage(const std::string &aProgram)
 {
     static const std::string usage = "usage: \n"
                                      "    " +
-                                     aProgram + " <config-file>";
+                                     aProgram + " [<config-file>]";
 
     Console::Write(usage, Console::Color::kWhite);
 }
@@ -89,18 +89,25 @@ static void HandleSignalInterrupt()
 
 int main(int argc, const char *argv[])
 {
-    Error  error;
-    Config config;
+    Error       error;
+    std::string configFile;
 
-    if (argc < 2 || ToLower(argv[1]) == "-h" || ToLower(argv[1]) == "--help")
+    if (argc >= 2)
     {
-        PrintUsage(argv[0]);
-        ExitNow();
-    }
-    else if (ToLower(argv[1]) == "-v" || ToLower(argv[1]) == "--version")
-    {
-        PrintVersion();
-        ExitNow();
+        if (ToLower(argv[1]) == "-h" || ToLower(argv[1]) == "--help")
+        {
+            PrintUsage(argv[0]);
+            ExitNow();
+        }
+        else if (ToLower(argv[1]) == "-v" || ToLower(argv[1]) == "--version")
+        {
+            PrintVersion();
+            ExitNow();
+        }
+        else
+        {
+            configFile = argv[1];
+        }
     }
 
     // Block signals in this thread and subsequently spawned threads.
@@ -112,7 +119,7 @@ int main(int argc, const char *argv[])
 
     Console::Write(kLogo, Console::Color::kBlue);
 
-    SuccessOrExit(error = gInterpreter.Init(argv[1]));
+    SuccessOrExit(error = gInterpreter.Init(configFile));
 
     gInterpreter.Run();
 

--- a/src/app/sys_logger.hpp
+++ b/src/app/sys_logger.hpp
@@ -69,7 +69,7 @@ private:
     SysLogger() = default;
     void Init(LogLevel aLogLevel);
 
-    LogLevel   mLogLevel;
+    LogLevel mLogLevel;
 };
 
 } // namespace commissioner

--- a/src/app/sys_logger.hpp
+++ b/src/app/sys_logger.hpp
@@ -1,0 +1,79 @@
+/*
+ *    Copyright (c) 2021, The OpenThread Commissioner Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *  This file defines sys logger.
+ *
+ */
+
+#ifndef OT_COMM_APP_SYS_LOGGER_HPP_
+#define OT_COMM_APP_SYS_LOGGER_HPP_
+
+#include <string>
+
+#include <commissioner/commissioner.hpp>
+
+namespace ot {
+
+namespace commissioner {
+
+/**
+ * @brief An implementation of the Logger interface that write log to syslog.
+ *
+ */
+class SysLogger : public Logger
+{
+public:
+    ~SysLogger() override;
+
+    /**
+     * This function returns a sys logger with given minimum log level.
+     *
+     * @param[in] aLogLevel  The minimum log level. Log messages with a lower
+     *                       log level than this will be dropped silently.
+     *
+     * @retval An instance of SysLogger.
+     *
+     */
+    static std::shared_ptr<SysLogger> Create(LogLevel aLogLevel);
+
+    void Log(LogLevel aLevel, const std::string &aRegion, const std::string &aMsg) override;
+
+private:
+    SysLogger() = default;
+    void Init(LogLevel aLogLevel);
+
+    LogLevel   mLogLevel;
+};
+
+} // namespace commissioner
+
+} // namespace ot
+
+#endif // OT_COMM_APP_SYS_LOGGER_HPP_

--- a/tests/integration/test_joining.sh
+++ b/tests/integration/test_joining.sh
@@ -47,6 +47,26 @@ test_joining() {
     stop_daemon
 }
 
+test_joining_default_config() {
+    start_daemon
+    form_network "${PSKC}"
+
+    # Start the commissioner with default config.
+    start_commissioner ""
+    send_command_to_commissioner "config set pskc ${PSKC}"
+    petition_commissioner
+    send_command_to_commissioner "active"
+
+    ## enable all MeshCoP joiners
+    send_command_to_commissioner "joiner enable meshcop ${JOINER_EUI64} ${JOINER_CREDENTIAL}"
+
+    start_joiner "meshcop"
+
+    stop_commissioner
+
+    stop_daemon
+}
+
 test_joining_fail() {
     start_daemon
     form_network "${PSKC}"

--- a/tools/commissioner_thci/commissioner_ctl.py
+++ b/tools/commissioner_thci/commissioner_ctl.py
@@ -55,10 +55,11 @@ def main():
     args = parser.parse_args()
 
     if args.action == 'init':
+        config = os.path.realpath(args.config) if args.config else ""
         message = {
             'type': 'control',
             'command': 'init',
-            'config': os.path.realpath(args.config),
+            'config': config,
         }
     elif args.action == 'exit':
         message = {


### PR DESCRIPTION
This PR includes two small enhancements:
1. Support starting the `commissioner-cli` without specifying a configuration file.
    a. pskc is set to all-one.
    b. log messages are printed to syslog (/var/log/syslog).
2. Add sys logger support. 