### PR TITLE
[cli] fix "borderagent" command documentation

### DIFF
--- a/src/app/cli/README.md
+++ b/src/app/cli/README.md
@@ -115,15 +115,41 @@ The command `exit` exits the CLI session.
 
 ### Border Agent
 
-The command `borderagent` provides access to Border Agent information:
+The command `borderagent` provides access to Border Agent information and scans for Border Agent services.
 
 ```shell
 > help borderagent
 usage:
+borderagent discover [<timeout-in-milliseconds>]
 borderagent get locator
-borderagent get meshlocaladdr
 [done]
 >
+```
+
+Discover Border Agent services:
+
+```shell
+> borderagent discover
+Addr=172.23.57.126
+Port=49152
+Discriminator=76db7e6dcb420b1c
+ThreadVersion=1.2.0
+State.ConnectionMode=1(PSKc)
+State.ThreadIfStatus=2(active)
+State.Availability=1(high)
+State.BbrIsActive=1
+State.BbrIsPrimary=1
+NetworkName=OpenThread
+ExtendedPanId=0xdead00beef00cafe
+[done]
+```
+
+Get Border Agent locator:
+
+```shell
+> borderagent get locator
+0x5000
+[done]
 ```
 
 ### Backbone Router dataset

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -149,10 +149,14 @@ Error CommissionerApp::SyncNetworkData(void)
     ActiveOperationalDataset  activeDataset;
     PendingOperationalDataset pendingDataset;
     BbrDataset                bbrDataset;
+    CommissionerDataset       commDataset;
 
     SuccessOrExit(error = mCommissioner->GetActiveDataset(activeDataset, 0xFFFF));
     SuccessOrExit(error = mCommissioner->GetPendingDataset(pendingDataset, 0xFFFF));
     SuccessOrExit(error = mCommissioner->SetCommissionerDataset(mCommDataset));
+    SuccessOrExit(error = mCommissioner->GetCommissionerDataset(commDataset, 0xFFFF));
+    MergeDataset(mCommDataset, commDataset);
+
     if (IsCcmMode())
     {
         SuccessOrExit(error = mCommissioner->GetBbrDataset(bbrDataset, 0xFFFF));


### PR DESCRIPTION
This commit adds the CLI documentation of the `borderagent discover` command.
Also fixes a bug for the `borderagent get locator` command that the locator is not
pulled to the commissioner.