### PR TITLE
[github-action] build jobs failure due to deprecated macOS-12 environment

### DIFF
--- a/.github/workflows/android-app-build.yml
+++ b/.github/workflows/android-app-build.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         android-api: [26, 34]
         android-abi: [x86_64]
-        os: [macos-12, ubuntu-22.04]
+        os: [macos-13, ubuntu-22.04]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
           ./tests/interpreter-test
 
   macos:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
       - name: Bootstrap
@@ -163,7 +163,7 @@ jobs:
           ANDROID_ABI=arm64-v8a ANDROID_NDK_HOME=$(find $ANDROID_HOME/ndk -name "26.*") ./build-commissioner-libs.sh
 
   java-binding:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
       - name: Bootstrap

--- a/android/build-commissioner-libs.sh
+++ b/android/build-commissioner-libs.sh
@@ -27,7 +27,7 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-readonly CUR_DIR="$(dirname "$(realpath -s "$0")")"
+readonly CUR_DIR="$(dirname "$(realpath "$0")")"
 
 set -e
 

--- a/android/build-commissioner-libs.sh
+++ b/android/build-commissioner-libs.sh
@@ -33,6 +33,7 @@ if [ "$(uname)" = "Linux" ]; then
 elif [ "$(uname)" = "Darwin" ]; then
     echo "OS is Darwin"
     readonly CUR_DIR="$(dirname "$(realpath "$0")")"
+fi
 
 set -e
 

--- a/android/build-commissioner-libs.sh
+++ b/android/build-commissioner-libs.sh
@@ -27,13 +27,7 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-if [ "$(uname)" = "Linux" ]; then
-    echo "OS is Linux"
-    readonly CUR_DIR="$(dirname "$(realpath -s "$0")")"
-elif [ "$(uname)" = "Darwin" ]; then
-    echo "OS is Darwin"
-    readonly CUR_DIR="$(dirname "$(realpath "$0")")"
-fi
+readonly CUR_DIR="$(dirname "$(realpath "$0")")"
 
 set -e
 

--- a/android/build-commissioner-libs.sh
+++ b/android/build-commissioner-libs.sh
@@ -27,7 +27,7 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-readonly CUR_DIR="$(dirname "$(realpath "$0")")"
+readonly CUR_DIR="$(dirname "$(realpath -s "$0")")"
 
 set -e
 

--- a/android/build-commissioner-libs.sh
+++ b/android/build-commissioner-libs.sh
@@ -27,7 +27,12 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-readonly CUR_DIR="$(dirname "$(realpath "$0")")"
+if [ "$(uname)" = "Linux" ]; then
+    echo "OS is Linux"
+    readonly CUR_DIR="$(dirname "$(realpath -s "$0")")"
+elif [ "$(uname)" = "Darwin" ]; then
+    echo "OS is Darwin"
+    readonly CUR_DIR="$(dirname "$(realpath "$0")")"
 
 set -e
 

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -117,11 +117,7 @@ elif [ "$(uname)" = "Darwin" ]; then
     brew install readline
     brew install cmake
     brew install ninja
-<<<<<<< HEAD
-    brew install swig@4
-=======
     brew install swig
->>>>>>> 170baf0 (execute the realpath command based on OS environment)
     brew install lcov
 
     brew install llvm@14 && \

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -138,7 +138,7 @@ else
     exit 1
 fi
 
-readonly CUR_DIR="$(dirname "$(realpath "$0")")"
+readonly CUR_DIR="$(dirname "$(realpath -s "$0")")"
 
 cd "${CUR_DIR}/.."
 if [ "${WITH_CCM}" = "1" ]; then

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -105,9 +105,6 @@ if [ "$(uname)" = "Linux" ]; then
         echo "Did you forget to add '/usr/bin' to beginning of your PATH?"
         exit 1
     }
-
-    readonly CUR_DIR="$(dirname "$(realpath -s "$0")")"
-
 elif [ "$(uname)" = "Darwin" ]; then
     echo "OS is Darwin"
 
@@ -132,12 +129,12 @@ elif [ "$(uname)" = "Darwin" ]; then
         brew unlink cmake
         brew install cmake --HEAD
     }
