### PR TITLE
[github-action] handle the `cmake` installation conflict on Darwin OS

### DIFF
--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -110,6 +110,7 @@ elif [ "$(uname)" = "Darwin" ]; then
 
     ## Install packages
     brew update
+    brew uninstall cmake || true
     brew install coreutils \
                  readline \
                  cmake \


### PR DESCRIPTION
In current GitHub actions, the runner will pre-install cmake from custom repository. In this change, we need to uninstall the pre-installed cmake to avoid the following error in bootstrap phase.

```
Error: cmake was installed from the local/pinned tap
but you are trying to install it from the homebrew/core tap.
```