### PR TITLE
[build] fix Android builds

### DIFF
--- a/.github/workflows/android-app-build.yml
+++ b/.github/workflows/android-app-build.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         android-api: [24]
         android-abi: [x86, x86_64]
-        os: [macos-10.15, ubuntu-20.04]
+        os: [macos-12, ubuntu-20.04]
     steps:
       - uses: actions/checkout@v2
       - name: Bootstrap
@@ -46,7 +46,7 @@ jobs:
       - name: Build
         run: |
           cd android
-          ANDROID_ABI=${{ matrix.android-abi }} ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle ./build-commissioner-libs.sh
+          ANDROID_ABI=${{ matrix.android-abi }} ANDROID_NDK_HOME=$(find $ANDROID_HOME/ndk -name "24.*") ./build-commissioner-libs.sh
           cd openthread_commissioner
           ./gradlew build
       - name: Tests

--- a/.github/workflows/android-app-release.yml
+++ b/.github/workflows/android-app-release.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Build APK
         run: |
           cd android
-          ANDROID_ABI=armeabi-v7a ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle ./build-commissioner-libs.sh
-          ANDROID_ABI=arm64-v8a ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle ./build-commissioner-libs.sh
+          ANDROID_ABI=armeabi-v7a ANDROID_NDK_HOME=$(find $ANDROID_HOME/ndk -name "24.*") ./build-commissioner-libs.sh
+          ANDROID_ABI=arm64-v8a ANDROID_NDK_HOME=$(find $ANDROID_HOME/ndk -name "24.*") ./build-commissioner-libs.sh
           cd openthread_commissioner
           ./gradlew assembleDebug
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
           ./tests/interpreter-test
 
   macos:
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
       - name: Bootstrap
@@ -161,7 +161,7 @@ jobs:
         run: |
           mkdir build && cd build
           cmake -GNinja                                                                             \
-                -DCMAKE_TOOLCHAIN_FILE=$ANDROID_HOME/ndk-bundle/build/cmake/android.toolchain.cmake \
+                -DCMAKE_TOOLCHAIN_FILE=$(find $ANDROID_HOME/ndk -name "24.*")/build/cmake/android.toolchain.cmake \
                 -DANDROID_ABI="armeabi-v7a"                                                         \
                 -DANDROID_ARM_NEON=ON                                                               \
                 -DANDROID_NATIVE_API_LEVEL=21                                                       \
@@ -177,7 +177,7 @@ jobs:
           ninja
 
   java-binding:
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v2
       - name: Bootstrap


### PR DESCRIPTION
1. `android/sdk/ndk-bundle` was moved to `android/sdk/ndk/$API`
2. macos-10.15 was deprecated by macos-12