### PR TITLE
[cli] update `borderagent discover` to allow network interface selection for mDNS binding

### DIFF
--- a/src/app/border_agent_functions_mock.cpp
+++ b/src/app/border_agent_functions_mock.cpp
@@ -43,9 +43,9 @@ void ClearBorderAgentFunctionsMock()
     gBorderAgentFunctionsMock = nullptr;
 }
 
-Error DiscoverBorderAgent(BorderAgentHandler aBorderAgentHandler, size_t aTimeout)
+Error DiscoverBorderAgent(BorderAgentHandler aBorderAgentHandler, size_t aTimeout, const std::string &aNetIf)
 {
-    return gBorderAgentFunctionsMock->DiscoverBorderAgent(aBorderAgentHandler, aTimeout);
+    return gBorderAgentFunctionsMock->DiscoverBorderAgent(aBorderAgentHandler, aTimeout, aNetIf);
 }
 
 } // namespace commissioner

--- a/src/app/border_agent_functions_mock.hpp
+++ b/src/app/border_agent_functions_mock.hpp
@@ -45,7 +45,7 @@ class BorderAgentFunctionsMock
 public:
     virtual ~BorderAgentFunctionsMock() = default;
 
-    MOCK_METHOD(Error, DiscoverBorderAgent, (BorderAgentHandler, size_t, const std::string));
+    MOCK_METHOD(Error, DiscoverBorderAgent, (BorderAgentHandler, size_t, const std::string&));
 };
 
 void SetBorderAgentFunctionsMock(ot::commissioner::BorderAgentFunctionsMock *ptr);

--- a/src/app/border_agent_functions_mock.hpp
+++ b/src/app/border_agent_functions_mock.hpp
@@ -45,7 +45,7 @@ class BorderAgentFunctionsMock
 public:
     virtual ~BorderAgentFunctionsMock() = default;
 
-    MOCK_METHOD(Error, DiscoverBorderAgent, (BorderAgentHandler, size_t));
+    MOCK_METHOD(Error, DiscoverBorderAgent, (BorderAgentHandler, size_t, const std::string));
 };
 
 void SetBorderAgentFunctionsMock(ot::commissioner::BorderAgentFunctionsMock *ptr);

--- a/src/app/border_agent_functions_mock.hpp
+++ b/src/app/border_agent_functions_mock.hpp
@@ -45,7 +45,7 @@ class BorderAgentFunctionsMock
 public:
     virtual ~BorderAgentFunctionsMock() = default;
 
-    MOCK_METHOD(Error, DiscoverBorderAgent, (BorderAgentHandler, size_t, const std::string&));
+    MOCK_METHOD(Error, DiscoverBorderAgent, (BorderAgentHandler, size_t, const std::string &));
 };
 
 void SetBorderAgentFunctionsMock(ot::commissioner::BorderAgentFunctionsMock *ptr);