-
-    readonly CUR_DIR="$(dirname "$(realpath "$0")")"
 else
     echo "platform $(uname) is not fully supported"
     exit 1
 fi
+
+readonly CUR_DIR="$(dirname "$(realpath "$0")")"
 
 cd "${CUR_DIR}/.."
 if [ "${WITH_CCM}" = "1" ]; then

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -113,12 +113,12 @@ elif [ "$(uname)" = "Darwin" ]; then
 
     ## Install packages
     brew update
-    brew install coreutils \
-                 readline \
-                 cmake \
-                 ninja \
-                 swig@4 \
-                 lcov && true
+    brew install coreutils
+    brew install readline
+    brew install cmake
+    brew install ninja
+    brew install swig@4
+    brew install lcov
 
     brew install llvm@14 && \
     sudo ln -s "$(brew --prefix llvm@14)/bin/clang-format" /usr/local/bin/clang-format-14 && \

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -113,12 +113,21 @@ elif [ "$(uname)" = "Darwin" ]; then
 
     ## Install packages
     brew update
+<<<<<<< HEAD
     brew install coreutils
     brew install readline
     brew install cmake
     brew install ninja
     brew install swig
     brew install lcov
+=======
+    brew install coreutils \
+                    readline \
+                    cmake \
+                    ninja \
+                    swig  \
+                    lcov && true
+>>>>>>> f9ebac8 (execute the realpath command based on OS environment)
 
     brew install llvm@14 && \
     sudo ln -s "$(brew --prefix llvm@14)/bin/clang-format" /usr/local/bin/clang-format-14 && \
@@ -132,11 +141,6 @@ elif [ "$(uname)" = "Darwin" ]; then
         brew unlink cmake
         brew install cmake --HEAD
     }
-
-    ## Install coreutils for realpath
-    brew install coreutils
-
-    brew install ninja
 
     readonly CUR_DIR="$(dirname "$(realpath "$0")")"
 else

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -106,6 +106,8 @@ if [ "$(uname)" = "Linux" ]; then
         exit 1
     }
 
+    readonly CUR_DIR="$(dirname "$(realpath -s "$0")")"
+
 elif [ "$(uname)" = "Darwin" ]; then
     echo "OS is Darwin"
 
@@ -133,12 +135,12 @@ elif [ "$(uname)" = "Darwin" ]; then
 
     ## Install coreutils for realpath
     brew install coreutils
+
+    readonly CUR_DIR="$(dirname "$(realpath "$0")")"
 else
     echo "platform $(uname) is not fully supported"
     exit 1
 fi
-
-readonly CUR_DIR="$(dirname "$(realpath "$0")")"
 
 cd "${CUR_DIR}/.."
 if [ "${WITH_CCM}" = "1" ]; then

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -136,6 +136,8 @@ elif [ "$(uname)" = "Darwin" ]; then
     ## Install coreutils for realpath
     brew install coreutils
 
+    brew install ninja
+
     readonly CUR_DIR="$(dirname "$(realpath "$0")")"
 else
     echo "platform $(uname) is not fully supported"

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -117,7 +117,11 @@ elif [ "$(uname)" = "Darwin" ]; then
     brew install readline
     brew install cmake
     brew install ninja
+<<<<<<< HEAD
     brew install swig@4
+=======
+    brew install swig
+>>>>>>> 170baf0 (execute the realpath command based on OS environment)
     brew install lcov
 
     brew install llvm@14 && \

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -113,21 +113,12 @@ elif [ "$(uname)" = "Darwin" ]; then
 
     ## Install packages
     brew update
-<<<<<<< HEAD
-    brew install coreutils
-    brew install readline
-    brew install cmake
-    brew install ninja
-    brew install swig
-    brew install lcov
-=======
     brew install coreutils \
                     readline \
                     cmake \
                     ninja \
                     swig  \
                     lcov && true
->>>>>>> f9ebac8 (execute the realpath command based on OS environment)
 
     brew install llvm@14 && \
     sudo ln -s "$(brew --prefix llvm@14)/bin/clang-format" /usr/local/bin/clang-format-14 && \

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -138,7 +138,7 @@ else
     exit 1
 fi
 
