### PR TITLE
[api] enable a DIAG_GET reset command into commissioner

### DIFF
--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -1146,6 +1146,30 @@ public:
      *         git repository.
      */
     static std::string GetVersion(void);
+
+    /**
+     * @brief Asynchronously reset a set of available diagnostic TLV(s) value.
+     *
+     * This method notifies a Thread device to reset a set of diagnostic value by sending DIAG_GET.rst message.
+     * It always returns immediately without waiting for the completion. //TBC by real test
+     *
+     * @param[in, out] aHandler       A handler of all response and errors; Guaranteed to be called.
+     * @param[in]      aRloc          The RLOC of dest Thread device.
+     * @param[in]      aDiagTlvFlags  Diagnostic TLVs flags indicate which TLVs are wanted.
+     */
+    virtual void CommandDiagGetReset(ErrorHandler aHandler, uint16_t aRloc, uint64_t aaDiagTlvFlags) = 0;
+
+    /**
+     * @brief Synchronously reset a set of available diagnostic TLV(s) value.
+     *
+     * This method notifies a Thread device to reset a set of diagnostic value by sending DIAG_GET.rst message.
+     * It will not return until errors happened, timeouted or succeed.
+     * @param[out] aRawTlvData    A diagnostic TLVs data returned by the leader or other Thread Device.
+     * @param[in]  aRloc          The RLOC of dest Thread device.
+     * @param[in]  aDiagTlvFlags  Diagnostic TLVs flags indicate which TLVs are wanted.
+     *
+     */
+    virtual Error CommandDiagGetReset(uint16_t aRloc, uint64_t aDiagTlvFlags) = 0;
 };
 
 } // namespace commissioner

--- a/src/library/commissioner_impl.hpp
+++ b/src/library/commissioner_impl.hpp
@@ -196,6 +196,9 @@ public:
 
     struct event_base *GetEventBase() { return mEventBase; }
 
+    void  CommandDiagGetReset(ErrorHandler aHandler, uint16_t aRloc, uint64_t aDiagTlvFlags) override;
+    Error CommandDiagGetReset(uint16_t, uint64_t) override { return ERROR_UNIMPLEMENTED(""); }
+
 private:
     using AsyncRequest = std::function<void()>;
 

--- a/src/library/commissioner_safe.hpp
+++ b/src/library/commissioner_safe.hpp
@@ -183,6 +183,9 @@ public:
 
     Error SetToken(const ByteArray &aSignedToken) override;
 
+    void  CommandDiagGetReset(ErrorHandler aHandler, uint16_t aRloc, uint64_t aaDiagTlvFlags) override;
+    Error CommandDiagGetReset(uint16_t aRloc, uint64_t aDiagTlvFlags) override;
+
 private:
     using AsyncRequest = std::function<void()>;
 


### PR DESCRIPTION
the DIAG_GET reset command is a key functionality of diagnositic feature in TMF, it can be used to reset MAC counters (9) and MLE counters (34).

User can use reset/request commands to do the link stats on MAC and Mesh layer.