### PR TITLE
[github-actions] fix existing checks failures due to workflows settings

### DIFF
--- a/.github/workflows/android-app-build.yml
+++ b/.github/workflows/android-app-build.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build
         run: |
           cd android
-          ANDROID_ABI=${{ matrix.android-abi }} ANDROID_NDK_HOME=$(find $ANDROID_HOME/ndk -name "24.*") ./build-commissioner-libs.sh
+          ANDROID_ABI=${{ matrix.android-abi }} ANDROID_NDK_HOME=$(find $ANDROID_HOME/ndk -name "26.*") ./build-commissioner-libs.sh
           cd openthread_commissioner
           ./gradlew build
       - name: Tests

--- a/.github/workflows/android-app-release.yml
+++ b/.github/workflows/android-app-release.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Build APK
         run: |
           cd android
-          ANDROID_ABI=armeabi-v7a ANDROID_NDK_HOME=$(find $ANDROID_HOME/ndk -name "24.*") ./build-commissioner-libs.sh
-          ANDROID_ABI=arm64-v8a ANDROID_NDK_HOME=$(find $ANDROID_HOME/ndk -name "24.*") ./build-commissioner-libs.sh
+          ANDROID_ABI=armeabi-v7a ANDROID_NDK_HOME=$(find $ANDROID_HOME/ndk -name "26.*") ./build-commissioner-libs.sh
+          ANDROID_ABI=arm64-v8a ANDROID_NDK_HOME=$(find $ANDROID_HOME/ndk -name "26.*") ./build-commissioner-libs.sh
           cd openthread_commissioner
           ./gradlew assembleDebug
 

--- a/.github/workflows/android-app-release.yml
+++ b/.github/workflows/android-app-release.yml
@@ -62,7 +62,7 @@ jobs:
              ot-commissioner-app-debug-${{ steps.check_release_version.outputs.release_version }}.apk
       - name: Upload APK for release
         if: success() && github.repository == 'openthread/ot-commissioner' && github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ot-commissioner-app-debug-v${{ steps.check_release_version.outputs.release_version }}
           path: ./android/openthread_commissioner/ot-commissioner-app-debug-*.apk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,8 +159,8 @@ jobs:
       - name: Build
         run: |
           cd android
-          ANDROID_ABI=armeabi-v7a ANDROID_NDK_HOME=$(find $ANDROID_HOME/ndk -name "24.*") ./build-commissioner-libs.sh
-          ANDROID_ABI=arm64-v8a ANDROID_NDK_HOME=$(find $ANDROID_HOME/ndk -name "24.*") ./build-commissioner-libs.sh
+          ANDROID_ABI=armeabi-v7a ANDROID_NDK_HOME=$(find $ANDROID_HOME/ndk -name "26.*") ./build-commissioner-libs.sh
+          ANDROID_ABI=arm64-v8a ANDROID_NDK_HOME=$(find $ANDROID_HOME/ndk -name "26.*") ./build-commissioner-libs.sh
 
   java-binding:
     runs-on: macos-12

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -130,6 +130,9 @@ elif [ "$(uname)" = "Darwin" ]; then
         brew unlink cmake
         brew install cmake --HEAD
     }
+
+    ## Install coreutils for realpath
+    brew install coreutils
 else
     echo "platform $(uname) is not fully supported"
     exit 1


### PR DESCRIPTION
-  Update upload-artifact version from v2 to v4 for handling the build-release check failure:

Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`.

Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

- Update the ANDROID_NDK_HOME setting for fixing the build apk failure

ANDROID_NDK_HOME not set! Please set it to your Android NDK location!
Error: Process completed with exit code 1.

-  Install coreutils for realpath tool on MacOS for "macos" check failure

script/bootstrap.sh: line 138: realpath: command not found