### PR TITLE
[api] enable DIAG_RST notify funcation into commissioner

### DIFF
--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -1147,6 +1147,36 @@ public:
      *         git repository.
      */
     static std::string GetVersion(void);
+
+    /**
+     * @brief Asynchronously reset dedicated diagnostic TLVs from a Thread device.
+     *
+     * This method sends a DIAG_RST.ntf message to the specified Thread device,
+     * resetting the diagnostic TLVs (MacCounters & MleCounters) indicated by `aDiagTlvFlags`.
+     * The response, or any errors encountered, will be delivered to the provided `aHandler`.
+     *
+     * @param[in, out] aHandler        A handler to process the response or any errors.
+     *                                 This handler is guaranteed to be called.
+     * @param[in]      aAddr           Mesh local address of the target Thread device.
+     * @param[in]      aDiagTlvFlags   Diagnostic TLVs flags indicate which TLVs are wanted.
+     *
+     */
+    virtual void CommandDiagReset(ErrorHandler aHandler, const std::string &aAddr, uint64_t aDiagTlvFlags) = 0;
+
+    /**
+     * @brief Synchronously reset dedicated diagnostic TLVs from a Thread device.
+     *
+     * This method sends a DIAG_RST.nrf message to the specified Thread device,
+     * resetting the diagnostic TLVs (MacCounters & MleCounters) indicated by `aDiagTlvFlags`.
+     * The method blocks until a response is received, an error occurs.
+     *
+     * @param[in]  aAddr            Mesh local address of the target Thread device.
+     * @param[in]  aDiagTlvFlags    Diagnostic TLVs flags indicate which TLVs are wanted.
+     *
+     * @return Error::kNone, succeed; Otherwise, failed.
+     *
+     */
+    virtual Error CommandDiagReset(const std::string &aAddr, uint64_t aDiagTlvFlags) = 0;
 };
 
 } // namespace commissioner

