### PR TITLE
[udp-proxy] set local port to dedicated port number(:mm) for udp proxy transaction

### DIFF
--- a/include/commissioner/defines.hpp
+++ b/include/commissioner/defines.hpp
@@ -124,6 +124,11 @@ static constexpr uint16_t kDefaultAeUdpPort = 1001;
 static constexpr uint16_t kDefaultNmkpUdpPort = 1002;
 
 /**
+ * The default management UDP Port used by TMF transaction Thread devices if not specified.
+ */
+static constexpr uint16_t kDefaultMmPort = 61631;
+
+/**
  * If using radio 915Mhz. Default radio freq of Thread is 2.4Ghz.
  *
  * Used to encoding ChannelMask TLV.

--- a/include/commissioner/defines.hpp
+++ b/include/commissioner/defines.hpp
@@ -124,7 +124,7 @@ static constexpr uint16_t kDefaultAeUdpPort = 1001;
 static constexpr uint16_t kDefaultNmkpUdpPort = 1002;
 
 /**
- * The default management UDP Port used by TMF transaction Thread devices if not specified.
+ * The default management UDP Port used by TMF transaction in Thread devices.
  */
 static constexpr uint16_t kDefaultMmPort = 61631;
 

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -70,8 +70,6 @@ namespace commissioner {
 static constexpr uint16_t kLeaderAloc16     = 0xFC00;
 static constexpr uint16_t kPrimaryBbrAloc16 = 0xFC38;
 
-static constexpr uint16_t kDefaultMmPort = 61631;
-
 static constexpr uint32_t kMinKeepAliveInterval = 30;
 static constexpr uint32_t kMaxKeepAliveInterval = 45;
 

--- a/src/library/udp_proxy.cpp
+++ b/src/library/udp_proxy.cpp
@@ -73,6 +73,7 @@ Error ProxyEndpoint::Send(const ByteArray &aRequest, MessageSubType aSubType)
     Error         error;
     coap::Request udpTx{coap::Type::kNonConfirmable, coap::Code::kPost};
     ByteArray     udpPayload;
+    uint16_t      sockPort;
 
     (void)aSubType;
 
@@ -81,7 +82,8 @@ Error ProxyEndpoint::Send(const ByteArray &aRequest, MessageSubType aSubType)
 
     VerifyOrExit(mBrClient.IsConnected(), error = ERROR_INVALID_STATE("not connected to the border agent"));
 
-    utils::Encode<uint16_t>(udpPayload, mBrClient.GetDtlsSession().GetLocalPort());
+    sockPort = (mSockPort == 0) ? mBrClient.GetDtlsSession().GetLocalPort() : GetSockPort();
+    utils::Encode<uint16_t>(udpPayload, sockPort);
     utils::Encode<uint16_t>(udpPayload, GetPeerPort());
     udpPayload.insert(udpPayload.end(), aRequest.begin(), aRequest.end());
 
@@ -165,6 +167,7 @@ void ProxyClient::HandleUdpRx(const coap::Request &aUdpRx)
 
     mEndpoint.SetPeerAddr(peerAddr);
     mEndpoint.SetPeerPort(peerPort);
+    mEndpoint.SetSockPort(peerPort);
 
     mCoap.Receive({udpEncap->GetValue().begin() + 4, udpEncap->GetValue().end()});
 

--- a/src/library/udp_proxy.hpp
+++ b/src/library/udp_proxy.hpp
@@ -59,7 +59,6 @@ public:
     explicit ProxyEndpoint(coap::CoapSecure &aBrClient)
         : mBrClient(aBrClient)
         , mPeerPort(0)
-        , mSockPort(0)
     {
     }
     ~ProxyEndpoint() override = default;
@@ -67,17 +66,14 @@ public:
     Error    Send(const ByteArray &aRequest, MessageSubType aSubType) override;
     Address  GetPeerAddr() const override { return mPeerAddr; }
     uint16_t GetPeerPort() const override { return mPeerPort; }
-    uint16_t GetSockPort() const { return mSockPort; }
 
     void SetPeerAddr(const Address &aPeerAddr) { mPeerAddr = aPeerAddr; }
     void SetPeerPort(uint16_t aPeerPort) { mPeerPort = aPeerPort; }
-    void SetSockPort(uint16_t aSockPort) { mSockPort = aSockPort; }
 
 private:
     coap::CoapSecure &mBrClient;
     Address           mPeerAddr;
     uint16_t          mPeerPort;
-    uint16_t          mSockPort;
 };
 
 // The UDP proxy CoAP client that sends CoAP requests encapsulated

--- a/src/library/udp_proxy.hpp
+++ b/src/library/udp_proxy.hpp
@@ -71,7 +71,7 @@ public:
 
     void SetPeerAddr(const Address &aPeerAddr) { mPeerAddr = aPeerAddr; }
     void SetPeerPort(uint16_t aPeerPort) { mPeerPort = aPeerPort; }
-    void SetSockPort(uint16_t aSockPort) { mSockPort = mSockPort; }
+    void SetSockPort(uint16_t aSockPort) { mSockPort = aSockPort; }
 
 private:
     coap::CoapSecure &mBrClient;

--- a/src/library/udp_proxy.hpp
+++ b/src/library/udp_proxy.hpp
@@ -59,6 +59,7 @@ public:
     explicit ProxyEndpoint(coap::CoapSecure &aBrClient)
         : mBrClient(aBrClient)
         , mPeerPort(0)
+        , mSockPort(0)
     {
     }
     ~ProxyEndpoint() override = default;
@@ -66,14 +67,17 @@ public:
     Error    Send(const ByteArray &aRequest, MessageSubType aSubType) override;
     Address  GetPeerAddr() const override { return mPeerAddr; }
     uint16_t GetPeerPort() const override { return mPeerPort; }
+    uint16_t GetSockPort() const { return mSockPort; }
 
     void SetPeerAddr(const Address &aPeerAddr) { mPeerAddr = aPeerAddr; }
     void SetPeerPort(uint16_t aPeerPort) { mPeerPort = aPeerPort; }
+    void SetSockPort(uint16_t aSockPort) { mSockPort = mSockPort; }
 
 private:
     coap::CoapSecure &mBrClient;
     Address           mPeerAddr;
     uint16_t          mPeerPort;
+    uint16_t          mSockPort;
 };
 
 // The UDP proxy CoAP client that sends CoAP requests encapsulated


### PR DESCRIPTION
Currently, while the commissioner is transmitting udp_tx messages, the UDP source port is provided by the `DtlsSession` interface. This value is randomly generated. However, the CoAP layer on the border router side performs checks on the received udp_tx port to ensure that the destination UDP port used to outgoing messages matches the source port of the received messages. This leads to the commissioner's ACK messages not being processed, causing the BR side to repeatedly retransmit the same udp_rx message.

To resolve this issue, we use the default MM port as the only supported destination port for UDP_RX messages