-readonly CUR_DIR="$(dirname "$(realpath -s "$0")")"
+readonly CUR_DIR="$(dirname "$(realpath "$0")")"
 
 cd "${CUR_DIR}/.."
 if [ "${WITH_CCM}" = "1" ]; then

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -114,11 +114,11 @@ elif [ "$(uname)" = "Darwin" ]; then
     ## Install packages
     brew update
     brew install coreutils \
-                    readline \
-                    cmake \
-                    ninja \
-                    swig  \
-                    lcov && true
+                 readline \
+                 cmake \
+                 ninja \
+                 swig  \
+                 lcov && true
 
     brew install llvm@14 && \
     sudo ln -s "$(brew --prefix llvm@14)/bin/clang-format" /usr/local/bin/clang-format-14 && \

--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -29,14 +29,7 @@
 
 ## This file defines constants and common functions for test cases.
 
-if [ "$(uname)" = "Linux" ]; then
-    echo "OS is Linux"
-    readonly CUR_DIR="$(dirname "$(realpath -s "$0")")"
-elif [ "$(uname)" = "Darwin" ]; then
-    echo "OS is Darwin"
-    readonly CUR_DIR="$(dirname "$(realpath "$0")")"
-fi
-
+readonly CUR_DIR="$(dirname "$(realpath -s "$0")")"
 readonly TEST_ROOT_DIR=${CUR_DIR}
 
 readonly RUNTIME_DIR=/tmp/test-ot-commissioner

--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -35,6 +35,7 @@ if [ "$(uname)" = "Linux" ]; then
 elif [ "$(uname)" = "Darwin" ]; then
     echo "OS is Darwin"
     readonly CUR_DIR="$(dirname "$(realpath "$0")")"
+fi
 
 readonly TEST_ROOT_DIR=${CUR_DIR}
 

--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -29,7 +29,7 @@
 
 ## This file defines constants and common functions for test cases.
 
-readonly CUR_DIR=$(dirname "$(realpath $0)")
+readonly CUR_DIR=$(dirname "$(realpath -s $0)")
 readonly TEST_ROOT_DIR=${CUR_DIR}
 
 readonly RUNTIME_DIR=/tmp/test-ot-commissioner

--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -29,7 +29,13 @@
 
 ## This file defines constants and common functions for test cases.
 
-readonly CUR_DIR=$(dirname "$(realpath -s $0)")
+if [ "$(uname)" = "Linux" ]; then
+    echo "OS is Linux"
+    readonly CUR_DIR="$(dirname "$(realpath -s "$0")")"
+elif [ "$(uname)" = "Darwin" ]; then
+    echo "OS is Darwin"
+    readonly CUR_DIR="$(dirname "$(realpath "$0")")"
+
 readonly TEST_ROOT_DIR=${CUR_DIR}
 
 readonly RUNTIME_DIR=/tmp/test-ot-commissioner

--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -29,7 +29,7 @@
 
 ## This file defines constants and common functions for test cases.
 
-readonly CUR_DIR=$(dirname "$(realpath -s $0)")
+readonly CUR_DIR=$(dirname "$(realpath $0)")
 readonly TEST_ROOT_DIR=${CUR_DIR}
 
 readonly RUNTIME_DIR=/tmp/test-ot-commissioner

--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -29,7 +29,7 @@
 
 ## This file defines constants and common functions for test cases.
 
-readonly CUR_DIR="$(dirname "$(realpath -s "$0")")"
+readonly CUR_DIR=$(dirname "$(realpath -s $0)")
 readonly TEST_ROOT_DIR=${CUR_DIR}
 
 readonly RUNTIME_DIR=/tmp/test-ot-commissioner


### PR DESCRIPTION
The macOS-12 environment is deprecated, consider switching to macOS-13, macOS-14 (macos-latest) or macOS-15.

For more details, see https://github.com/actions/runner-images/issues/10721

In addition, removed the -s option because the -s option is not supported by the realpath command in macOS 13 (Ventura) and later versions, and change the `swig@4` to `swig` due to no available formula with the name "swig@4" in macOS13.