--- a/include/commissioner/network_diag_data.hpp
+++ b/include/commissioner/network_diag_data.hpp
@@ -1,0 +1,341 @@
+/*
+ *    Copyright (c) 2024, The OpenThread Commissioner Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file defines the types of Thread Network Diagnostic TLVs used for network diagnostics.
+ */
+
+#ifndef OT_COMM_NETWORK_DIAG_TLVS_HPP_
+#define OT_COMM_NETWORK_DIAG_TLVS_HPP_
+
+#include <cstddef>
+#include <cstdint>
+#include <stdbool.h>
+#include <string>
+#include <vector>
+
+#include "defines.hpp"
+#include "error.hpp"
+
+namespace ot {
+
+namespace commissioner {
+
+/**
+ * @brief Mode TLV
+ */
+struct Mode
+{
+    bool mIsRxOnWhenIdleMode          = false;
+    bool mIsMtd                       = false;
+    bool mIsStableNetworkDataRequired = false;
+
+    /**
+     * Decodes Mode from a ByteArray
+     */
+    static void Decode(Mode &aMode, uint8_t aBuf);
+
+    /**
+     * Returns a string representation of the Mode.
+     */
+    std::string ToString() const;
+};
+
+/**
+ * @brief Child Entry in Child Table TLV
+ */
+struct ChildEntry
+{
+    uint8_t mTimeout             = 0;
+    uint8_t mIncomingLinkQuality = 0;
+    uint8_t mChildId             = 0;
+    Mode    mModeData;
+
+    /**
+     * Decodes ChildEntry from a ByteArray
+     */
+    static Error Decode(ChildEntry &aChildEntry, const ByteArray &aBuf);
+
+    /**
+     * Returns a string representation of the ChildEntry.
+     */
+    std::string ToString() const;
+};
+
+/**
+ * @brief Child Table TLV
+ */
+struct ChildTable
+{
+    std::vector<ChildEntry> mChildEntries;
+    /**
+     * Decodes ChildTable from a ByteArray
+     */
+    static Error Decode(ChildTable &aChildTable, const ByteArray &aBuf);
+
+    /**
+     * Returns a string representation of the ChildTable.
+     */
+    std::string ToString() const;
+
+    /**
+     * Returns the size of the ChildTable.
+     */
+    size_t GetSize() const;
+
+    /**
+     * Returns the ChildEntry at the given index.
+     */
+    ChildEntry GetChildEntry(size_t aIndex) const;
+};
+
+/**
+ * @brief IPv6 Address TLV
+ */
+struct Ipv6Address
+{
+    ByteArray mAddress;
+    /**
+     * Decodes Ipv6Address from a ByteArray
+     */
+    static Error Decode(Ipv6Address &aIpv6Address, const ByteArray &aBuf);
+
+    /**
+     * Returns a string representation of the Ipv6Address.
+     */
+    std::string ToString() const;
+};
+
+/**
+ * @brief IPv6 Address TLV
+ */
+struct Ipv6AddressList
+{
+    std::vector<Ipv6Address> mIpv6Addresses;
+
+    /**
+     * Returns the size of the Ipv6AddressList.
+     */
+    size_t GetSize() const;
+
+    /**
+     * Returns the Ipv6Address at the given index.
+     */
+    Ipv6Address GetIpv6Address(size_t aIndex) const;
+
+    /**
+     * Decodes Ipv6Address from a ByteArray
+     */
+    static Error Decode(Ipv6AddressList &aIpv6Address, const ByteArray &aBuf);
+
+    /**
+     * Returns a string representation of the Ipv6Address.
+     */
+    std::string ToString() const;
+};
+
+/**
+ * @brief Leader Data TLV
+ */
+struct LeaderData
+{
+    uint32_t mPartitionId       = 0;
+    uint8_t  mWeighting         = 0;
+    uint8_t  mDataVersion       = 0;
+    uint8_t  mStableDataVersion = 0;
+    uint8_t  mRouterId          = 0;
+
+    /**
+     * Decodes LeaderData from a ByteArray
+     */
+    static Error Decode(LeaderData &aLeaderData, const ByteArray &aBuf);
+
+    /**
+     * Returns a string representation of the LeaderData.
+     */
+    std::string ToString() const;
+};
+
+/**
+ * @brief Route Data Entry of RouteData in Route64 TLV
+ */
+struct RouteDataEntry
+{
+    uint8_t mRouterId            = 0;
+    uint8_t mOutgoingLinkQuality = 0;
+    uint8_t mIncomingLinkQuality = 0;
+    uint8_t mRouteCost           = 0;
+    /**
+     * Decodes RouteDataEntry from a ByteArray
+     */
+    static void Decode(RouteDataEntry &aRouteDataEntry, uint8_t aBuf);
+};
+
+/**
+ * @brief Route64 TLV
+ */
+struct Route64
+{
+    uint8_t                     mIdSequence = 0;
+    ByteArray                   mMask;
+    std::vector<RouteDataEntry> mRouteData;
+    /**
+     * Decodes Route64 from a ByteArray
+     */
+    static Error Decode(Route64 &aRoute64, const ByteArray &aBuf);
+
+    /**
+     * Extracts router IDs from a router ID mask.
+     */
+    static ByteArray ExtractRouterIds(const ByteArray &aMask);
+
+    /**
+     * Returns a string representation of the Route64.
+     */
+    std::string ToString() const;
+
+    /**
+     * Returns the size of the RouteData.
+     */
+    size_t GetRouteDataSize() const;
+
+    /**
+     * Returns the RouteDataEntry at the given index.
+     */
+    RouteDataEntry GetRouteData(size_t aIndex) const;
+};
+
+struct ChildIpv6AddressList
+{
+    uint16_t        mRloc16 = 0;
+    Ipv6AddressList mIpv6AddressList;
+
+    /**
+     * Decodes ChildIpv6Address from a ByteArray
+     */
+    static Error Decode(ChildIpv6AddressList &aChildIpv6AddressList, const ByteArray &aBuf);
+
+    /**
+     * Returns a string representation of the ChildIpv6Address.
+     */
+    std::string ToString() const;
+};
+
+struct Child
+{
+    bool      mRxOnWhenIdleFlag     = false;
+    bool      mFullThreadDeviceFlag = false;
+    bool      mFullNetworkDataFlag  = false;
+    bool      mCslFlag              = false;
+    bool      mErrorRateFlag        = false;
+    uint16_t  mRloc16               = 0;
+    ByteArray mExtMacAddress;
+    uint16_t  mThreadVersion       = 0;
+    uint32_t  mTimeout             = 0;
+    uint32_t  mAge                 = 0;
+    uint32_t  mConnectionTime      = 0;
+    uint16_t  mSupervisionInterval = 0;
+    uint8_t   mLinkMargin          = 0;
+    uint8_t   mAverageRssi         = 0;
+    uint8_t   mLastRssi            = 0;
+    uint16_t  mFrameErrorRate      = 0;
+    uint16_t  mMessageErrorRate    = 0;
+    uint16_t  mQueuedMessageCount  = 0;
+    uint16_t  mCslPeriod           = 0;
+    uint32_t  mCslTimeout          = 0;
+    uint8_t   mCslChannel          = 0;
+};
+
+struct MacCounters
+{
+    uint32_t mIfInUnknownProtos  = 0;
+    uint32_t mIfInErrors         = 0;
+    uint32_t mIfOutErrors        = 0;
+    uint32_t mIfInUcastPkts      = 0;
+    uint32_t mIfInBroadcastPkts  = 0;
+    uint32_t mIfInDiscards       = 0;
+    uint32_t mIfOutUcastPkts     = 0;
+    uint32_t mIfOutBroadcastPkts = 0;
+    uint32_t mIfOutDiscards      = 0;
+
+    /**
+     * Decodes MacCounters from a ByteArray
+     */
+    static Error Decode(MacCounters &aMacCounters, const ByteArray &aBuf);
+
+    /**
+     * Returns a string representation of the MacCounters.
+     */
+    std::string ToString() const;
+};
+
+/**
+ * @brief network diagnostic TLVs in TMF
+ *
+ * Each data field of Diagnostic TLVs is optional. The field is
+ * meaningful only when associative PresentFlags is included in
+ * `mPresentFlags`.
+ */
+struct NetDiagTlvs
+{
+    ByteArray            mExtMacAddress;
+    uint16_t             mMacAddress = 0;
+    Mode                 mMode;
+    Route64              mRoute64;
+    LeaderData           mLeaderData;
+    Ipv6AddressList      mIpv6Addresses;
+    ChildTable           mChildTable;
+    ByteArray            mEui64;
+    ByteArray            mTlvTypeList;
+    ChildIpv6AddressList mChildIpv6AddressList;
+    MacCounters          mMacCounters;
+
+    /**
+     * Indicates which fields are included in the dataset.
+     */
+    uint64_t mPresentFlags;
+
+    static constexpr uint64_t kExtMacAddressBit    = (1ull << 63);
+    static constexpr uint64_t kMacAddressBit       = (1ull << 62);
+    static constexpr uint64_t kModeBit             = (1ull << 61);
+    static constexpr uint64_t kRoute64Bit          = (1ull << 60);
+    static constexpr uint64_t kLeaderDataBit       = (1ull << 59);
+    static constexpr uint64_t kIpv6AddressBit      = (1ull << 58);
+    static constexpr uint64_t kChildTableBit       = (1ull << 57);
+    static constexpr uint64_t kEui64Bit            = (1ull << 56);
+    static constexpr uint64_t kTlvTypeBit          = (1ull << 55);
+    static constexpr uint64_t kMacCountersBit      = (1ull << 54);
+    static constexpr uint64_t kChildIpv6AddressBit = (1ull << 53);
+};
+
+} // namespace commissioner
+
+} // namespace ot
+
+#endif // OT_COMM_NETWORK_DIAG_TLVS_HPP_

