### PR TITLE
[test] write test files to ./tmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ Makefile.in
 /build
 cmake-build-*
 
+# Test
+/tmp
+
 #tools
 .vscode
 .idea

--- a/src/app/cli/job_manager_test.cpp
+++ b/src/app/cli/job_manager_test.cpp
@@ -119,6 +119,12 @@ public:
         EXPECT_EQ(aContext.mJobManager.Init(aContext.mConf).mCode, ErrorCode::kNone);
         aContext.mInterpreter.mRegistry = aContext.mRegistry;
     }
+
+    void SetUp() override
+    {
+        ASSERT_TRUE(system("rm -rf tmp") == 0);
+        ASSERT_TRUE(system("mkdir -p tmp") == 0);
+    }
 };
 
 TEST_F(JobManagerTestSuite, TestInit)
@@ -321,23 +327,22 @@ TEST_F(JobManagerTestSuite, StartCancel)
 
 TEST_F(JobManagerTestSuite, MalformedCredentialsJobCreateFailsByXPan)
 {
-    // Remove './nwk' subtree
-    ASSERT_EQ(system("rm -rf ./dom ./nwk"), 0);
+    ASSERT_EQ(system("rm -rf ./tmp/dom ./tmp/nwk"), 0);
 
-    EXPECT_EQ(mkdir("./nwk", 0777), 0);
-    EXPECT_EQ(mkdir("./nwk/0000000000000001", 0777), 0);
-    EXPECT_EQ(mkdir("./nwk/0000000000000002", 0777), 0);
-    EXPECT_EQ(mkdir("./nwk/0000000000000003", 0777), 0);
+    EXPECT_EQ(mkdir("./tmp/nwk", 0777), 0);
+    EXPECT_EQ(mkdir("./tmp/nwk/0000000000000001", 0777), 0);
+    EXPECT_EQ(mkdir("./tmp/nwk/0000000000000002", 0777), 0);
+    EXPECT_EQ(mkdir("./tmp/nwk/0000000000000003", 0777), 0);
 
     // Loose credentials for Network 1
-    EXPECT_EQ(WriteFile("1", "./nwk/0000000000000001/ca.pem").mCode, ErrorCode::kNone);
-    EXPECT_EQ(WriteFile("1", "./nwk/0000000000000001/priv.pem").mCode, ErrorCode::kNone);
+    EXPECT_EQ(WriteFile("1", "./tmp/nwk/0000000000000001/ca.pem").mCode, ErrorCode::kNone);
+    EXPECT_EQ(WriteFile("1", "./tmp/nwk/0000000000000001/priv.pem").mCode, ErrorCode::kNone);
     // Loose credentials for Network 2
-    EXPECT_EQ(WriteFile("1", "./nwk/0000000000000002/cert.pem").mCode, ErrorCode::kNone);
-    EXPECT_EQ(WriteFile("1", "./nwk/0000000000000002/priv.pem").mCode, ErrorCode::kNone);
+    EXPECT_EQ(WriteFile("1", "./tmp/nwk/0000000000000002/cert.pem").mCode, ErrorCode::kNone);
+    EXPECT_EQ(WriteFile("1", "./tmp/nwk/0000000000000002/priv.pem").mCode, ErrorCode::kNone);
     // Loose credentials for Network 3
-    EXPECT_EQ(WriteFile("1", "./nwk/0000000000000003/cert.pem").mCode, ErrorCode::kNone);
-    EXPECT_EQ(WriteFile("1", "./nwk/0000000000000003/ca.pem").mCode, ErrorCode::kNone);
+    EXPECT_EQ(WriteFile("1", "./tmp/nwk/0000000000000003/cert.pem").mCode, ErrorCode::kNone);
+    EXPECT_EQ(WriteFile("1", "./tmp/nwk/0000000000000003/ca.pem").mCode, ErrorCode::kNone);
 
     TestContext ctx;
     SetInitialExpectations(ctx);
@@ -399,23 +404,22 @@ TEST_F(JobManagerTestSuite, MalformedCredentialsJobCreateFailsByXPan)
 
 TEST_F(JobManagerTestSuite, MalformedCredentialsJobCreateFailsByName)
 {
-    // Remove './nwk' subtree
-    ASSERT_EQ(system("rm -rf ./dom ./nwk"), 0);
+    ASSERT_EQ(system("rm -rf ./tmp/dom ./tmp/nwk"), 0);
 
-    EXPECT_EQ(mkdir("./nwk", 0777), 0);
-    EXPECT_EQ(mkdir("./nwk/pan1", 0777), 0);
-    EXPECT_EQ(mkdir("./nwk/pan2", 0777), 0);
-    EXPECT_EQ(mkdir("./nwk/pan3", 0777), 0);
+    EXPECT_EQ(mkdir("./tmp/nwk", 0777), 0);
+    EXPECT_EQ(mkdir("./tmp/nwk/pan1", 0777), 0);
+    EXPECT_EQ(mkdir("./tmp/nwk/pan2", 0777), 0);
+    EXPECT_EQ(mkdir("./tmp/nwk/pan3", 0777), 0);
 
     // Loose credentials for Network 1
-    EXPECT_EQ(WriteFile("1", "./nwk/pan1/ca.pem").mCode, ErrorCode::kNone);
-    EXPECT_EQ(WriteFile("1", "./nwk/pan1/priv.pem").mCode, ErrorCode::kNone);
+    EXPECT_EQ(WriteFile("1", "./tmp/nwk/pan1/ca.pem").mCode, ErrorCode::kNone);
+    EXPECT_EQ(WriteFile("1", "./tmp/nwk/pan1/priv.pem").mCode, ErrorCode::kNone);
     // Loose credentials for panwork 2
-    EXPECT_EQ(WriteFile("1", "./nwk/pan2/cert.pem").mCode, ErrorCode::kNone);
-    EXPECT_EQ(WriteFile("1", "./nwk/pan2/priv.pem").mCode, ErrorCode::kNone);
+    EXPECT_EQ(WriteFile("1", "./tmp/nwk/pan2/cert.pem").mCode, ErrorCode::kNone);
+    EXPECT_EQ(WriteFile("1", "./tmp/nwk/pan2/priv.pem").mCode, ErrorCode::kNone);
     // Loose credentials for panwork 3
-    EXPECT_EQ(WriteFile("1", "./nwk/pan3/cert.pem").mCode, ErrorCode::kNone);
-    EXPECT_EQ(WriteFile("1", "./nwk/pan3/ca.pem").mCode, ErrorCode::kNone);
+    EXPECT_EQ(WriteFile("1", "./tmp/nwk/pan3/cert.pem").mCode, ErrorCode::kNone);
+    EXPECT_EQ(WriteFile("1", "./tmp/nwk/pan3/ca.pem").mCode, ErrorCode::kNone);
 
     TestContext ctx;
     SetInitialExpectations(ctx);
@@ -478,22 +482,22 @@ TEST_F(JobManagerTestSuite, MalformedCredentialsJobCreateFailsByName)
 TEST_F(JobManagerTestSuite, MalformedCredentialsJobCreateFailsByDomain)
 {
     // Remove SM subtrees
-    ASSERT_EQ(system("rm -rf ./dom ./nwk"), 0);
+    ASSERT_EQ(system("rm -rf ./tmp/dom ./tmp/nwk"), 0);
 
-    EXPECT_EQ(mkdir("./dom", 0777), 0);
-    EXPECT_EQ(mkdir("./dom/domain1", 0777), 0);
-    EXPECT_EQ(mkdir("./dom/domain2", 0777), 0);
-    EXPECT_EQ(mkdir("./dom/domain3", 0777), 0);
+    EXPECT_EQ(mkdir("./tmp/dom", 0777), 0);
+    EXPECT_EQ(mkdir("./tmp/dom/domain1", 0777), 0);
+    EXPECT_EQ(mkdir("./tmp/dom/domain2", 0777), 0);
+    EXPECT_EQ(mkdir("./tmp/dom/domain3", 0777), 0);
 
     // Loose credentials for domain1
-    EXPECT_EQ(WriteFile("1", "./dom/domain1/ca.pem").mCode, ErrorCode::kNone);
-    EXPECT_EQ(WriteFile("1", "./dom/domain1/priv.pem").mCode, ErrorCode::kNone);
+    EXPECT_EQ(WriteFile("1", "./tmp/dom/domain1/ca.pem").mCode, ErrorCode::kNone);
+    EXPECT_EQ(WriteFile("1", "./tmp/dom/domain1/priv.pem").mCode, ErrorCode::kNone);
     // Loose credentials for domain2
-    EXPECT_EQ(WriteFile("1", "./dom/domain2/cert.pem").mCode, ErrorCode::kNone);
-    EXPECT_EQ(WriteFile("1", "./dom/domain2/priv.pem").mCode, ErrorCode::kNone);
+    EXPECT_EQ(WriteFile("1", "./tmp/dom/domain2/cert.pem").mCode, ErrorCode::kNone);
+    EXPECT_EQ(WriteFile("1", "./tmp/dom/domain2/priv.pem").mCode, ErrorCode::kNone);
     // Loose credentials for domain 3
-    EXPECT_EQ(WriteFile("1", "./dom/domain3/cert.pem").mCode, ErrorCode::kNone);
-    EXPECT_EQ(WriteFile("1", "./dom/domain3/ca.pem").mCode, ErrorCode::kNone);
+    EXPECT_EQ(WriteFile("1", "./tmp/dom/domain3/cert.pem").mCode, ErrorCode::kNone);
+    EXPECT_EQ(WriteFile("1", "./tmp/dom/domain3/ca.pem").mCode, ErrorCode::kNone);
 
     TestContext ctx;
     SetInitialExpectations(ctx);

--- a/src/app/ps/persistent_storage_json_test.cpp
+++ b/src/app/ps/persistent_storage_json_test.cpp
@@ -31,46 +31,59 @@
  *   The file implements unit tests for JSON-based persistent storage
  */
 
+#include <cstdlib>
+#include <fstream>
 #include <gtest/gtest.h>
 
 #include "persistent_storage_json.hpp"
 #include "app/border_agent.hpp"
 
-#include <fstream>
-
 using namespace ot::commissioner::persistent_storage;
 using namespace ot::commissioner;
 
-TEST(PSJson, CreateDefaultIfNotExists)
+class PersistentStorageJsonTestSuite : public testing::Test
 {
-    PersistentStorageJson psj("./test_ps.json");
+public:
+    PersistentStorageJsonTestSuite()          = default;
+    virtual ~PersistentStorageJsonTestSuite() = default;
+
+    void SetUp() override
+    {
+        ASSERT_TRUE(system("rm -rf tmp") == 0);
+        ASSERT_TRUE(system("mkdir -p tmp") == 0);
+    }
+};
+
+TEST(PersistentStorageJsonTestSuite, CreateDefaultIfNotExists)
+{
+    PersistentStorageJson psj("./tmp/test_ps.json");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, ReadEmptyFile)
+TEST(PersistentStorageJsonTestSuite, ReadEmptyFile)
 {
-    std::ofstream testTmp("./test.tmp");
+    std::ofstream testTmp("./tmp/test.tmp");
     testTmp.close();
 
-    PersistentStorageJson psj("./test.tmp");
+    PersistentStorageJson psj("./tmp/test.tmp");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, ReadNonEmptyDefault)
+TEST(PersistentStorageJsonTestSuite, ReadNonEmptyDefault)
 {
-    PersistentStorageJson psj("./test.tmp");
+    PersistentStorageJson psj("./tmp/test.tmp");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, AddRegistrar)
+TEST(PersistentStorageJsonTestSuite, AddRegistrar)
 {
-    PersistentStorageJson psj("./test.tmp");
+    PersistentStorageJson psj("./tmp/test.tmp");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
 
@@ -86,9 +99,9 @@ TEST(PSJson, AddRegistrar)
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, AddDomain)
+TEST(PersistentStorageJsonTestSuite, AddDomain)
 {
-    PersistentStorageJson psj("./test.tmp");
+    PersistentStorageJson psj("./tmp/test.tmp");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
 
@@ -104,12 +117,12 @@ TEST(PSJson, AddDomain)
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, AddNetwork)
+TEST(PersistentStorageJsonTestSuite, AddNetwork)
 {
     // Make the test independent
-    unlink("./test.tmp");
+    unlink("./tmp/test.tmp");
 
-    PersistentStorageJson psj("./test.tmp");
+    PersistentStorageJson psj("./tmp/test.tmp");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
 
@@ -131,9 +144,9 @@ TEST(PSJson, AddNetwork)
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, AddBorderRouter)
+TEST(PersistentStorageJsonTestSuite, AddBorderRouter)
 {
-    PersistentStorageJson psj("./test.tmp");
+    PersistentStorageJson psj("./tmp/test.tmp");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
 
@@ -164,9 +177,9 @@ TEST(PSJson, AddBorderRouter)
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, DelRegistrar)
+TEST(PersistentStorageJsonTestSuite, DelRegistrar)
 {
-    PersistentStorageJson psj("./test.tmp");
+    PersistentStorageJson psj("./tmp/test.tmp");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
 
@@ -178,9 +191,9 @@ TEST(PSJson, DelRegistrar)
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, DelDomain)
+TEST(PersistentStorageJsonTestSuite, DelDomain)
 {
-    PersistentStorageJson psj("./test.tmp");
+    PersistentStorageJson psj("./tmp/test.tmp");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
 
@@ -192,7 +205,7 @@ TEST(PSJson, DelDomain)
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, DelNetwork)
+TEST(PersistentStorageJsonTestSuite, DelNetwork)
 {
     PersistentStorageJson psj("");
 
@@ -214,9 +227,9 @@ TEST(PSJson, DelNetwork)
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, DelBorderRouter)
+TEST(PersistentStorageJsonTestSuite, DelBorderRouter)
 {
-    PersistentStorageJson psj("./test.tmp");
+    PersistentStorageJson psj("./tmp/test.tmp");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
 
@@ -228,9 +241,9 @@ TEST(PSJson, DelBorderRouter)
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, GetRegistrarFromEmpty)
+TEST(PersistentStorageJsonTestSuite, GetRegistrarFromEmpty)
 {
-    PersistentStorageJson psj("./test.tmp");
+    PersistentStorageJson psj("./tmp/test.tmp");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
 
@@ -241,9 +254,9 @@ TEST(PSJson, GetRegistrarFromEmpty)
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, GetDomainFromEmpty)
+TEST(PersistentStorageJsonTestSuite, GetDomainFromEmpty)
 {
-    PersistentStorageJson psj("./test.tmp");
+    PersistentStorageJson psj("./tmp/test.tmp");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
 
@@ -254,7 +267,7 @@ TEST(PSJson, GetDomainFromEmpty)
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, GetNetworkFromEmpty)
+TEST(PersistentStorageJsonTestSuite, GetNetworkFromEmpty)
 {
     PersistentStorageJson psj("");
 
@@ -267,9 +280,9 @@ TEST(PSJson, GetNetworkFromEmpty)
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, GetBorderRouterFromEmpty)
+TEST(PersistentStorageJsonTestSuite, GetBorderRouterFromEmpty)
 {
-    PersistentStorageJson psj("./test.tmp");
+    PersistentStorageJson psj("./tmp/test.tmp");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
 
@@ -280,12 +293,12 @@ TEST(PSJson, GetBorderRouterFromEmpty)
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, GetRegistrarNotEmpty)
+TEST(PersistentStorageJsonTestSuite, GetRegistrarNotEmpty)
 {
     // Make test independent
-    unlink("./test.tmp");
+    unlink("./tmp/test.tmp");
 
-    PersistentStorageJson psj("./test.tmp");
+    PersistentStorageJson psj("./tmp/test.tmp");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
 
@@ -310,12 +323,12 @@ TEST(PSJson, GetRegistrarNotEmpty)
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, GetDomainNotEmpty)
+TEST(PersistentStorageJsonTestSuite, GetDomainNotEmpty)
 {
     // Make test independent
-    unlink("./test.tmp");
+    unlink("./tmp/test.tmp");
 
-    PersistentStorageJson psj("./test.tmp");
+    PersistentStorageJson psj("./tmp/test.tmp");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
 
@@ -338,9 +351,9 @@ TEST(PSJson, GetDomainNotEmpty)
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, GetNetworkNotEmpty)
+TEST(PersistentStorageJsonTestSuite, GetNetworkNotEmpty)
 {
-    PersistentStorageJson psj("./test.tmp");
+    PersistentStorageJson psj("./tmp/test.tmp");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
 
@@ -367,12 +380,12 @@ TEST(PSJson, GetNetworkNotEmpty)
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, GetBorderRouterNotEmpty)
+TEST(PersistentStorageJsonTestSuite, GetBorderRouterNotEmpty)
 {
     // Make the test independent
-    unlink("./test.tmp");
+    unlink("./tmp/test.tmp");
 
-    PersistentStorageJson psj("./test.tmp");
+    PersistentStorageJson psj("./tmp/test.tmp");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
 
@@ -412,12 +425,12 @@ TEST(PSJson, GetBorderRouterNotEmpty)
 }
 
 // UPD
-TEST(PSJson, UpdRegistrar)
+TEST(PersistentStorageJsonTestSuite, UpdRegistrar)
 {
     // Make the test independent
-    unlink("./test.tmp");
+    unlink("./tmp/test.tmp");
 
-    PersistentStorageJson psj("./test.tmp");
+    PersistentStorageJson psj("./tmp/test.tmp");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
 
@@ -446,12 +459,12 @@ TEST(PSJson, UpdRegistrar)
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, UpdDomain)
+TEST(PersistentStorageJsonTestSuite, UpdDomain)
 {
     // Make the test independent
-    unlink("./test.tmp");
+    unlink("./tmp/test.tmp");
 
-    PersistentStorageJson psj("./test.tmp");
+    PersistentStorageJson psj("./tmp/test.tmp");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
 
@@ -478,10 +491,10 @@ TEST(PSJson, UpdDomain)
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, UpdNetwork)
+TEST(PersistentStorageJsonTestSuite, UpdNetwork)
 {
-    unlink("./tmp.json");
-    PersistentStorageJson psj("./tmp.json");
+    unlink("./tmp/tmp.json");
+    PersistentStorageJson psj("./tmp/tmp.json");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
 
@@ -505,12 +518,12 @@ TEST(PSJson, UpdNetwork)
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, UpdBorderRouter)
+TEST(PersistentStorageJsonTestSuite, UpdBorderRouter)
 {
     // Make test independent
-    unlink("./test.tmp");
+    unlink("./tmp/test.tmp");
 
-    PersistentStorageJson psj("./test.tmp");
+    PersistentStorageJson psj("./tmp/test.tmp");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
 
@@ -558,12 +571,12 @@ TEST(PSJson, UpdBorderRouter)
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, LookupRegistrar)
+TEST(PersistentStorageJsonTestSuite, LookupRegistrar)
 {
     // Make test independent
-    unlink("./test.tmp");
+    unlink("./tmp/test.tmp");
 
-    PersistentStorageJson psj("./test.tmp");
+    PersistentStorageJson psj("./tmp/test.tmp");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
 
@@ -634,12 +647,12 @@ TEST(PSJson, LookupRegistrar)
     EXPECT_TRUE(psj.Close() == PersistentStorage::Status::kSuccess);
 }
 
-TEST(PSJson, LookupNetwork)
+TEST(PersistentStorageJsonTestSuite, LookupNetwork)
 {
     // Make test independent
-    unlink("./test.tmp");
+    unlink("./tmp/test.tmp");
 
-    PersistentStorageJson psj("./test.tmp");
+    PersistentStorageJson psj("./tmp/test.tmp");
 
     EXPECT_TRUE(psj.Open() == PersistentStorage::Status::kSuccess);
 

--- a/src/app/ps/registry_test.cpp
+++ b/src/app/ps/registry_test.cpp
@@ -32,21 +32,17 @@
  */
 
 #include <gtest/gtest.h>
-
-#include "registry.hpp"
-
-#include <vector>
-
 #include <unistd.h>
 
 #include "app/cli/console.hpp"
+#include "app/ps/registry.hpp"
 
 #define INFO(str) Console::Write(str)
 
 using namespace ot::commissioner::persistent_storage;
 using namespace ot::commissioner;
 
-const char json_path[] = "./registry_test.json";
+const char json_path[] = "./tmp/registry_test.json";
 
 TEST(RegJson, CreateEmptyRegistry)
 {


### PR DESCRIPTION
Current unit tests are writing intermediate testing files to current dir.
This is polluting the source dir when executing the tests in the source root dir.

This commit updates the unit tests to output the testing data files to a dedicated
./tmp dir and ignore dir tmp/ from git.

Fixes https://github.com/openthread/ot-commissioner/issues/253