### PR TITLE
[api] enable DIAG_RST notify funcation into commissioner

### DIFF
--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -1216,7 +1216,7 @@ public:
      * @brief Synchronously reset dedicated diagnostic TLVs on a Thread device.
      *
      * This method sends a DIAG_RST.ntf message to the specified Thread device,
-     * resetting the diagnostic TLVs such as MacCounters  indicated by `aDiagDataFlags`.
+     * resetting the diagnostic TLVs such as MacCounters indicated by `aDiagDataFlags`.
      * The method blocks until a response is received, an error occurs.
      *
      * @param[in]      aAddr          Unicast mesh local address of the target Thread device,

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -1213,7 +1213,7 @@ public:
     virtual void CommandDiagReset(ErrorHandler aHandler, const std::string &aAddr, uint64_t aDiagDataFlags) = 0;
 
     /**
-     * @brief Synchronously reset dedicated diagnostic TLVs from a Thread device.
+     * @brief Synchronously reset dedicated diagnostic TLVs on a Thread device.
      *
      * This method sends a DIAG_RST.ntf message to the specified Thread device,
      * resetting the diagnostic TLVs such as MacCounters  indicated by `aDiagDataFlags`.

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -1217,7 +1217,7 @@ public:
      *
      * This method sends a DIAG_RST.ntf message to the specified Thread device,
      * resetting the diagnostic TLVs such as MacCounters indicated by `aDiagDataFlags`.
-     * The method blocks until a response is received, an error occurs.
+     * The method blocks until a response is received or an error occurs.
      *
      * @param[in]      aAddr          Unicast mesh local address of the target Thread device,
      *                                the leader ALOC will be used if it is empty.

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -1206,7 +1206,7 @@ public:
      * @param[in, out] aHandler        A handler to process the response or any errors.
      *                                 This handler is guaranteed to be called.
      * @param[in]      aAddr           Unicast mesh local address of the target Thread device,
-     *                                 the leader ALOC will be set by default if it is empty.
+     *                                 the leader ALOC will be used if it is empty.
      * @param[in]      aDiagDataFlags  Diagnostic data flags indicate which TLVs are wanted.
      *
      */

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -1195,6 +1195,38 @@ public:
      *
      */
     virtual Error CommandDiagGetQuery(const std::string &aAddr, uint64_t aDiagDataFlags) = 0;
+
+    /**
+     * @brief Asynchronously reset dedicated diagnostic TLV(s) from a Thread device.
+     *
+     * This method sends a DIAG_RST.ntf message to the specified Thread device,
+     * resetting the diagnostic TLVs such as MacCounters  indicated by `aDiagDataFlags`.
+     * The response, or any errors encountered, will be delivered to the provided `aHandler`.
+     *
+     * @param[in, out] aHandler        A handler to process the response or any errors.
+     *                                 This handler is guaranteed to be called.
+     * @param[in]      aAddr           Unicast mesh local address of the target Thread device,
+     *                                 the leader ALOC will be set by default if it is empty.
+     * @param[in]      aDiagDataFlags  Diagnostic data flags indicate which TLVs are wanted.
+     *
+     */
+    virtual void CommandDiagReset(ErrorHandler aHandler, const std::string &aAddr, uint64_t aDiagDataFlags) = 0;
+
+    /**
+     * @brief Synchronously reset dedicated diagnostic TLVs from a Thread device.
+     *
+     * This method sends a DIAG_RST.ntf message to the specified Thread device,
+     * resetting the diagnostic TLVs such as MacCounters  indicated by `aDiagDataFlags`.
+     * The method blocks until a response is received, an error occurs.
+     *
+     * @param[in]      aAddr          Unicast mesh local address of the target Thread device,
+     *                                the leader ALOC will be set by default if it is empty.
+     * @param[in]  aDiagDataFlags     Diagnostic data flags indicate which TLVs are wanted.
+     *
+     * @return Error::kNone, succeed; Otherwise, failed.
+     *
+     */
+    virtual Error CommandDiagReset(const std::string &aAddr, uint64_t aDiagDataFlags) = 0;
 };
 
 } // namespace commissioner

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -1220,7 +1220,7 @@ public:
      * The method blocks until a response is received, an error occurs.
      *
      * @param[in]      aAddr          Unicast mesh local address of the target Thread device,
