### PR TITLE
[cli] add DIAG_GET reset command into cli

### DIFF
--- a/src/app/cli/interpreter.hpp
+++ b/src/app/cli/interpreter.hpp
@@ -224,6 +224,7 @@ private:
     Value ProcessEnergy(const Expression &aExpr);
     Value ProcessExit(const Expression &aExpr);
     Value ProcessHelp(const Expression &aExpr);
+    Value ProcessDiag(const Expression &aExpr);
 
     Value ProcessStartJob(CommissionerAppPtr &aCommissioner, const Expression &aExpr);
     Value ProcessStopJob(CommissionerAppPtr &aCommissioner, const Expression &aExpr);
@@ -232,6 +233,7 @@ private:
     Value ProcessCommDatasetJob(CommissionerAppPtr &aCommissioner, const Expression &aExpr);
     Value ProcessOpDatasetJob(CommissionerAppPtr &aCommissioner, const Expression &aExpr);
     Value ProcessBbrDatasetJob(CommissionerAppPtr &aCommissioner, const Expression &aExpr);
+    Value ProcessDiagJob(CommissionerAppPtr &aCommissioner, const Expression &aExpr);
 
     static void BorderAgentHandler(const BorderAgent *aBorderAgent, const Error &aError);
 

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -825,6 +825,14 @@ exit:
     return error;
 }
 
+Error CommissionerApp::CommandDiagGetReset(uint16_t aRloc, uint64_t aDiagTlvFlags)
+{
+    Error error;
+    SuccessOrExit(error = mCommissioner->CommandDiagGetReset(aRloc, aDiagTlvFlags));
+exit:
+    return error;
+}
+
 Error CommissionerApp::GetTriHostname(std::string &aHostname) const
 {
     Error error;

--- a/src/app/commissioner_app.hpp
+++ b/src/app/commissioner_app.hpp
@@ -226,6 +226,13 @@ public:
     MOCKABLE Error SetPendingDataset(const PendingOperationalDataset &aDataset);
 
     /*
+     * Diag TLV APIs
+     */
+
+    // Always send DIAG_GET.rst.
+    MOCKABLE Error CommandDiagGetReset(uint16_t aRloc, uint64_t aDiagTlvFlags);
+
+    /*
      * BBR Dataset APIs
      */
     MOCKABLE Error GetTriHostname(std::string &aHostname) const;


### PR DESCRIPTION
The DIAG_GET reset command can reset the diagnostic TLVs:

* MAC Counters (9)
* MLE Counters (34)

> diag reset --flag 512
diag reset --flag 512
[done]