--- a/src/app/cli/interpreter.cpp
+++ b/src/app/cli/interpreter.cpp
@@ -116,6 +116,8 @@
 #define WARN_NETWORK_SELECTION_DROPPED "Network selection was dropped by the command"
 #define WARN_NETWORK_SELECTION_CHANGED "Network selection was changed by the command"
 
+#define DIAG_RST_NTF_TYPE 2
+
 #define COLOR_ALIAS_FAILED Console::Color::kYellow
 
 namespace ot {
@@ -200,7 +202,7 @@ const std::map<std::string, Interpreter::Evaluator> &Interpreter::mEvaluatorMap 
     {"announce", &Interpreter::ProcessAnnounce},   {"panid", &Interpreter::ProcessPanId},
     {"energy", &Interpreter::ProcessEnergy},       {"exit", &Interpreter::ProcessExit},
     {"quit", &Interpreter::ProcessExit},           {"help", &Interpreter::ProcessHelp},
-    {"state", &Interpreter::ProcessState},
+    {"state", &Interpreter::ProcessState},         {"diag", &Interpreter::ProcessDiag},
 };
 
 const std::map<std::string, std::string> &Interpreter::mUsageMap = *new std::map<std::string, std::string>{
@@ -263,6 +265,7 @@ const std::map<std::string, std::string> &Interpreter::mUsageMap = *new std::map
                   "opdataset set active '<active-dataset-in-json-string>'\n"
                   "opdataset get pending\n"
                   "opdataset set pending '<pending-dataset-in-json-string>'"},
+    {"diag", "diag reset maccounters <dest mesh local address>"},
     {"bbrdataset", "bbrdataset get trihostname\n"
                    "bbrdataset set trihostname <TRI-hostname>\n"
                    "bbrdataset get reghostname\n"
@@ -2549,6 +2552,59 @@ Interpreter::Value Interpreter::ProcessEnergy(const Expression &aExpr)
         value = ERROR_INVALID_COMMAND(SYNTAX_INVALID_SUBCOMMAND, aExpr[1]);
     }
 
