### PR TITLE
[diag] add a function to generate diag type list TLV based on a flag

### DIFF
--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1901,6 +1901,129 @@ exit:
     return error;
 }
 
+ByteArray CommissionerImpl::GetDiagTypeListTlvs(uint64_t aDiagTlvFlags)
+{
+    ByteArray tlvTypes;
+
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagExtMacAddress))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagExtMacAddress);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagMacAddress))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagMacAddress);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagMode))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagMode);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagTimeout))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagTimeout);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagConnectivity))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagConnectivity);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagRoute64))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagRoute64);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagLeaderData))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagLeaderData);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagNetworkData))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagNetworkData);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagIpv6Address))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagIpv6Address);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagMacCounters))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagMacCounters);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagBatteryLevel))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagBatteryLevel);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagSupplyVoltage))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagSupplyVoltage);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagChildTable))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagChildTable);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagChannelPages))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagChannelPages);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagMaxChildTimeout))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagMaxChildTimeout);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagLDevIDSubjectPubKeyInfo))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagLDevIDSubjectPubKeyInfo);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagIDevIDCert))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagIDevIDCert);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagEui64))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagEui64);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagVersion))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagVersion);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagVendorName))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagVendorName);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagVendorModel))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagVendorModel);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagVendorSWVersion))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagVendorSWVersion);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagThreadStackVersion))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagThreadStackVersion);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagChild))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagChild);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagChildIpv6Address))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagChildIpv6Address);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagRouterNeighbor))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagRouterNeighbor);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagAnswer))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagAnswer);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagQueryID))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagQueryID);
+    }
+    if (aDiagTlvFlags & (1 << (uint8_t)tlv::Type::kNetworkDiagMleCounters))
+    {
+        EncodeTlvType(tlvTypes, tlv::Type::kNetworkDiagMleCounters);
+    }
+    return tlvTypes;
+}
+
 ByteArray CommissionerImpl::GetCommissionerDatasetTlvs(uint16_t aDatasetFlags)
 {
     ByteArray tlvTypes;

--- a/src/library/commissioner_impl.hpp
+++ b/src/library/commissioner_impl.hpp
@@ -208,6 +208,8 @@ private:
     static ByteArray GetActiveOperationalDatasetTlvs(uint16_t aDatasetFlags);
     static ByteArray GetPendingOperationalDatasetTlvs(uint16_t aDatasetFlags);
 
+    static ByteArray GetDiagTypeListTlvs(uint64_t aDiagTlvFlags);
+
     static Error DecodeActiveOperationalDataset(ActiveOperationalDataset &aDataset, const ByteArray &aPayload);
     static Error DecodePendingOperationalDataset(PendingOperationalDataset &aDataset, const coap::Response &aResponse);
     static Error DecodeChannelMask(ChannelMask &aChannelMask, const ByteArray &aBuf);


### PR DESCRIPTION
Based on spec `10.11.4.6`, the type list TLV(18) concatenates the list of type identifiers of diagnostic TLVs. This TLV is used to request or reset the diag vlaues from other Thread devices.

This PR implements a function to generate the type list TLV vlaue based on a flag. Users can custmize the flag based on the diag TLVs type value. E.x. if users want to requeset or reset type 0, 1, 2 TLVs, they can set the flag to 0x7, where the position of bits 111 represent the required TLV types.