### PR TITLE
[python] explicitly specify python3 as the python interpreter

### DIFF
--- a/tests/integration/common.sh
+++ b/tests/integration/common.sh
@@ -112,7 +112,7 @@ start_commissioner() {
     local config=$1
 
     echo "starting commissioner daemon: [ ${COMMISSIONER_DAEMON} --cli ${COMMISSIONER_CLI} ]"
-    python -u "${COMMISSIONER_DAEMON}" --cli "${COMMISSIONER_CLI}" --timeout 200 > "${COMMISSIONER_DAEMON_LOG}" 2>&1 &
+    python3 -u "${COMMISSIONER_DAEMON}" --cli "${COMMISSIONER_CLI}" --timeout 200 > "${COMMISSIONER_DAEMON_LOG}" 2>&1 &
     sleep 1
 
     pgrep -f "${COMMISSIONER_DAEMON}"

--- a/tools/commissioner_thci/commissionerd.service
+++ b/tools/commissioner_thci/commissionerd.service
@@ -3,7 +3,7 @@ Description=OT-commissioner daemon.
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python -u /usr/bin/commissionerd.py -c /usr/bin/commissioner-cli
+ExecStart=/usr/bin/python3 -u /usr/bin/commissionerd.py -c /usr/bin/commissioner-cli
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
There are places in the repo that uses `python <script>` command to execute the code. This can cause problems when there's python2 interpreter available on the device because the code is for python3 only. This already happens on the OS of ot-reference-release because the image is too old and python2 is still available on that one. 

While there's still a distance before ot-reference-release can migrate to a newer image, we need to fix it here.

This PR also contains the commit of https://github.com/openthread/ot-commissioner/pull/316.