### PR TITLE
[python] remove the occurrence of python2 in the repo

### DIFF
--- a/tools/commissioner_thci/commissionerd.service
+++ b/tools/commissioner_thci/commissionerd.service
@@ -3,7 +3,7 @@ Description=OT-commissioner daemon.
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python2 -u /usr/bin/commissionerd.py -c /usr/bin/commissioner-cli
+ExecStart=/usr/bin/python -u /usr/bin/commissionerd.py -c /usr/bin/commissioner-cli
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
After https://github.com/openthread/ot-commissioner/pull/310 this repo should be compatible with python3 so all python2 occurrences should be removed. 

The only occurrence is in `commissionerd.service` that it launches the service using python2. 

With this PR we can further get rid of python2 occurrences in ot-reference-release repo.