### PR TITLE
refactor Commissioner Resign and KeepAlive handling.

### DIFF
--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -513,7 +513,8 @@ public:
      *
      * This method leaves a Thread network by sending a keep-alive message with the state TLV set
      * to `Reject`. Eventually, the connection will be closed.
-     *
+     * 
+     * @return Error::kNone, succeed; otherwise, failed;
      */
     virtual Error Resign() = 0;
 

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -513,7 +513,7 @@ public:
      *
      * This method leaves a Thread network by sending a keep-alive message with the state TLV set
      * to `Reject`. Eventually, the connection will be closed.
-     * 
+     *
      * @return Error::kNone, succeed; otherwise, failed;
      */
     virtual Error Resign() = 0;

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -511,14 +511,9 @@ public:
     /**
      * @brief Synchronously resign from the commissioner role.
      *
-     * This method petitions to a Thread network with specified border agent address and port.
-     * If succeed, a keep-alive message will be periodically sent to keep itself active.
-     * It will not return until errors happened, timeouted or succeed.
+     * This method leave a Thread network by sending a keep-alive message with the state TLV set
+     * to `Reject`. Eventually, the connection will be closed.
      *
-     * @param aAddr  A border agent address.
-     * @param aPort  A border agent port.
-     *
-     * @return Error::kNone, succeed; otherwise, failed;
      */
     virtual Error Resign() = 0;
 

--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -511,7 +511,7 @@ public:
     /**
      * @brief Synchronously resign from the commissioner role.
      *
-     * This method leave a Thread network by sending a keep-alive message with the state TLV set
+     * This method leaves a Thread network by sending a keep-alive message with the state TLV set
      * to `Reject`. Eventually, the connection will be closed.
      *
      */

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -110,12 +110,23 @@ elif [ "$(uname)" = "Darwin" ]; then
 
     ## Install packages
     brew update
-    brew install coreutils \
-                 readline \
-                 cmake \
-                 ninja \
-                 swig  \
-                 lcov && true
+    
+    # Handle CMake installation conflict
+    if brew list cmake >/dev/null 2>&1; then
+        echo "CMake is already installed, skipping CMake installation"
+        brew install coreutils \
+                     readline \
+                     ninja \
+                     swig  \
+                     lcov && true
+    else
+        brew install coreutils \
+                     readline \
+                     cmake \
+                     ninja \
+                     swig  \
+                     lcov && true
+    fi
 
     brew install llvm@14 && \
     sudo ln -s "$(brew --prefix llvm@14)/bin/clang-format" /usr/local/bin/clang-format-14 && \
@@ -124,11 +135,23 @@ elif [ "$(uname)" = "Darwin" ]; then
     sudo ln -s "$(brew --prefix llvm@14)/bin/run-clang-tidy" /usr/local/bin/run-clang-tidy-14 || \
     echo 'WARNING: could not install clang-format-14, which is useful if you plan to contribute C/C++ code to the OpenThread project.'
 
-    ## Install latest cmake
-    match_version "$(cmake --version | grep -E -o '[0-9].*')" "${MIN_CMAKE_VERSION}" || {
-        brew unlink cmake
+    ## Install latest cmake if needed
+    if command -v cmake >/dev/null 2>&1; then
+        current_cmake_version="$(cmake --version | grep -E -o '[0-9].*')"
+        if match_version "$current_cmake_version" "${MIN_CMAKE_VERSION}"; then
+            echo "CMake $current_cmake_version meets minimum requirement ${MIN_CMAKE_VERSION}"
+        else
+            echo "CMake version $current_cmake_version is less than required ${MIN_CMAKE_VERSION}"
+            if brew list cmake >/dev/null 2>&1; then
+                brew unlink cmake
+                brew install cmake --HEAD
+            else
+                brew install cmake --HEAD
+            fi
+        fi
+    else
         brew install cmake --HEAD
-    }
+    fi
 else
     echo "platform $(uname) is not fully supported"
     exit 1

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -110,23 +110,13 @@ elif [ "$(uname)" = "Darwin" ]; then
 
     ## Install packages
     brew update
-    
-    # Handle CMake installation conflict
-    if brew list cmake >/dev/null 2>&1; then
-        echo "CMake is already installed, skipping CMake installation"
-        brew install coreutils \
-                     readline \
-                     ninja \
-                     swig  \
-                     lcov && true
-    else
-        brew install coreutils \
-                     readline \
-                     cmake \
-                     ninja \
-                     swig  \
-                     lcov && true
-    fi
+
+    brew install coreutils \
+                 readline \
+                 cmake \
+                 ninja \
+                 swig  \
+                 lcov && true
 
     brew install llvm@14 && \
     sudo ln -s "$(brew --prefix llvm@14)/bin/clang-format" /usr/local/bin/clang-format-14 && \
