### PR TITLE
[build] update cmake to 3.20.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,11 +60,11 @@ jobs:
         gcc_ver: [5, 6, 7, 8, 9, 10]
     steps:
       - uses: actions/checkout@v3
-      - name: Install CMake 3.10.1
+      - name: Install CMake 3.20.1
         run: |
-          wget https://cmake.org/files/v3.10/cmake-3.10.1.zip
-          unzip cmake-3.10.1
-          cd cmake-3.10.1
+          wget https://cmake.org/files/v3.20/cmake-3.20.1.zip
+          unzip cmake-3.20.1
+          cd cmake-3.20.1
           cmake .
           make -j4
           sudo make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-cmake_minimum_required(VERSION 3.10.1)
+cmake_minimum_required(VERSION 3.20.1)
 project(ot-commissioner VERSION 0.2.0)
 
 option(OT_COMM_ANDROID           "Build with Android NDK" OFF)

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -31,7 +31,7 @@ set -e
 
 # Bootstrap with CCM dependencies.
 readonly WITH_CCM="${WITH_CCM:-1}"
-readonly MIN_CMAKE_VERSION="3.10.1"
+readonly MIN_CMAKE_VERSION="3.20.1"
 
 ## Match the version to see if current version is greater than or euqal to required version.
 ## Args: $1 current version

--- a/src/java/CMakeLists.txt
+++ b/src/java/CMakeLists.txt
@@ -48,6 +48,9 @@ include_directories(${PROJECT_SOURCE_DIR}/include)
 
 set_property(SOURCE commissioner.i PROPERTY CPLUSPLUS ON)
 
+# Tells SWIG compiler to rebuild the java library when any of the dependencies are updated
+set_property(SOURCE commissioner.i PROPERTY USE_SWIG_DEPENDENCIES ON)
+
 set(UseSWIG_TARGET_NAME_PREFERENCE LEGACY)
 
 swig_add_library(commissioner-java


### PR DESCRIPTION
Updates cmake to 3.20.1 which adds support for USE_SWIG_DEPENDENCIES

USE_SWIG_DEPENDENCIES is needed to tell SWIG compiler to rebuild the java
library when the dependencies are changed. For example, we currently have a problem
that the java library is not updated even a new API is added to commissioner.hpp