### PR TITLE
[test] update leader start in `test_native_commissioner()`

### DIFF
--- a/tests/integration/test_native_commissioner.sh
+++ b/tests/integration/test_native_commissioner.sh
@@ -44,7 +44,7 @@ send "pskc ${PSKC}\r\n"
 expect "Done"
 send "thread start\r\n"
 expect "Done"
-sleep 3
+sleep 10
 send "state\r\n"
 expect "leader"
 expect "Done"
@@ -66,7 +66,7 @@ stop_leader() {
 test_native_commissioner() {
     set -x
     start_leader
-    sleep 6
+    sleep 15
 
     ba_lla=$(grep -A+1 'ipaddr linklocal' "${LEADER_OUTPUT}" | tail -n1 | tr -d '\r\n')
     ba_port=$(grep -A+1 'ba port' "${LEADER_OUTPUT}" | tail -n1 | tr -d '\r\n')


### PR DESCRIPTION
This commit increases the wait time for leader start. This is to
address the changes in behavior in Thread spec related to the
number of MLE Parent Request messages that device needs to send in
the first attach attempt before it can become leader.  The new design
requires a device to send a total of six Parent Request messages,
first two to routers followed by four to routers and REEDs, each
having its own corresponding wait time.