+exit:
+    return value;
+}
+
+// Diagnostic feature in TMF
+Interpreter::Value Interpreter::ProcessDiag(const Expression &aExpr)
+{
+    Value              value;
+    CommissionerAppPtr commissioner = nullptr;
+
+    SuccessOrExit(value = mJobManager->GetSelectedCommissioner(commissioner));
+    value = ProcessDiagJob(commissioner, aExpr);
+exit:
+    return value;
+}
+
+Interpreter::Value Interpreter::ProcessDiagJob(CommissionerAppPtr &aCommissioner, const Expression &aExpr)
+{
+    Value       value;
+    uint64_t    flags         = 0;
+    uint8_t     operationType = 0;
+    std::string dstAddr;
+    NetDiagTlvs tlvs;
+    ByteArray   rawTlvs;
+
+    VerifyOrExit(aExpr.size() >= 3, value = ERROR_INVALID_ARGS("{} \n {}", SYNTAX_FEW_ARGS,
+                                                               "diag [reset] [maccounters] <dest mesh local address>"));
+    if (aExpr.size() > 3 && !aExpr[3].empty())
+    {
+        dstAddr = aExpr[3];
+    }
+    else
+    {
+        dstAddr.clear();
+    }
+
+    if (CaseInsensitiveEqual(aExpr[1], "reset"))
+    {
+        operationType = DIAG_RST_NTF_TYPE;
+    }
+    else
+    {
+        ExitNow(value = ERROR_INVALID_COMMAND(SYNTAX_INVALID_SUBCOMMAND, aExpr[1]));
+    }
+
+    if (CaseInsensitiveEqual(aExpr[2], "maccounters"))
+    {
+        flags = NetDiagTlvs::kMacCountersBit;
+        if (operationType == DIAG_RST_NTF_TYPE)
+        {
+            SuccessOrExit(value = aCommissioner->CommandDiagReset(dstAddr, flags));
+        }
+    }
 exit:
     return value;
 }

--- a/src/app/cli/interpreter.hpp
+++ b/src/app/cli/interpreter.hpp
@@ -225,6 +225,8 @@ private:
     Value ProcessEnergy(const Expression &aExpr);
     Value ProcessExit(const Expression &aExpr);
     Value ProcessHelp(const Expression &aExpr);
+    // Diagnostic feature in TMF
+    Value ProcessDiag(const Expression &aExpr);
 
     Value ProcessStartJob(CommissionerAppPtr &aCommissioner, const Expression &aExpr);
     Value ProcessStopJob(CommissionerAppPtr &aCommissioner, const Expression &aExpr);
@@ -233,6 +235,8 @@ private:
     Value ProcessCommDatasetJob(CommissionerAppPtr &aCommissioner, const Expression &aExpr);
     Value ProcessOpDatasetJob(CommissionerAppPtr &aCommissioner, const Expression &aExpr);
     Value ProcessBbrDatasetJob(CommissionerAppPtr &aCommissioner, const Expression &aExpr);
+    // Diagnostic feature in TMF
+    Value ProcessDiagJob(CommissionerAppPtr &aCommissioner, const Expression &aExpr);
 
     static void BorderAgentHandler(const BorderAgent *aBorderAgent, const Error &aError);
 

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -1389,6 +1389,15 @@ const JoinerInfo *CommissionerApp::GetJoinerInfo(JoinerType aType, const ByteArr
     return nullptr;
 }
 
+// Network Diagnostic
+Error CommissionerApp::CommandDiagReset(const std::string &aAddr, uint64_t aDiagTlvFlags)
+{
+    Error error;
+
+    error = mCommissioner->CommandDiagReset(aAddr, aDiagTlvFlags);
+    return error;
+}
+
 } // namespace commissioner
 
 } // namespace ot

--- a/src/app/commissioner_app.hpp
+++ b/src/app/commissioner_app.hpp
@@ -50,6 +50,7 @@
 #include "commissioner/defines.hpp"
 #include "commissioner/error.hpp"
 #include "commissioner/network_data.hpp"
