### PR TITLE
[thci] change python format string to format function

### DIFF
--- a/tools/commissioner_thci/commissioner_impl.py
+++ b/tools/commissioner_thci/commissioner_impl.py
@@ -166,8 +166,8 @@ class OTCommissioner(ICommissioner):
         return OTCommissioner(config, serial_handler)
 
     def start(self, borderAgentAddr, borderAgentPort):
-        self._command(f'sudo rm {self.log_file}')
-        self._command(f'sudo touch {self.log_file}')
+        self._command('sudo rm {}'.format(self.log_file))
+        self._command('sudo touch {}'.format(self.log_file))
         self._execute_and_check('start {} {}'.format(
             borderAgentAddr,
             borderAgentPort,


### PR DESCRIPTION
Change format string introduced in python 3 to python 2 compatible 'format' function.