--- a/src/app/br_discover.cpp
+++ b/src/app/br_discover.cpp
@@ -55,11 +55,7 @@ Error DiscoverBorderAgent(BorderAgentHandler aBorderAgentHandler, size_t aTimeou
 
     if (!aNetIf.empty() && setsockopt(socket, SOL_SOCKET, SO_BINDTODEVICE, &aNetIf[0], sizeof(aNetIf)) < 0)
     {
-<<<<<<< HEAD
-         ExitNow(error = ERROR_SOCKET_BIND_ERROR("failed to bind network interface {}: {}", aNetIf, strerror(errno)));
-=======
-        ExitNow(error = ERROR_SOCKET_BIND_ERROR("failed to bind network interface {}: {}", aNetIf, strerror(errno)));
->>>>>>> a6d0658 (Update src/app/br_discover.cpp)
+        ExitNow(error = ERROR_INVALID_ARGS("failed to bind network interface {}: {}", aNetIf, strerror(errno)));
     }
 
     if (mdns_query_send(socket, kMdnsQueryType, kServiceName, strlen(kServiceName), buf, sizeof(buf)) != 0)

--- a/src/app/br_discover.cpp
+++ b/src/app/br_discover.cpp
@@ -65,7 +65,8 @@ Error DiscoverBorderAgent(BorderAgentHandler aBorderAgentHandler, size_t aTimeou
 #else  // __NetBSD__ || __FreeBSD__ || __APPLE__
         rval = setsockopt(socket, IPPROTO_IPV6, IP_BOUND_IF, aNetIf.c_str(), aNetIf.size());
 #endif // __linux__
-        VerifyOrDie(rval == 0);
+        VerifyOrExit(rval == 0,
+                     error = ERROR_INVALID_ARGS("failed to bind network interface {}: {}", aNetIf, strerror(errno)));
     }
 
     if (mdns_query_send(socket, kMdnsQueryType, kServiceName, strlen(kServiceName), buf, sizeof(buf)) != 0)

--- a/src/app/br_discover.cpp
+++ b/src/app/br_discover.cpp
@@ -53,8 +53,9 @@ Error DiscoverBorderAgent(BorderAgentHandler aBorderAgentHandler, size_t aTimeou
     int socket = mdns_socket_open_ipv4();
     VerifyOrExit(socket >= 0, error = ERROR_IO_ERROR("failed to open mDNS IPv4 socket"));
 
-    if (aNetIf != "" && setsockopt(socket, SOL_SOCKET, SO_BINDTODEVICE, &aNetIf[0], sizeof(aNetIf)) < 0) {
-         ExitNow(error = ERROR_IO_ERROR("failed to bind network interface: {}", aNetIf));
+    if (aNetIf != "" && setsockopt(socket, SOL_SOCKET, SO_BINDTODEVICE, &aNetIf[0], sizeof(aNetIf)) < 0)
+    {
+         ExitNow(error = ERROR_SOCKET_BIND_ERROR("failed to bind network interface: {}", aNetIf));
     }
 
     if (mdns_query_send(socket, kMdnsQueryType, kServiceName, strlen(kServiceName), buf, sizeof(buf)) != 0)

--- a/src/app/br_discover.cpp
+++ b/src/app/br_discover.cpp
@@ -29,8 +29,8 @@
 #include "br_discover.hpp"
 
 #include <chrono>
-#include <thread>
 #include <sys/socket.h>
+#include <thread>
 
 #include "common/error_macros.hpp"
 #include "common/utils.hpp"
@@ -55,7 +55,11 @@ Error DiscoverBorderAgent(BorderAgentHandler aBorderAgentHandler, size_t aTimeou
 
     if (!aNetIf.empty() && setsockopt(socket, SOL_SOCKET, SO_BINDTODEVICE, &aNetIf[0], sizeof(aNetIf)) < 0)
     {
+<<<<<<< HEAD
          ExitNow(error = ERROR_SOCKET_BIND_ERROR("failed to bind network interface {}: {}", aNetIf, strerror(errno)));
+=======
+        ExitNow(error = ERROR_SOCKET_BIND_ERROR("failed to bind network interface {}: {}", aNetIf, strerror(errno)));
+>>>>>>> a6d0658 (Update src/app/br_discover.cpp)
     }
 
     if (mdns_query_send(socket, kMdnsQueryType, kServiceName, strlen(kServiceName), buf, sizeof(buf)) != 0)

--- a/src/app/br_discover.cpp
+++ b/src/app/br_discover.cpp
@@ -35,6 +35,8 @@
 #include "common/error_macros.hpp"
 #include "common/utils.hpp"
 
+#define SO_BINDTODEVICE 25
+
 namespace ot {
 
 namespace commissioner {

--- a/src/app/br_discover.cpp
+++ b/src/app/br_discover.cpp
@@ -53,9 +53,9 @@ Error DiscoverBorderAgent(BorderAgentHandler aBorderAgentHandler, size_t aTimeou
     int socket = mdns_socket_open_ipv4();
     VerifyOrExit(socket >= 0, error = ERROR_IO_ERROR("failed to open mDNS IPv4 socket"));
 
-    if (aNetIf != "" && setsockopt(socket, SOL_SOCKET, SO_BINDTODEVICE, &aNetIf[0], sizeof(aNetIf)) < 0)
+    if (!aNetIf.empty() && setsockopt(socket, SOL_SOCKET, SO_BINDTODEVICE, &aNetIf[0], sizeof(aNetIf)) < 0)
     {
-         ExitNow(error = ERROR_SOCKET_BIND_ERROR("failed to bind network interface: {}", aNetIf));
+         ExitNow(error = ERROR_SOCKET_BIND_ERROR("failed to bind network interface {}: {}", aNetIf, strerror(errno)));
     }
 
     if (mdns_query_send(socket, kMdnsQueryType, kServiceName, strlen(kServiceName), buf, sizeof(buf)) != 0)

--- a/src/app/br_discover.cpp
+++ b/src/app/br_discover.cpp
@@ -58,12 +58,15 @@ Error DiscoverBorderAgent(BorderAgentHandler aBorderAgentHandler, size_t aTimeou
     int socket = mdns_socket_open_ipv4();
     VerifyOrExit(socket >= 0, error = ERROR_IO_ERROR("failed to open mDNS IPv4 socket"));
 
+    if (!aNetIf.empty())
+    {
 #ifdef __linux__
-    rval = setsockopt(socket, SOL_SOCKET, SO_BINDTODEVICE, aNetIf.c_str(), aNetIf.size());
+        rval = setsockopt(socket, SOL_SOCKET, SO_BINDTODEVICE, aNetIf.c_str(), aNetIf.size());
 #else  // __NetBSD__ || __FreeBSD__ || __APPLE__
-    rval = setsockopt(socket, IPPROTO_IPV6, IP_BOUND_IF, aNetIf.c_str(), aNetIf.size());
+        rval = setsockopt(socket, IPPROTO_IPV6, IP_BOUND_IF, aNetIf.c_str(), aNetIf.size());
 #endif // __linux__
-    VerifyOrDie(rval == 0);
+        VerifyOrDie(rval == 0);
+    }
 
     if (mdns_query_send(socket, kMdnsQueryType, kServiceName, strlen(kServiceName), buf, sizeof(buf)) != 0)
     {

--- a/src/app/br_discover.hpp
+++ b/src/app/br_discover.hpp
@@ -56,9 +56,11 @@ using BorderAgentHandler = std::function<void(const BorderAgent *aBorderAgent, c
  * @param[in] aBorderAgentHandler  The handler of a single Border Agent response.
  * @param[in] aTimeout             The time to wait for mDNS responses. Any
  *                                 response not within the interval is ignored.
+ * @param[in] aNetIf               The specified network interface for mDNS binding.
+ *
  *
  */
-Error DiscoverBorderAgent(BorderAgentHandler aBorderAgentHandler, size_t aTimeout);
+Error DiscoverBorderAgent(BorderAgentHandler aBorderAgentHandler, size_t aTimeout, const std::string &aNetIf);
 
 } // namespace commissioner
 

--- a/src/app/br_discover.hpp
+++ b/src/app/br_discover.hpp
@@ -56,7 +56,7 @@ using BorderAgentHandler = std::function<void(const BorderAgent *aBorderAgent, c
  * @param[in] aBorderAgentHandler  The handler of a single Border Agent response.
  * @param[in] aTimeout             The time to wait for mDNS responses. Any
  *                                 response not within the interval is ignored.
- * @param[in] aNetIf               The specified network interface for mDNS binding.
+ * @param[in] aNetIf               The specified network interface for mDNS binding. Can be an empty string
  *
  *
  */

--- a/src/app/cli/README.md
+++ b/src/app/cli/README.md
@@ -377,7 +377,7 @@ The command `borderagent` provides access to Border Agent information and scans 
 ```shell
 > help borderagent
 usage:
-borderagent discover [<timeout-in-milliseconds>]
+borderagent discover [<timeout-in-milliseconds>] [<specified-network-interface>]
 borderagent get locator
 [done]
 >

--- a/src/app/cli/interpreter.cpp
+++ b/src/app/cli/interpreter.cpp
@@ -1793,8 +1793,14 @@ Interpreter::Value Interpreter::ProcessBorderAgent(const Expression &aExpr)
         {
             SuccessOrExit(value = ParseInteger(timeout, aExpr[2]));
         }
+        std::string netIf = "";
 
-        SuccessOrExit(value = DiscoverBorderAgent(BorderAgentHandler, static_cast<size_t>(timeout)));
+        if (aExpr.size() == 4)
+        {
+            netIf = aExpr[3];
+        }
+
+        SuccessOrExit(value = DiscoverBorderAgent(BorderAgentHandler, static_cast<size_t>(timeout), netIf));
     }
     else if (CaseInsensitiveEqual(aExpr[1], "get"))
     {

--- a/src/app/cli/interpreter.cpp
+++ b/src/app/cli/interpreter.cpp
@@ -1788,6 +1788,7 @@ Interpreter::Value Interpreter::ProcessBorderAgent(const Expression &aExpr)
     if (CaseInsensitiveEqual(aExpr[1], "discover"))
     {
         uint64_t timeout = 4000;
+        std::string netIf = "";
 
         if (aExpr.size() >= 3)
         {

--- a/src/app/cli/interpreter.cpp
+++ b/src/app/cli/interpreter.cpp
@@ -1787,14 +1787,13 @@ Interpreter::Value Interpreter::ProcessBorderAgent(const Expression &aExpr)
 
     if (CaseInsensitiveEqual(aExpr[1], "discover"))
     {
-        uint64_t timeout = 4000;
-        std::string netIf = "";
+        uint64_t    timeout = 4000;
+        std::string netIf   = "";
 
         if (aExpr.size() >= 3)
         {
             SuccessOrExit(value = ParseInteger(timeout, aExpr[2]));
         }
-        std::string netIf = "";
 
         if (aExpr.size() == 4)
         {

--- a/src/app/cli/interpreter_test.cpp
+++ b/src/app/cli/interpreter_test.cpp
@@ -1629,7 +1629,7 @@ TEST_F(InterpreterTestSuite, PC_BorderagentDiscover)
     BorderAgentFunctionsMock bafm;
     SetBorderAgentFunctionsMock(&bafm);
 
-    EXPECT_CALL(bafm, DiscoverBorderAgent(_, _)).WillOnce(Return(Error{}));
+    EXPECT_CALL(bafm, DiscoverBorderAgent(_, _, _)).WillOnce(Return(Error{}));
 
     Interpreter::Expression expr;
     Interpreter::Value      value;


### PR DESCRIPTION
Within the OTBR practice application, the BR host will have several interfaces. When users want to discover the border agent using mDNS, they'll need to choose the specific interface the border agent is bound to.

This change introduces a new option for the CLI command `borderagent dicover`. Users can now specify a network interface using the syntax `borderagent discover <timeout> <network interface>`. The chosen interface will be used for mDNS binding through socket options.