+#include "commissioner/network_diag_data.hpp"
 #include "common/address.hpp"
 
 namespace ot {
@@ -228,6 +229,9 @@ public:
 
     // Always send MGMT_PENDING_SET.req.
     MOCKABLE Error SetPendingDataset(const PendingOperationalDataset &aDataset);
+
+    // Network Diagnostic
+    MOCKABLE Error CommandDiagReset(const std::string &aAddr, uint64_t aDiagTlvFlags);
 
     /*
      * BBR Dataset APIs

--- a/src/app/commissioner_app_dummy.cpp
+++ b/src/app/commissioner_app_dummy.cpp
@@ -518,6 +518,13 @@ const EnergyReportMap &CommissionerApp::GetAllEnergyReports() const
     return sEnergyReportMap;
 }
 
+Error CommissionerApp::CommandDiagReset(const std::string &aAddr, uint64_t aDiagTlvFlags)
+{
+    UNUSED(aAddr);
+    UNUSED(aDiagTlvFlags);
+    return Error{};
+}
+
 } // namespace commissioner
 
 } // namespace ot

--- a/src/app/commissioner_app_mock.hpp
+++ b/src/app/commissioner_app_mock.hpp
@@ -137,6 +137,7 @@ public:
     MOCK_METHOD(Error, EnergyScan, (uint32_t, uint8_t, uint16_t, uint16_t, const std::string &));
     MOCK_METHOD(const EnergyReport *, GetEnergyReport, (const Address &), (const));
     MOCK_METHOD(const EnergyReportMap &, GetAllEnergyReports, (), (const));
+    MOCK_METHOD(Error, CommandDiagReset, (const std::string &, uint64_t));
 };
 
 class CommissionerAppStaticExpecter

--- a/src/java/commissioner.i
+++ b/src/java/commissioner.i
@@ -167,6 +167,9 @@ namespace commissioner {
                                                     const std::vector<std::string> &aMulticastAddrList,
                                                     uint32_t                        aTimeout);
     %ignore Commissioner::RequestToken(Handler<ByteArray> aHandler, const std::string &aAddr, uint16_t aPort);
+    %ignore Commissioner::CommandDiagReset(ErrorHandler         aHandler,
+                                           const std::string   &aAddr,
+                                           uint64_t             aDiagTlvFlags);
 
     // Remove operators and move constructor of Error.
     %ignore Error::operator=(const Error &aError);
@@ -186,5 +189,6 @@ namespace commissioner {
 %include <commissioner/defines.hpp>
 %include <commissioner/error.hpp>
 %include <commissioner/network_data.hpp>
+%include <commissioner/network_diag_data.hpp>
 %include <commissioner/commissioner.hpp>
 %include <commissioner/commissioner.hpp>

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(commissioner
     mbedtls_error.hpp
     message.hpp
     network_data.cpp
+    network_diag_data.cpp
     openthread/bloom_filter.cpp
     openthread/bloom_filter.hpp
     openthread/crc16.cpp

--- a/src/library/commissioner_impl.hpp
+++ b/src/library/commissioner_impl.hpp
@@ -40,6 +40,7 @@
 #include "commissioner/defines.hpp"
 #include "commissioner/error.hpp"
 #include "commissioner/network_data.hpp"
+#include "commissioner/network_diag_data.hpp"
 #include "common/error_macros.hpp"
 #include "common/time.hpp"
 #include "event2/event.h"
@@ -144,6 +145,9 @@ public:
         return ERROR_UNIMPLEMENTED("");
     }
 
+    void  CommandDiagReset(ErrorHandler aHandler, const std::string &aAddr, uint64_t aDiagTlvFlags) override;
+    Error CommandDiagReset(const std::string &, uint64_t) override { return ERROR_UNIMPLEMENTED(""); }
+
     void  AnnounceBegin(ErrorHandler       aHandler,
                         uint32_t           aChannelMask,
                         uint8_t            aCount,
@@ -214,6 +218,9 @@ private:
     static Error EncodeActiveOperationalDataset(coap::Request &aRequest, const ActiveOperationalDataset &aDataset);
     static Error EncodePendingOperationalDataset(coap::Request &aRequest, const PendingOperationalDataset &aDataset);
     static Error EncodeChannelMask(ByteArray &aBuf, const ChannelMask &aChannelMask);
+
+    static Error     DecodeNetDiagTlvs(NetDiagTlvs &aNetDiagTlvs, const ByteArray &aPayload);
+    static ByteArray GetDiagTlvs(uint64_t aDiagTlvFlags);
 
 #if OT_COMM_CONFIG_CCM_ENABLE
     static Error     DecodeBbrDataset(BbrDataset &aDataset, const coap::Response &aResponse);

--- a/src/library/commissioner_safe.cpp
+++ b/src/library/commissioner_safe.cpp
@@ -46,6 +46,7 @@
 #include "commissioner/defines.hpp"
 #include "commissioner/error.hpp"
 #include "commissioner/network_data.hpp"
+#include "commissioner/network_diag_data.hpp"
 #include "common/error_macros.hpp"
 #include "common/logging.hpp"
 #include "common/utils.hpp"
@@ -327,6 +328,19 @@ Error CommissionerSafe::GetRawActiveDataset(ByteArray &aRawDataset, uint16_t aDa
     };
 
     GetRawActiveDataset(wait, aDatasetFlags);
+    return pro.get_future().get();
+}
+
+void CommissionerSafe::CommandDiagReset(ErrorHandler aHandler, const std::string &aAddr, uint64_t aDiagTlvFlags)
+{
+    PushAsyncRequest([=]() { mImpl->CommandDiagReset(aHandler, aAddr, aDiagTlvFlags); });
+}
+
+Error CommissionerSafe::CommandDiagReset(const std::string &aAddr, uint64_t aDiagTlvFlags)
+{
+    std::promise<Error> pro;
+    auto                wait = [&pro](Error error) { pro.set_value(error); };
+    CommandDiagReset(wait, aAddr, aDiagTlvFlags);
     return pro.get_future().get();
 }
 

--- a/src/library/commissioner_safe.hpp
+++ b/src/library/commissioner_safe.hpp
@@ -146,6 +146,9 @@ public:
                          const std::string &aDstNetworkName) override;
     Error CommandMigrate(const std::string &aDstAddr, const std::string &aDesignatedNetwork) override;
 
+    void  CommandDiagReset(ErrorHandler aHandler, const std::string &aAddr, uint64_t aDiagTlvFlags) override;
+    Error CommandDiagReset(const std::string &aAddr, uint64_t aDiagTlvFlags) override;
+
     void  RegisterMulticastListener(Handler<uint8_t>                aHandler,
                                     const std::vector<std::string> &aMulticastAddrList,
                                     uint32_t                        aTimeout) override;

--- a/src/library/network_diag_data.cpp
+++ b/src/library/network_diag_data.cpp
@@ -1,0 +1,350 @@
+/*
+ *    Copyright (c) 2024, The OpenThread Commissioner Authors.
+ *    All rights reserved.
+ *
+ *    Redistribution and use in source and binary forms, with or without
+ *    modification, are permitted provided that the following conditions are met:
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    3. Neither the name of the copyright holder nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ *    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *    POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "commissioner/network_diag_data.hpp"
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <sys/types.h>
+#include "commissioner/defines.hpp"
+#include "commissioner/error.hpp"
+#include "common/error_macros.hpp"
+#include "common/utils.hpp"
+
+#define ROUTER_ID_MASK_BYTES 8
+#define CHILD_TABLE_ENTRY_BYTES 4
+#define IPV6_ADDRESS_BYTES 16
+#define RLOC16_BYTES 2
+#define MAC_COUNTERS_BYTES 36
+
+namespace ot {
+
+namespace commissioner {
+
+Error LeaderData::Decode(LeaderData &aLeaderData, const ByteArray &aBuf)
+{
+    size_t length = aBuf.size();
+    Error  error;
+
+    VerifyOrExit(length == 8, error = ERROR_BAD_FORMAT("incorrect size of LeaderData"));
+
+    aLeaderData.mPartitionId       = utils::Decode<uint32_t>(aBuf.data(), 4);
+    aLeaderData.mWeighting         = aBuf[length - 4];
+    aLeaderData.mDataVersion       = aBuf[length - 3];
+    aLeaderData.mStableDataVersion = aBuf[length - 2];
+    aLeaderData.mRouterId          = aBuf[length - 1];
+exit:
+    return error;
+}
+
+void RouteDataEntry::Decode(RouteDataEntry &aRouteDataEntry, uint8_t aBuf)
+{
+    aRouteDataEntry.mOutgoingLinkQuality = (aBuf >> 6) & 0x03;
+    aRouteDataEntry.mIncomingLinkQuality = (aBuf >> 4) & 0x03;
+    aRouteDataEntry.mRouteCost           = aBuf & 0x0F;
+}
+
+Error Route64::Decode(Route64 &aRoute64, const ByteArray &aBuf)
+{
+    Error     error;
+    size_t    length = aBuf.size();
+    size_t    offset = 0;
+    ByteArray routerIdList;
+
+    VerifyOrExit(length >= ROUTER_ID_MASK_BYTES + 1, error = ERROR_BAD_FORMAT("incorrect size of Route64"));
+    aRoute64.mIdSequence = aBuf[offset++];
+    aRoute64.mMask       = {aBuf.begin() + offset, aBuf.begin() + offset + ROUTER_ID_MASK_BYTES};
+    offset += ROUTER_ID_MASK_BYTES;
+
+    routerIdList = ExtractRouterIds(aRoute64.mMask);
+    VerifyOrExit((length - offset) == routerIdList.size(), error = ERROR_BAD_FORMAT("incorrect size of RouteData"));
+    while (offset < length)
+    {
+        RouteDataEntry entry;
+        entry.mRouterId = routerIdList[offset - ROUTER_ID_MASK_BYTES - 1];
+        RouteDataEntry::Decode(entry, aBuf[offset]);
+        aRoute64.mRouteData.emplace_back(entry);
+        offset++;
+    }
+exit:
+    return error;
+}
+
+std::string Route64::ToString() const
+{
+    std::string ret;
+    ret += "id_sequence: " + std::to_string(mIdSequence) + "\n";
+    ret += "mask: ";
+    for (uint8_t byte : mMask)
+    {
+        ret += std::to_string(byte) + " ";
+    }
+    ret += "\n";
+    for (const auto &entry : mRouteData)
+    {
+        ret += "router_id: " + std::to_string(entry.mRouterId) + "\n";
+        ret += "outgoing_link_quality: " + std::to_string(entry.mOutgoingLinkQuality) + "\n";
+        ret += "incomming_link_quality: " + std::to_string(entry.mIncomingLinkQuality) + "\n";
+        ret += "route_cost: " + std::to_string(entry.mRouteCost) + "\n";
+    }
+    return ret;
+}
+
+size_t Route64::GetRouteDataSize() const
+{
+    return mRouteData.size();
+}
+
+RouteDataEntry Route64::GetRouteData(size_t aIndex) const
+{
+    return mRouteData[aIndex];
+}
+
+std::string LeaderData::ToString() const
+{
+    std::string ret;
+    ret += "partition_id: " + std::to_string(mPartitionId) + "\n";
+    ret += "weighting: " + std::to_string(mWeighting) + "\n";
+    ret += "data_version: " + std::to_string(mDataVersion) + "\n";
+    ret += "stable_data_version: " + std::to_string(mStableDataVersion) + "\n";
+    ret += "router_id: " + std::to_string(mRouterId) + "\n";
+    return ret;
+}
+
+ByteArray Route64::ExtractRouterIds(const ByteArray &aMask)
+{
+    ByteArray routerIdList;
+
+    for (size_t i = 0; i < ROUTER_ID_MASK_BYTES * 8; i++)
+    {
+        if ((aMask[i / 8] & (0x80 >> (i % 8))) != 0)
+        {
+            routerIdList.push_back(i);
+        }
+    }
+
+    return routerIdList;
+}
+
+void Mode::Decode(Mode &aMode, uint8_t aBuf)
+{
+    aMode.mIsRxOnWhenIdleMode          = (aBuf & 0x01) != 0;
+    aMode.mIsMtd                       = (aBuf & 0x02) != 0;
+    aMode.mIsStableNetworkDataRequired = (aBuf & 0x04) != 0;
+}
+
+std::string Mode::ToString() const
+{
+    std::string ret;
+    ret += "is_rx_on_when_idle_mode: " + std::to_string(mIsRxOnWhenIdleMode) + "\n";
+    ret += "is_mtd: " + std::to_string(mIsMtd) + "\n";
+    ret += "is_stable_network_data_required: " + std::to_string(mIsStableNetworkDataRequired) + "\n";
+    return ret;
+}
+
+Error ChildEntry::Decode(ChildEntry &aChildEntry, const ByteArray &aBuf)
+{
+    Error  error;
+    size_t length = aBuf.size();
+    size_t offset = 0;
+
+    VerifyOrExit(offset + 4 <= length, error = ERROR_BAD_FORMAT("premature end of Child Table"));
+    aChildEntry.mTimeout             = aBuf[offset++];
+    aChildEntry.mIncomingLinkQuality = aBuf[offset++];
+    aChildEntry.mChildId             = aBuf[offset++];
+    Mode::Decode(aChildEntry.mModeData, aBuf[offset++]);
+exit:
+    return error;
+}
+
+std::string ChildEntry::ToString() const
+{
+    std::string ret;
+    ret += "timeout: " + std::to_string(mTimeout) + "\n";
+    ret += "incoming_link_quality: " + std::to_string(mIncomingLinkQuality) + "\n";
+    ret += "child_id: " + std::to_string(mChildId) + "\n";
+    ret += "mode: " + mModeData.ToString() + "\n";
+    return ret;
+}
+
+Error ChildTable::Decode(ChildTable &aChildTable, const ByteArray &aBuf)
+{
+    Error  error;
+    size_t length = aBuf.size();
+    size_t offset = 0;
+    while (offset < length)
+    {
+        ChildEntry entry;
+        VerifyOrExit(offset + 4 <= length, error = ERROR_BAD_FORMAT("premature end of Child Table"));
+        SuccessOrExit(error = ChildEntry::Decode(
+                          entry, {aBuf.begin() + offset, aBuf.begin() + offset + CHILD_TABLE_ENTRY_BYTES}));
+        aChildTable.mChildEntries.emplace_back(entry);
+    }
+exit:
+    return error;
+}
+
+std::string ChildTable::ToString() const
+{
+    std::string ret;
+    for (const auto &entry : mChildEntries)
+    {
+        ret += entry.ToString() + "\n";
+    }
+    return ret;
+}
+
+size_t ChildTable::GetSize() const
+{
+    return mChildEntries.size();
+}
+
+ChildEntry ChildTable::GetChildEntry(size_t aIndex) const
+{
+    return mChildEntries[aIndex];
+}
+
+Error Ipv6Address::Decode(Ipv6Address &aIpv6Address, const ByteArray &aBuf)
+{
+    Error error;
+    VerifyOrExit(aBuf.size() == IPV6_ADDRESS_BYTES, error = ERROR_BAD_FORMAT("premature end of IPv6 Address"));
+    aIpv6Address.mAddress = {aBuf.begin(), aBuf.end()};
+exit:
+    return error;
+}
+
+std::string Ipv6Address::ToString() const
+{
+    std::string ret;
+    for (size_t i = 0; i < IPV6_ADDRESS_BYTES; i++)
+    {
+        if (i % 2 == 0 && i != 0 && i != IPV6_ADDRESS_BYTES - 1)
+        {
+            ret += ":";
+        }
+        ret += std::to_string(mAddress[i]);
+    }
+    return ret;
+}
+
+Error Ipv6AddressList::Decode(Ipv6AddressList &aIpv6AddressList, const ByteArray &aBuf)
+{
+    Error  error;
+    size_t length = aBuf.size();
+    size_t offset = 0;
+    while (offset < length)
+    {
+        VerifyOrExit(offset + IPV6_ADDRESS_BYTES <= length, error = ERROR_BAD_FORMAT("premature end of IPv6 Address"));
+        Ipv6Address ipv6Address;
+        SuccessOrExit(error = Ipv6Address::Decode(ipv6Address,
+                                                  {aBuf.begin() + offset, aBuf.begin() + offset + IPV6_ADDRESS_BYTES}));
+        aIpv6AddressList.mIpv6Addresses.emplace_back(ipv6Address);
+        offset += IPV6_ADDRESS_BYTES;
+    }
+exit:
+    return error;
+}
+
+std::string Ipv6AddressList::ToString() const
+{
+    std::string ret;
+    for (const auto &address : mIpv6Addresses)
+    {
+        ret += address.ToString() + "\n";
+    }
+    return ret;
+}
+
+size_t Ipv6AddressList::GetSize() const
+{
+    return mIpv6Addresses.size();
+}
+
+Ipv6Address Ipv6AddressList::GetIpv6Address(size_t aIndex) const
+{
+    return mIpv6Addresses[aIndex];
+}
+
+Error ChildIpv6AddressList::Decode(ChildIpv6AddressList &aChildIpv6AddressList, const ByteArray &aBuf)
+{
+    Error  error;
+    size_t length = aBuf.size();
+    size_t offset = 0;
+    VerifyOrExit(length >= RLOC16_BYTES, error = ERROR_BAD_FORMAT("premature end of Child IPv6 Address"));
+    aChildIpv6AddressList.mRloc16 = utils::Decode<uint16_t>(aBuf.data(), 2);
+    offset += RLOC16_BYTES;
+    SuccessOrExit(
+        error = Ipv6AddressList::Decode(aChildIpv6AddressList.mIpv6AddressList, {aBuf.begin() + offset, aBuf.end()}));
+exit:
+    return error;
+}
+
+std::string ChildIpv6AddressList::ToString() const
+{
+    std::string ret;
+    ret += "rloc16: " + std::to_string(mRloc16) + "\n";
+    ret += "ipv6_address: " + mIpv6AddressList.ToString() + "\n";
+    return ret;
+}
+
+Error MacCounters::Decode(MacCounters &aMacCounters, const ByteArray &aBuf)
+{
+    Error  error;
+    size_t length = aBuf.size();
+    VerifyOrExit(length >= MAC_COUNTERS_BYTES, error = ERROR_BAD_FORMAT("premature end of MacCounters"));
+    aMacCounters.mIfInUnknownProtos  = utils::Decode<uint32_t>(aBuf.data(), 4);
+    aMacCounters.mIfInErrors         = utils::Decode<uint32_t>(aBuf.data() + 4, 4);
+    aMacCounters.mIfOutErrors        = utils::Decode<uint32_t>(aBuf.data() + 8, 4);
+    aMacCounters.mIfInUcastPkts      = utils::Decode<uint32_t>(aBuf.data() + 12, 4);
+    aMacCounters.mIfInBroadcastPkts  = utils::Decode<uint32_t>(aBuf.data() + 16, 4);
+    aMacCounters.mIfInDiscards       = utils::Decode<uint32_t>(aBuf.data() + 20, 4);
+    aMacCounters.mIfOutUcastPkts     = utils::Decode<uint32_t>(aBuf.data() + 24, 4);
+    aMacCounters.mIfOutBroadcastPkts = utils::Decode<uint32_t>(aBuf.data() + 28, 4);
+    aMacCounters.mIfOutDiscards      = utils::Decode<uint32_t>(aBuf.data() + 32, 4);
+exit:
+    return error;
+}
+
+std::string MacCounters::ToString() const
+{
+    std::string ret;
+    ret += "if_in_unknown_protos: " + std::to_string(mIfInUnknownProtos) + "\n";
+    ret += "if_in_errors: " + std::to_string(mIfInErrors) + "\n";
+    ret += "if_out_errors: " + std::to_string(mIfOutErrors) + "\n";
+    ret += "if_in_ucast_pkts: " + std::to_string(mIfInUcastPkts) + "\n";
+    ret += "if_in_broadcast_pkts: " + std::to_string(mIfInBroadcastPkts) + "\n";
+    ret += "if_in_discards: " + std::to_string(mIfInDiscards) + "\n";
+    ret += "if_out_ucast_pkts: " + std::to_string(mIfOutUcastPkts) + "\n";
+    ret += "if_out_broadcast_pkts: " + std::to_string(mIfOutBroadcastPkts) + "\n";
+    ret += "if_out_discards: " + std::to_string(mIfOutDiscards) + "\n";
+    return ret;
+}
+
+} // namespace commissioner
+
+} // namespace ot


### PR DESCRIPTION
This PR adds DIAG_RST notify command into the commissioner module, allowing users to reset MacCounters(9) TLV from a peer Thread device by settting the device's mesh local address and TLV mask bits flag.

Test:
config set pskc 445f2b5ca6f2a93a55ce570a70efeecb
[done]
start 192.168.9.2 49154
[done]
diag reset maccounters fdce:bb1d:37f6:6978:0:ff:fe00:cc00 [done]