### PR TITLE
[coap] fix the code to ack the confirmable coap response rather than respond with the payload over the dtls session

### DIFF
--- a/src/library/coap.cpp
+++ b/src/library/coap.cpp
@@ -653,7 +653,7 @@ void Coap::HandleRequest(const Request &aRequest)
     {
         LOG_INFO(LOG_REGION_COAP, "server(={}) found cached CoAP response for resource {}", static_cast<void *>(this),
                  uriPath);
-        ExitNow(error = Send(*response));
+        VerifyOrExit(aRequest.IsConfirmable(), error = SendAck(aRequest));
     }
 
     resource = mResources.find(uriPath);

--- a/src/library/coap.cpp
+++ b/src/library/coap.cpp
@@ -653,7 +653,10 @@ void Coap::HandleRequest(const Request &aRequest)
     {
         LOG_INFO(LOG_REGION_COAP, "server(={}) found cached CoAP response for resource {}", static_cast<void *>(this),
                  uriPath);
-        VerifyOrExit(aRequest.IsConfirmable(), error = SendAck(aRequest));
+        if (aRequest.IsConfirmable())
+        {
+            SuccessOrExit(error = SendAck(aRequest));
+        }
     }
 
     resource = mResources.find(uriPath);


### PR DESCRIPTION
based on the CoAP protocol, when a CoAP server receives a confirmable CoAP response from another device, it should send a CoAP ACK message. It is incorrect to directly respond with the response data through the DTLS session.

