### PR TITLE
[api] enable DIAG_GET request command into commissioner

### DIFF
--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -1146,6 +1146,39 @@ public:
      *         git repository.
      */
     static std::string GetVersion(void);
+
+    /**
+     * @brief Asynchronously requests diagnostic TLV data from a Thread device.
+     *
+     * This method sends a DIAG_GET.req message to the specified Thread device,
+     * requesting the set of diagnostic data indicated by `aDiagTlvFlags`.
+     * The response, or any errors encountered, will be delivered to the provided `aHandler`.
+     *
+     * @param[in, out] aHandler     A handler to process the response or any errors.
+     *                              This handler is guaranteed to be called.
+     * @param[in]     aAddr         Mesh local address (mesh local prefix + RLOC) of the target Thread device.
+     * @param[in]     aDiagTlvFlags Bitmask specifying the desired diagnostic TLVs.
+     *                              Each bit in the mask corresponds to a specific TLV type.
+     */
+    virtual void CommandDiagGetRequest(Handler<ByteArray> aHandler,
+                                       const std::string &aAddr,
+                                       uint64_t aaDiagTlvFlags) = 0;
+
+    /**
+     * @brief Synchronously requests diagnostic TLV data from a Thread device.
+     *
+     * This method sends a DIAG_GET.req message to the specified Thread device,
+     * requesting the set of diagnostic data indicated by `aDiagTlvFlags`.
+     * The method blocks until a response is received, an error occurs.
+     *
+     * @param[out] aRawTlvData   Upon success, contains the diagnostic TLV data returned by the device.
+     * @param[in]  aAddr         Mesh local address (mesh local prefix + RLOC) of the target Thread device.
+     * @param[in]  aDiagTlvFlags Bitmask for selecting desired diagnostic TLVs.
+     *                           Each bit in the mask corresponds to a specific TLV type.
+     *
+     * @return CHIP_NO_ERROR on success, or an appropriate error code on failure.
+     */
+    virtual Error CommandDiagGetRequest(ByteArray &aRawTlvData, const std::string &aAddr, uint64_t aDiagTlvFlags) = 0;
 };
 
 } // namespace commissioner

--- a/src/library/commissioner_impl.hpp
+++ b/src/library/commissioner_impl.hpp
@@ -196,6 +196,9 @@ public:
 
     struct event_base *GetEventBase() { return mEventBase; }
 
+    void  CommandDiagGetRequest(Handler<ByteArray> aHandler, const std::string &aAddr, uint64_t aDiagTlvFlags) override;
+    Error CommandDiagGetRequest(ByteArray &, const std::string &, uint64_t) override { return ERROR_UNIMPLEMENTED(""); }
+
 private:
     using AsyncRequest = std::function<void()>;
 
@@ -224,6 +227,7 @@ private:
     static Error     DecodeCommissionerDataset(CommissionerDataset &aDataset, const coap::Response &aResponse);
     static Error     EncodeCommissionerDataset(coap::Request &aRequest, const CommissionerDataset &aDataset);
     static ByteArray GetCommissionerDatasetTlvs(uint16_t aDatasetFlags);
+    static ByteArray GetDiagTypeListTlvs(uint64_t aDatasetFlags);
 
     void SendPetition(PetitionHandler aHandler);
 

--- a/src/library/commissioner_safe.cpp
+++ b/src/library/commissioner_safe.cpp
@@ -561,6 +561,25 @@ void CommissionerSafe::Invoke(evutil_socket_t, short, void *aContext)
     }
 }
 
+void CommissionerSafe::CommandDiagGetRequest(Handler<ByteArray> aHandler, const std::string &aAddr, uint64_t aDiagTlvFlags)
+{
+    PushAsyncRequest([=]() { mImpl->CommandDiagGetRequest(aHandler, aAddr, aDiagTlvFlags); });
+}
+
+Error CommissionerSafe::CommandDiagGetRequest(ByteArray &aRawTlvData, const std::string &aAddr, uint64_t aDiagTlvFlags)
+{
+    std::promise<Error> pro;
+    auto                wait = [&pro, &aRawTlvData](const ByteArray *rawTlvData, Error error) {
+        if (rawTlvData != nullptr)
+        {
+            aRawTlvData = *rawTlvData;
+        }
+        pro.set_value(error);
+    };
+    CommandDiagGetRequest(wait, aAddr, aDiagTlvFlags);
+    return pro.get_future().get();
+}
+
 void CommissionerSafe::PushAsyncRequest(AsyncRequest &&aAsyncRequest)
 {
     std::lock_guard<std::mutex> _(mInvokeMutex);

--- a/src/library/commissioner_safe.hpp
+++ b/src/library/commissioner_safe.hpp
@@ -183,6 +183,9 @@ public:
 
     Error SetToken(const ByteArray &aSignedToken) override;
 
+    void  CommandDiagGetRequest(Handler<ByteArray> aHandler, const std::string &aAddr, uint64_t aDiagTlvFlags) override;
+    Error CommandDiagGetRequest(ByteArray &aRawTlvData, const std::string &aAddr, uint64_t aDiagTlvFlags) override;
+
 private:
     using AsyncRequest = std::function<void()>;
 


### PR DESCRIPTION
This PR adds a DIAG_GET request command to the commissioner module, allowing users to request one or more diagnostic TLVs from a peer Thread device by setting the device's mesh local address and TLV mask bits flag. The content of received TLV(s) will be stored in the format of a raw Byte array.

Additionally, a function called `GetDiagTypeListTlvs` is implemented to parse the request TLV IDs and generate the value of the diagnostic type list TLV. The type list TLV is then sent out through the DIAG_GET request message.