### PR TITLE
[coap] handle zero coap token length

### DIFF
--- a/src/library/coap.cpp
+++ b/src/library/coap.cpp
@@ -328,10 +328,13 @@ Error Message::Deserialize(Header &aHeader, const ByteArray &aBuf, size_t &aOffs
     header.mMessageId = aBuf[offset++];
     header.mMessageId = (header.mMessageId << 8) | aBuf[offset++];
 
-    VerifyOrExit(offset + header.mTokenLength <= aBuf.size(),
-                 error = ERROR_BAD_FORMAT("premature end of CoAP message header"));
-    memcpy(header.mToken, &aBuf[offset], std::min(header.mTokenLength, kMaxTokenLength));
-    offset += header.mTokenLength;
+    if (header.mTokenLength != 0)
+    {
+        VerifyOrExit(offset + header.mTokenLength <= aBuf.size(),
+                     error = ERROR_BAD_FORMAT("premature end of CoAP message header"));
+        memcpy(header.mToken, &aBuf[offset], std::min(header.mTokenLength, kMaxTokenLength));
+        offset += header.mTokenLength;
+    }
 
     aHeader = header;
     aOffset = offset;

--- a/src/library/coap_test.cpp
+++ b/src/library/coap_test.cpp
@@ -131,6 +131,18 @@ TEST(CoapTest, CoapMessageHeader_TokenIsPresent)
     EXPECT_EQ(message->GetToken(), ByteArray{0xfa});
 }
 
+TEST(CoapTest, CoapMessageHeader_TokenLengthIsZero)
+{
+    ByteArray buffer{'`', 0, 0, 1};
+    Error     error;
+    auto      message = Message::Deserialize(error, buffer);
+
+    EXPECT_NE(message, nullptr);
+    EXPECT_EQ(error, ErrorCode::kNone);
+
+    EXPECT_EQ(message->GetToken(), ByteArray{});
+}
+
 TEST(CoapTest, CoapMessageHeader_TokenLengthIsTooLong)
 {
     ByteArray buffer{0x49, 0x00, 0x00, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99};


### PR DESCRIPTION
There could be potential out of bound error if the token length in CoAP header is zero (`&aBuf[offset]` could be referring to the next element after the end of the buffer).

Note that the added test can pass without the fix in coap.cpp but it's probably because the toolchain has some optimization to avoid such issues...