### PR TITLE
[uri] add DIAG_GET URIs for disgnostic APIs

### DIFF
--- a/src/library/uri.hpp
+++ b/src/library/uri.hpp
@@ -76,6 +76,15 @@ static const char *const kJoinFin             = "/c/jf";
 static const char *const kJoinApp             = "/c/ja";
 
 /*
+ * Thread diagnostic URIs
+ */
+
+static const char *const kDiagGet      = "/d/dg";
+static const char *const kDiagGetQuery = "/d/dq";
+static const char *const kDiagGetAns   = "/d/da";
+static const char *const kDiagRst      = "/d/dr";
+
+/*
  * Thread Network Layer URIs
  */
 static const char *const kMlr = "/n/mr";

--- a/src/library/uri.hpp
+++ b/src/library/uri.hpp
@@ -78,7 +78,6 @@ static const char *const kJoinApp             = "/c/ja";
 /*
  * Thread diagnostic URIs
  */
-
 static const char *const kDiagGet      = "/d/dg";
 static const char *const kDiagGetQuery = "/d/dq";
 static const char *const kDiagGetAns   = "/d/da";


### PR DESCRIPTION
In order to enable libotcommissioner.jar to support the diagnostic commands, it is necessary to integrate all diagnostic URIs into the uri module.