-     *                                the leader ALOC will be set by default if it is empty.
+     *                                the leader ALOC will be used if it is empty.
      * @param[in]  aDiagDataFlags     Diagnostic data flags indicate which TLVs are wanted.
      *
      * @return Error::kNone, succeed; Otherwise, failed.

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -1197,7 +1197,7 @@ public:
     virtual Error CommandDiagGetQuery(const std::string &aAddr, uint64_t aDiagDataFlags) = 0;
 
     /**
-     * @brief Asynchronously reset dedicated diagnostic TLV(s) from a Thread device.
+     * @brief Asynchronously reset dedicated diagnostic TLV(s) on a Thread device.
      *
      * This method sends a DIAG_RST.ntf message to the specified Thread device,
      * resetting the diagnostic TLVs such as MacCounters indicated by `aDiagDataFlags`.

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -1200,7 +1200,7 @@ public:
      * @brief Asynchronously reset dedicated diagnostic TLV(s) from a Thread device.
      *
      * This method sends a DIAG_RST.ntf message to the specified Thread device,
-     * resetting the diagnostic TLVs such as MacCounters  indicated by `aDiagDataFlags`.
+     * resetting the diagnostic TLVs such as MacCounters indicated by `aDiagDataFlags`.
      * The response, or any errors encountered, will be delivered to the provided `aHandler`.
      *
      * @param[in, out] aHandler        A handler to process the response or any errors.

--- a/src/app/commissioner_app.cpp
+++ b/src/app/commissioner_app.cpp
@@ -1413,6 +1413,14 @@ const DiagAnsDataMap &CommissionerApp::GetNetDiagTlvs() const
     return mDiagAnsDataMap;
 }
 
+Error CommissionerApp::CommandDiagReset(const std::string &aAddr, uint64_t aDiagDataFlags)
+{
+    Error error;
+
+    error = mCommissioner->CommandDiagReset(aAddr, aDiagDataFlags);
+    return error;
+}
+
 } // namespace commissioner
 
 } // namespace ot

--- a/src/app/commissioner_app.hpp
+++ b/src/app/commissioner_app.hpp
@@ -236,6 +236,7 @@ public:
 
     // Network Diagnostic
     MOCKABLE Error CommandDiagGetQuery(const std::string &aAddr, uint64_t aDiagDataFlags);
+    MOCKABLE Error CommandDiagReset(const std::string &aAddr, uint64_t aDiagDataFlags);
 
     /*
      * BBR Dataset APIs

--- a/src/app/commissioner_app_dummy.cpp
+++ b/src/app/commissioner_app_dummy.cpp
@@ -538,6 +538,13 @@ Error CommissionerApp::CommandDiagGetQuery(const std::string &aAddr, uint64_t aD
     return Error{};
 }
 
+Error CommissionerApp::CommandDiagReset(const std::string &aAddr, uint64_t aDiagTlvFlags)
+{
+    UNUSED(aAddr);
+    UNUSED(aDiagTlvFlags);
+    return Error{};
+}
+
 } // namespace commissioner
 
 } // namespace ot

--- a/src/app/commissioner_app_mock.hpp
+++ b/src/app/commissioner_app_mock.hpp
@@ -141,6 +141,7 @@ public:
     MOCK_METHOD(const EnergyReportMap &, GetAllEnergyReports, (), (const));
     MOCK_METHOD(const DiagAnsDataMap &, GetNetDiagTlvs, (), (const));
     MOCK_METHOD(Error, CommandDiagGetQuery, (const std::string &, uint64_t));
+    MOCK_METHOD(Error, CommandDiagReset, (const std::string &, uint64_t));
 };
 
 class CommissionerAppStaticExpecter

--- a/src/app/json.cpp
+++ b/src/app/json.cpp
@@ -777,11 +777,36 @@ static void to_json(Json &aJson, const NetDiagData &aNetDiagData)
     SET_IF_PRESENT(ExtMacAddr);
     SET_IF_PRESENT(MacAddr);
 #undef SET_IF_PRESENT
+    if (aNetDiagData.mPresentFlags & NetDiagData::kMacCountersBit)
+    {
+        aJson["MacCounters"] = MacCountersToJson(aNetDiagData.mMacCounters);
+    }
 }
 
 std::string NetDiagDataToJson(const NetDiagData &aNetDiagData)
 {
     Json json = aNetDiagData;
+    return json.dump(JSON_INDENT_DEFAULT);
+}
+
+static void to_json(Json &aJson, const MacCounters &aMacCounters)
+{
+#define SET(name) aJson[#name] = aMacCounters.m##name;
+    SET(IfInUnknownProtos);
+    SET(IfInErrors);
+    SET(IfOutErrors);
+    SET(IfInUcastPkts);
+    SET(IfInBroadcastPkts);
+    SET(IfInDiscards);
+    SET(IfOutUcastPkts);
+    SET(IfOutBroadcastPkts);
+    SET(IfOutDiscards);
+#undef SET
+}
+
+std::string MacCountersToJson(const MacCounters &aMacCounters)
+{
+    Json json = aMacCounters;
     return json.dump(JSON_INDENT_DEFAULT);
 }
 

--- a/src/app/json.hpp
+++ b/src/app/json.hpp
@@ -63,6 +63,7 @@ struct NetworkData
 
 Error       NetworkDataFromJson(NetworkData &aNetworkData, const std::string &aJson);
 std::string NetworkDataToJson(const NetworkData &aNetworkData);
+std::string MacCountersToJson(const MacCounters &aMacCounters);
 
 Error       CommissionerDatasetFromJson(CommissionerDataset &aDataset, const std::string &aJson);
 std::string CommissionerDatasetToJson(const CommissionerDataset &aDataset);

--- a/src/library/commissioner_impl.hpp
+++ b/src/library/commissioner_impl.hpp
@@ -195,6 +195,8 @@ public:
 
     void  CommandDiagGetQuery(ErrorHandler aHandler, const std::string &aAddr, uint64_t aDiagDataFlags) override;
     Error CommandDiagGetQuery(const std::string &, uint64_t) override { return ERROR_UNIMPLEMENTED(""); }
+    void  CommandDiagReset(ErrorHandler aHandler, const std::string &aAddr, uint64_t aDiagDataFlags) override;
+    Error CommandDiagReset(const std::string &, uint64_t) override { return ERROR_UNIMPLEMENTED(""); }
 
     Error SetToken(const ByteArray &aSignedToken) override;
 

--- a/src/library/commissioner_safe.cpp
+++ b/src/library/commissioner_safe.cpp
@@ -574,6 +574,19 @@ void CommissionerSafe::Invoke(evutil_socket_t, short, void *aContext)
     }
 }
 
+void CommissionerSafe::CommandDiagReset(ErrorHandler aHandler, const std::string &aAddr, uint64_t aDiagDataFlags)
+{
+    PushAsyncRequest([=]() { mImpl->CommandDiagReset(aHandler, aAddr, aDiagDataFlags); });
+}
+
+Error CommissionerSafe::CommandDiagReset(const std::string &aAddr, uint64_t aDiagDataFlags)
+{
+    std::promise<Error> pro;
+    auto                wait = [&pro](Error error) { pro.set_value(error); };
+    CommandDiagReset(wait, aAddr, aDiagDataFlags);
+    return pro.get_future().get();
+}
+
 void CommissionerSafe::PushAsyncRequest(AsyncRequest &&aAsyncRequest)
 {
     std::lock_guard<std::mutex> _(mInvokeMutex);

--- a/src/library/commissioner_safe.hpp
+++ b/src/library/commissioner_safe.hpp
@@ -143,6 +143,8 @@ public:
 
     void  CommandDiagGetQuery(ErrorHandler aHandler, const std::string &aAddr, uint64_t aDiagDataFlags) override;
     Error CommandDiagGetQuery(const std::string &aAddr, uint64_t aDiagDataFlags) override;
+    void  CommandDiagReset(ErrorHandler aHandler, const std::string &aAddr, uint64_t aDiagDataFlags) override;
+    Error CommandDiagReset(const std::string &aAddr, uint64_t aDiagDataFlags) override;
 
     void  CommandMigrate(ErrorHandler       aHandler,
                          const std::string &aDstAddr,

--- a/tests/integration/test_cli.sh
+++ b/tests/integration/test_cli.sh
@@ -67,3 +67,16 @@ test_execute_diag_command()
 
     stop_daemon
 }
+
+test_execute_diag_command()
+{
+    start_daemon
+    form_network "${PSKC}"
+
+    start_commissioner "${NON_CCM_CONFIG}"
+    petition_commissioner
+    send_command_to_commissioner "netdiag reset maccounters"
+    stop_commissioner
+
+    stop_daemon
+}


### PR DESCRIPTION
This PR adds DIAG_RST notify command into the commissioner module, allowing users to reset MacCounters(9) TLV from a peer Thread device by settting the device's mesh local address and TLV mask bits flag.

Test:

>> config set pskc 445f2b5ca6f2a93a55ce570a70efeecb
[done]
>> start 192.168.9.2 49154
[done]
> netdiag reset maccounters
[done]

>> netdiag query maccounters
Peer Address: fda1:7966:fc90:d97:0:ff:fe00:bc00
Content: {
    "MacCounters": "{\n    \"IfInBroadcastPkts\": 0,\n    \"IfInDiscards\": 0,\n    \"IfInErrors\": 0,\n    \"IfInUcastPkts\": 0,\n    \"IfInUnknownProtos\": 0,\n    \"IfOutBroadcastPkts\": 2,\n    \"IfOutDiscards\": 0,\n    \"IfOutErrors\": 0,\n    \"IfOutUcastPkts\": 0\n}"
}
[done]