### PR TITLE
[build] include `common/logging.hpp` at `token_manager.cpp` to fix build

### DIFF
--- a/src/library/token_manager.cpp
+++ b/src/library/token_manager.cpp
@@ -45,6 +45,7 @@
 #include "commissioner/defines.hpp"
 #include "commissioner/error.hpp"
 #include "common/error_macros.hpp"
+#include "common/logging.hpp"
 #include "common/utils.hpp"
 #include "event2/event.h"
 #include "library/cbor.hpp"


### PR DESCRIPTION
There's a recent build failure of ot-reference-release when trying to bump the `ot-commissioner` repo: https://github.com/openthread/ot-reference-release/actions/runs/10164731867/job/28110844136?pr=79.

I also reproduced the issue locally. After including `common/logging.hpp`, the build is fixed.