### PR TITLE
[android] handles unscoped ipv6 link-local address

### DIFF
--- a/android/openthread_commissioner/app/build.gradle
+++ b/android/openthread_commissioner/app/build.gradle
@@ -97,7 +97,7 @@ dependencies {
 
     implementation fileTree(dir: "libs", include: ["*.jar"])
 
-    implementation 'com.google.guava:guava:31.1-jre'
+    implementation 'com.google.guava:guava:33.2.1-android'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "androidx.concurrent:concurrent-futures:1.1.0"
     implementation 'androidx.constraintlayout:constraintlayout:2.0.2'

--- a/android/openthread_commissioner/app/src/main/java/io/openthread/commissioner/app/BorderAgentInfo.java
+++ b/android/openthread_commissioner/app/src/main/java/io/openthread/commissioner/app/BorderAgentInfo.java
@@ -48,9 +48,9 @@ public class BorderAgentInfo implements Parcelable {
       @NonNull byte[] extendedPanId,
       @NonNull InetAddress host,
       @NonNull int port) {
-    this.id = id == null ? null : id.clone();
+    this.id = (id == null ? null : id.clone());
     this.networkName = networkName;
-    this.extendedPanId = extendedPanId == null ? null : extendedPanId.clone();
+    this.extendedPanId = (extendedPanId == null ? null : extendedPanId.clone());
     this.host = host;
     this.port = port;
   }


### PR DESCRIPTION
On Android devices before Android U, the scope ID of Ipv6 link-local address is not set when it's returned to the caller via NsdServiceInfo. To make the LLA usable, this commit sets the missing scope ID to the interface ID of the current active default network.