@@ -135,23 +125,11 @@ elif [ "$(uname)" = "Darwin" ]; then
     sudo ln -s "$(brew --prefix llvm@14)/bin/run-clang-tidy" /usr/local/bin/run-clang-tidy-14 || \
     echo 'WARNING: could not install clang-format-14, which is useful if you plan to contribute C/C++ code to the OpenThread project.'
 
-    ## Install latest cmake if needed
-    if command -v cmake >/dev/null 2>&1; then
-        current_cmake_version="$(cmake --version | grep -E -o '[0-9].*')"
-        if match_version "$current_cmake_version" "${MIN_CMAKE_VERSION}"; then
-            echo "CMake $current_cmake_version meets minimum requirement ${MIN_CMAKE_VERSION}"
-        else
-            echo "CMake version $current_cmake_version is less than required ${MIN_CMAKE_VERSION}"
-            if brew list cmake >/dev/null 2>&1; then
-                brew unlink cmake
-                brew install cmake --HEAD
-            else
-                brew install cmake --HEAD
-            fi
-        fi
-    else
+    ## Install latest cmake
+    match_version "$(cmake --version | grep -E -o '[0-9].*')" "${MIN_CMAKE_VERSION}" || {
+        brew unlink cmake
         brew install cmake --HEAD
-    fi
+    }
 else
     echo "platform $(uname) is not fully supported"
     exit 1

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1394,15 +1394,18 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
             }
             else
             {
-                mState = State::kDisabled;
-                Resign([](Error) {});
+                Resign([](Error error) {
+                    if (error != ErrorCode::kNone)
+                    {
+                        LOG_WARN(LOG_REGION_MESHCOP, "failed to resign commissioner: {}", error.ToString());
+                    }
+                });
                 Disconnect();
                 LOG_WARN(LOG_REGION_MESHCOP, "keep alive message rejected: {}", error.ToString());
             }
         }
         else
         {
-            mState = State::kDisabled;
             Disconnect();
             LOG_INFO(LOG_REGION_MESHCOP, "keep alive reject message sent, commissioner disconnected");
         }

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1424,7 +1424,7 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
     }
 #endif
 
-    mBrClient.SendRequest(request, onResponse);
+    SuccessOrExit(error = mBrClient.SendRequest(request, onResponse));
 
     LOG_DEBUG(LOG_REGION_MESHCOP, "sent keep alive message: keepAlive={}", aKeepAlive);
 

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1399,7 +1399,9 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
 
                 LOG_WARN(LOG_REGION_MESHCOP, "keep alive message rejected: {}", error.ToString());
             }
-        } else {
+        }
+       	else
+	{
             mState = State::kDisabled;
             Disconnect();
             LOG_INFO(LOG_REGION_MESHCOP, "keep alive reject message sent, commissioner disconnected");

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1424,7 +1424,7 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
     }
 #endif
 
-    SuccessOrExit(error = mBrClient.SendRequest(request, onResponse));
+    mBrClient.SendRequest(request, onResponse);
 
     LOG_DEBUG(LOG_REGION_MESHCOP, "sent keep alive message: keepAlive={}", aKeepAlive);
 

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1399,7 +1399,7 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
                     {
                         LOG_WARN(LOG_REGION_MESHCOP, "failed to resign commissioner: {}", error.ToString());
                     }
-		    Disconnect();
+                    Disconnect();
                 });
                 LOG_WARN(LOG_REGION_MESHCOP, "keep alive message rejected: {}", error.ToString());
             }

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1394,13 +1394,13 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
             }
             else
             {
-                Resign([](Error error) {
+                Resign([this](Error error) {
                     if (error != ErrorCode::kNone)
                     {
                         LOG_WARN(LOG_REGION_MESHCOP, "failed to resign commissioner: {}", error.ToString());
                     }
+		    Disconnect();
                 });
-                Disconnect();
                 LOG_WARN(LOG_REGION_MESHCOP, "keep alive message rejected: {}", error.ToString());
             }
         }

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1396,12 +1396,12 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
             {
                 mState = State::kDisabled;
                 Resign([](Error) {});
-
+                Disconnect();
                 LOG_WARN(LOG_REGION_MESHCOP, "keep alive message rejected: {}", error.ToString());
             }
         }
-       	else
-	{
+        else
+        {
             mState = State::kDisabled;
             Disconnect();
             LOG_INFO(LOG_REGION_MESHCOP, "keep alive reject message sent, commissioner disconnected");
@@ -1423,11 +1423,6 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
         SuccessOrExit(error = SignRequest(request, tlv::Scope::kMeshCoP, /* aAppendToken */ false));
     }
 #endif
-
-    if (aKeepAlive)
-    {
-        mKeepAliveTimer.Start(GetKeepAliveInterval());
-    }
 
     mBrClient.SendRequest(request, onResponse);
 


### PR DESCRIPTION
Corrected the logic for handling responses to KeepAlive messages. Removed the `Disconnect()` call to `Resign` from within the KeepAlive response handler. Ensured that the commissioner disconnects properly after sending a "Reject" KeepAlive or if sending it fails.