### PR TITLE
[android] add basic tests for auto generated java lib

### DIFF
--- a/.github/workflows/android-app-build.yml
+++ b/.github/workflows/android-app-build.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        android-api: [24, 34]
+        android-api: [26, 34]
         android-abi: [x86_64]
         os: [macos-12, ubuntu-22.04]
     steps:

--- a/android/openthread_commissioner/service/build.gradle
+++ b/android/openthread_commissioner/service/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-vision:20.1.3+'
     implementation 'com.google.android.gms:play-services-threadnetwork:16.0.0'
     implementation 'com.google.android.material:material:1.2.1'
-    testImplementation 'junit:junit:4.+'
+    androidTestImplementation 'com.google.truth:truth:1.4.4'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
 }

--- a/android/openthread_commissioner/service/src/androidTest/java/io/openthread/commissioner/ActiveOperationalDatasetTest.java
+++ b/android/openthread_commissioner/service/src/androidTest/java/io/openthread/commissioner/ActiveOperationalDatasetTest.java
@@ -1,0 +1,34 @@
+package io.openthread.commissioner;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.stream.Collectors;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class ActiveOperationalDatasetTest {
+  @Test
+  public void channelMask_valuesAreCorrect() {
+    ActiveOperationalDataset dataset = new ActiveOperationalDataset();
+    ChannelMaskEntry entry1 = new ChannelMaskEntry();
+    entry1.setPage((short) 0);
+    entry1.setMasks(new ByteArray(new byte[] {0x01, 0x02, 0x03, 0x04}));
+    ChannelMaskEntry entry2 = new ChannelMaskEntry();
+    entry2.setPage((short) 1);
+    entry2.setMasks(new ByteArray(new byte[] {0x05, 0x06, 0x07, 0x08}));
+    ChannelMask maskEntries = new ChannelMask();
+    maskEntries.add(entry1);
+    maskEntries.add(entry2);
+    dataset.setChannelMask(maskEntries);
+
+    assertThat(dataset.getChannelMask()).hasSize(2);
+    assertThat(dataset.getChannelMask().get(0).getPage()).isEqualTo(0);
+    assertThat(dataset.getChannelMask().get(0).getMasks().stream().collect(Collectors.toList()))
+        .containsExactly((byte) 0x01, (byte) 0x02, (byte) 0x03, (byte) 0x04);
+    assertThat(dataset.getChannelMask().get(1).getPage()).isEqualTo(1);
+    assertThat(dataset.getChannelMask().get(1).getMasks().stream().collect(Collectors.toList()))
+        .containsExactly((byte) 0x05, (byte) 0x06, (byte) 0x07, (byte) 0x08);
+  }
+}


### PR DESCRIPTION
When the SWIG interface file (commissioner.i) is updated, the generated
java library API may be broken. There are currently no tests to guard this.
This commit adds a basic androidTest for this purpose. Note that an
Android rather than junit test is added because the test case depends on
an JNI library (and it's easier to work with JNI in Android tests).