### PR TITLE
[gradle] update gradle tool version from 6.5 to 7.2

### DIFF
--- a/android/openthread_commissioner/gradle/wrapper/gradle-wrapper.properties
+++ b/android/openthread_commissioner/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip


### PR DESCRIPTION
fix gradle project sync issue

Unsupported Java.
Your build is currently configured to use Java 17.0.7 and Gradle 6.5.

Possible solution:
 - Upgrade Gradle wrapper to 7.2 version and re-import the pro