### PR TITLE
[tlv] add new tlvs for network diagnostic

### DIFF
--- a/src/library/tlv.cpp
+++ b/src/library/tlv.cpp
@@ -278,9 +278,9 @@ bool Tlv::IsValid() const
         case Type::kNetworkDiagRouterNeighbor:
             return length >= 24;
         case Type::kNetworkDiagAnswer:
-            return length == 2;
+            return length >= 2;
         case Type::kNetworkDiagQueryID:
-            return length == 2;
+            return length >= 2;
         case Type::kNetworkDiagMleCounters:
             return length >= 66;
         default:

--- a/src/library/tlv.cpp
+++ b/src/library/tlv.cpp
@@ -220,6 +220,73 @@ bool Tlv::IsValid() const
     {
         return false;
     }
+    else if (mScope == Scope::kNetworkDiag)
+    {
+        switch (mType)
+        {
+        // Network disgnostic layer TLVs
+        case Type::kNetworkDiagExtMacAddress:
+            return length >= 8;
+        case Type::kNetworkDiagMacAddress:
+            return length >= 2;
+        case Type::kNetworkDiagMode:
+            return length >= 1;
+        case Type::kNetworkDiagTimeout:
+            return length >= 4;
+        case Type::kNetworkDiagConnectivity:
+            return true;
+        case Type::kNetworkDiagRoute64:
+            return length >= 4;
+        case Type::kNetworkDiagLeaderData:
+            return length >= 8;
+        case Type::kNetworkDiagNetworkData:
+            return true;
+        case Type::kNetworkDiagIpv6Address:
+            return (length % 16 == 0) && (length / 16 >= 1 && length / 16 <= 15);
+        case Type::kNetworkDiagMacCounters:
+            return length >= 36;
+        case Type::kNetworkDiagBatteryLevel:
+            return length >= 1;
+        case Type::kNetworkDiagSupplyVoltage:
+            return length >= 2;
+        case Type::kNetworkDiagChildTable:
+            return true; // list of 0 or more child entry data
+        case Type::kNetworkDiagChannelPages:
+            return length >= 1; // 1 or more 8-bit integers
+        case Type::kNetworkDiagTypeList:
+            return length >= 1; // 1 or more 8-bit integers
+        case Type::kNetworkDiagMaxChildTimeout:
+            return length >= 4;
+        case Type::kNetworkDiagLDevIDSubjectPubKeyInfo:
+            return true;
+        case Type::kNetworkDiagIDevIDCert:
+            return true;
+        case Type::kNetworkDiagEui64:
+            return length >= 8;
+        case Type::kNetworkDiagVersion:
+            return length >= 2;
+        case Type::kNetworkDiagVendorName:
+            return length >= 4;
+        case Type::kNetworkDiagVendorModel:
+            return length >= 4;
+        case Type::kNetworkDiagVendorSWVersion:
+            return length >= 2;
+        case Type::kNetworkDiagChild:
+            return length >= 43;
+        case Type::kNetworkDiagChildIpv6Address:
+            return (length % 16 == 0) && (length / 16 >= 1 && length / 16 <= 15);
+        case Type::kNetworkDiagRouterNeighbor:
+            return length >= 24;
+        case Type::kNetworkDiagAnswer:
+            return length == 2;
+        case Type::kNetworkDiagQueryID:
+            return length == 2;
+        case Type::kNetworkDiagMleCounters:
+            return length >= 66;
+        default:
+            return false;
+        }
+    }
 
     switch (mType)
     {

--- a/src/library/tlv.cpp
+++ b/src/library/tlv.cpp
@@ -274,7 +274,7 @@ bool Tlv::IsValid() const
         case Type::kNetworkDiagChild:
             return length >= 43;
         case Type::kNetworkDiagChildIpv6Address:
-            return (length % 16 == 0) && (length / 16 >= 1 && length / 16 <= 15);
+            return (length % 16 == 0) && (length / 16 >= 1);
         case Type::kNetworkDiagRouterNeighbor:
             return length >= 24;
         case Type::kNetworkDiagAnswer:

--- a/src/library/tlv.cpp
+++ b/src/library/tlv.cpp
@@ -242,7 +242,7 @@ bool Tlv::IsValid() const
         case Type::kNetworkDiagNetworkData:
             return true;
         case Type::kNetworkDiagIpv6Address:
-            return (length % 16 == 0) && (length / 16 >= 1 && length / 16 <= 15);
+            return (length % 16 == 0) && (length / 16 >= 1);
         case Type::kNetworkDiagMacCounters:
             return length >= 36;
         case Type::kNetworkDiagBatteryLevel:

--- a/src/library/tlv.hpp
+++ b/src/library/tlv.hpp
@@ -63,6 +63,7 @@ enum class Scope : uint8_t
     kMeshCoP = 0,
     kThread,
     kMeshLink,
+    kNetworkDiag,
 };
 
 enum class Type : uint8_t
@@ -139,6 +140,38 @@ enum class Type : uint8_t
     kCommissionerPenSignature = 70,
     kDiscoveryRequest         = 128,
     kDiscoveryResponse        = 129,
+
+    // TMF Network Diagnositcs TLVs
+    kNetworkDiagExtMacAddress           = 0,
+    kNetworkDiagMacAddress              = 1,
+    kNetworkDiagMode                    = 2,
+    kNetworkDiagTimeout                 = 3,
+    kNetworkDiagConnectivity            = 4,
+    kNetworkDiagRoute64                 = 5,
+    kNetworkDiagLeaderData              = 6,
+    kNetworkDiagNetworkData             = 7,
+    kNetworkDiagIpv6Address             = 8,
+    kNetworkDiagMacCounters             = 9,
+    kNetworkDiagBatteryLevel            = 14,
+    kNetworkDiagSupplyVoltage           = 15,
+    kNetworkDiagChildTable              = 16,
+    kNetworkDiagChannelPages            = 17,
+    kNetworkDiagTypeList                = 18,
+    kNetworkDiagMaxChildTimeout         = 19,
+    kNetworkDiagLDevIDSubjectPubKeyInfo = 20,
+    kNetworkDiagIDevIDCert              = 21,
+    kNetworkDiagEui64                   = 23,
+    kNetworkDiagVersion                 = 24,
+    kNetworkDiagVendorName              = 25,
+    kNetworkDiagVendorModel             = 26,
+    kNetworkDiagVendorSWVersion         = 27,
+    kNetworkDiagThreadStackVersion      = 28,
+    kNetworkDiagChild                   = 29,
+    kNetworkDiagChildIpv6Address        = 30,
+    kNetworkDiagRouterNeighbor          = 31,
+    kNetworkDiagAnswer                  = 32,
+    kNetworkDiagQueryID                 = 33,
+    kNetworkDiagMleCounters             = 34,
 };
 
 using TlvPtr      = std::shared_ptr<Tlv>;


### PR DESCRIPTION
libotcommissioner.jar, a versatile Java library, provides support for wide range of TMF message transactions, including MeshCop protocols and diagnostic TLVs. This PR focuses on integrating all the diagnostic TLVs, as defined in the spec `10.11.3` into the library's TLV modulei