### PR TITLE
[api] add a new api for getting the mesh local prefix

### DIFF
--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -1146,6 +1146,22 @@ public:
      *         git repository.
      */
     static std::string GetVersion(void);
+
+    /**
+     * @brief Asynchronously request mesh local prefix of the Thread Network.
+     *
+     * @param[in, out] aHandler  A handler of all errors; Guaranteed to be called.
+     */
+    virtual void RequestMeshLocalPrefix(Handler<ByteArray> aHandler) = 0;
+
+    /**
+     * @brief Request mesh local prefix of the Thread Network.
+     *
+     * @param[in] aMeshLocalPrefix  A mesh local prefix of the Thread Network.
+     *
+     * @return Error::kNone, succeed; Otherwise, failed.
+     */
+    virtual Error RequestMeshLocalPrefix(ByteArray &aMeshLocalPrefix) = 0;
 };
 
 } // namespace commissioner

--- a/src/java/commissioner.i
+++ b/src/java/commissioner.i
@@ -169,6 +169,8 @@ namespace commissioner {
                                                     uint32_t                        aTimeout);
     %ignore Commissioner::RequestToken(Handler<ByteArray> aHandler, const std::string &aAddr, uint16_t aPort);
 
+    %ignore Commissioner::RequestMeshLocalPrefix(Handler<ByteArray> aHandler);
+
     // Remove operators and move constructor of Error.
     %ignore Error::operator=(const Error &aError);
     %ignore Error::Error(Error &&aError) noexcept;

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -2212,6 +2212,31 @@ void CommissionerImpl::HandleJoinerSessionTimer(Timer &aTimer)
     }
 }
 
+void CommissionerImpl::RequestMeshLocalPrefix(Handler<ByteArray> aHandler)
+{
+    ByteArray meshLocalPrefix = mProxyClient.GetMeshLocalPrefix();
+
+    auto onMeshLocalPrefixResponse = [=](Error aError) {
+        if (aError == ErrorCode::kNone)
+        {
+            aHandler(&mProxyClient.GetMeshLocalPrefix(), aError);
+        }
+        else
+        {
+            aHandler(nullptr, ERROR_INVALID_STATE("failed to get the mesh local prefix"));
+        }
+    };
+
+    if (meshLocalPrefix.empty())
+    {
+        mProxyClient.FetchMeshLocalPrefix(onMeshLocalPrefixResponse);
+    }
+    else
+    {
+        aHandler(&meshLocalPrefix, ERROR_NONE);
+    }
+}
+
 } // namespace commissioner
 
 } // namespace ot

--- a/src/library/commissioner_impl.hpp
+++ b/src/library/commissioner_impl.hpp
@@ -194,6 +194,9 @@ public:
 
     Error SetToken(const ByteArray &aSignedToken) override;
 
+    void  RequestMeshLocalPrefix(Handler<ByteArray> aHandler) override;
+    Error RequestMeshLocalPrefix(ByteArray &) override { return ERROR_UNIMPLEMENTED(""); }
+
     struct event_base *GetEventBase() { return mEventBase; }
 
 private:

--- a/src/library/commissioner_safe.cpp
+++ b/src/library/commissioner_safe.cpp
@@ -542,6 +542,26 @@ Error CommissionerSafe::RequestToken(ByteArray &aSignedToken, const std::string 
     return pro.get_future().get();
 }
 
+void CommissionerSafe::RequestMeshLocalPrefix(Handler<ByteArray> aHandler)
+{
+    PushAsyncRequest([=]() { mImpl->RequestMeshLocalPrefix(aHandler); });
+}
+
+Error CommissionerSafe::RequestMeshLocalPrefix(ByteArray &aMeshLocalPrefix)
+{
+    std::promise<Error> pro;
+    auto                wait = [&pro, &aMeshLocalPrefix](const ByteArray *meshLocalPrefix, Error error) {
+        if (meshLocalPrefix != nullptr)
+        {
+            aMeshLocalPrefix = *meshLocalPrefix;
+        }
+        pro.set_value(error);
+    };
+
+    RequestMeshLocalPrefix(wait);
+    return pro.get_future().get();
+}
+
 Error CommissionerSafe::SetToken(const ByteArray &aSignedToken)
 {
     std::promise<Error> pro;

--- a/src/library/commissioner_safe.hpp
+++ b/src/library/commissioner_safe.hpp
@@ -183,6 +183,9 @@ public:
 
     Error SetToken(const ByteArray &aSignedToken) override;
 
+    void  RequestMeshLocalPrefix(Handler<ByteArray> aHandler) override;
+    Error RequestMeshLocalPrefix(ByteArray &) override;
+
 private:
     using AsyncRequest = std::function<void()>;
 


### PR DESCRIPTION
The primary purpose of providing this API is to enable external apps to generate the mesh local address(pefix + rloc) of a Thread device, which serves as the destination address for external commissioner to send UDP proxy commands.

Tested with CLI command:
> config set pskc 445f2b5ca6f2a93a55ce570a70efeecb
[done]
> start 192.168.9.2 49154
[done]
> meshlocalprefix
fd2b471153fcbe46
[done]