### PR TITLE
[ci] fix cannot find Threads on Android

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,22 +159,9 @@ jobs:
           script/bootstrap.sh
       - name: Build
         run: |
-          mkdir build && cd build
-          cmake -GNinja                                                                             \
-                -DCMAKE_TOOLCHAIN_FILE=$(find $ANDROID_HOME/ndk -name "24.*")/build/cmake/android.toolchain.cmake \
-                -DANDROID_ABI="armeabi-v7a"                                                         \
-                -DANDROID_ARM_NEON=ON                                                               \
-                -DANDROID_NATIVE_API_LEVEL=21                                                       \
-                -DBUILD_SHARED_LIBS=ON                                                              \
-                -DCMAKE_CXX_STANDARD=11                                                             \
-                -DCMAKE_CXX_STANDARD_REQUIRED=ON                                                    \
-                -DCMAKE_BUILD_TYPE=Release                                                          \
-                -DOT_COMM_ANDROID=ON                                                                \
-                -DOT_COMM_APP=OFF                                                                   \
-                -DOT_COMM_TEST=OFF                                                                  \
-                -DOT_COMM_WARNING_AS_ERROR=ON                                                       \
-                ..
-          ninja
+          cd android
+          ANDROID_ABI=armeabi-v7a ANDROID_NDK_HOME=$(find $ANDROID_HOME/ndk -name "24.*") ./build-commissioner-libs.sh
+          ANDROID_ABI=arm64-v8a ANDROID_NDK_HOME=$(find $ANDROID_HOME/ndk -name "24.*") ./build-commissioner-libs.sh
 
   java-binding:
     runs-on: macos-12

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,12 @@ endif()
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# `pthread` is already included in Android glibc implementation (`bionic`),
+# so there is no necessary to find the thread libs separately.
+if (ANDROID)
+    set (CMAKE_THREAD_LIBS_INIT 1)
+endif()
+
 execute_process(
     COMMAND git describe HEAD --always
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ endif()
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # `pthread` is already included in Android glibc implementation (`bionic`),
-# so there is no necessary to find the thread libs separately.
+# so it is not necessary to find the thread libs separately.
 if (ANDROID)
     set (CMAKE_THREAD_LIBS_INIT 1)
 endif()


### PR DESCRIPTION
`pthread` is already included in Android glibc implementation (`bionic`), so there
is no necessary to find the thread libs separately.

Reference: https://stackoverflow.com/questions/5990661/cmake-find-packagethreads-for-android-cross-compilation