### PR TITLE
[android] make gradle rootProject.name match the project dir

### DIFF
--- a/android/openthread_commissioner/settings.gradle
+++ b/android/openthread_commissioner/settings.gradle
@@ -1,3 +1,3 @@
 include ':service'
 include ':app'
-rootProject.name = "OpenThread Commissioner"
+rootProject.name = "openthread_commissioner"


### PR DESCRIPTION
To fix the gradle error on some platforms:
```
java.lang.IllegalStateException: Module entity with name: openthread_commissioner.app should be available
```