### PR TITLE
[meshcop] refactor commissioner resign and keep alive handling logic

### DIFF
--- a/include/commissioner/commissioner.hpp
+++ b/include/commissioner/commissioner.hpp
@@ -511,12 +511,8 @@ public:
     /**
      * @brief Synchronously resign from the commissioner role.
      *
-     * This method petitions to a Thread network with specified border agent address and port.
-     * If succeed, a keep-alive message will be periodically sent to keep itself active.
-     * It will not return until errors happened, timeouted or succeed.
-     *
-     * @param aAddr  A border agent address.
-     * @param aPort  A border agent port.
+     * This method leaves a Thread network by sending a keep-alive message with the state TLV set
+     * to `Reject`. Eventually, the connection will be closed.
      *
      * @return Error::kNone, succeed; otherwise, failed;
      */

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1376,8 +1376,7 @@ exit:
     }
 }
 
-void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive) void CommissionerImpl::SendKeepAlive(Timer &,
-                                                                                                    bool aKeepAlive)
+void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
 {
     Error         error;
     coap::Request request{coap::Type::kConfirmable, coap::Code::kPost};

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1390,7 +1390,7 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
         {
             if (aError == ErrorCode::kNone && error.GetCode() == ErrorCode::kRejected)
             {
-                error = ErrorCode::kNone;
+                error = ERROR_NONE;
             }
             LOG_INFO(LOG_REGION_MESHCOP, "keep alive reject message sent, disconnecting commissioner");
             shouldDisconnect = true;

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1394,14 +1394,12 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive) void Commissioner
         }
         else if (error == ErrorCode::kNone)
         {
-            // Handle keep-alive success case
             mKeepAliveTimer.Start(GetKeepAliveInterval());
             LOG_INFO(LOG_REGION_MESHCOP, "keep alive message accepted, keep-alive timer restarted");
             mCommissionerHandler.OnKeepAliveResponse(error);
         }
         else
         {
-            // Handle keep-alive failure case
             LOG_WARN(LOG_REGION_MESHCOP, "keep alive message rejected: {}", error.ToString());
 
             auto resignHandler = [this, error](Error resignError) {

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1406,13 +1406,14 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
         // Handle keep-alive failure case
         LOG_WARN(LOG_REGION_MESHCOP, "keep alive message rejected: {}", error.ToString());
         
-        auto resignHandler = [this, error](Error resignError) {
+        // Capture error by value since Resign is asynchronous and error needs to outlive this scope
+        auto resignHandler = [this, originalError = error](Error resignError) {
             if (resignError != ErrorCode::kNone)
             {
                 LOG_WARN(LOG_REGION_MESHCOP, "failed to resign commissioner: {}", resignError.ToString());
             }
             Disconnect();
-            mCommissionerHandler.OnKeepAliveResponse(error);
+            mCommissionerHandler.OnKeepAliveResponse(originalError);
         };
         
         Resign(resignHandler);

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1400,17 +1400,8 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
         else
         {
             LOG_WARN(LOG_REGION_MESHCOP, "keep alive message rejected: {}", error.ToString());
-
-            auto resignHandler = [this, error](Error resignError) {
-                if (error != ErrorCode::kNone)
-                {
-                    LOG_WARN(LOG_REGION_MESHCOP, "failed to resign commissioner: {}", resignError.ToString());
-                }
-                mCommissionerHandler.OnKeepAliveResponse(error);
-                Disconnect();
-            };
-
-            Resign(resignHandler);
+            mCommissionerHandler.OnKeepAliveResponse(error);
+            Resign([](Error) {});
         }
     };
 

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1401,7 +1401,8 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
         {
             LOG_WARN(LOG_REGION_MESHCOP, "keep alive message rejected: {}", error.ToString());
             mCommissionerHandler.OnKeepAliveResponse(error);
-            Resign([](Error) {});
+            mKeepAliveTimer.Stop();
+            Disconnect();
         }
     };
 

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1406,8 +1406,9 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
         // Handle keep-alive failure case
         LOG_WARN(LOG_REGION_MESHCOP, "keep alive message rejected: {}", error.ToString());
         
-        // Capture error by value since Resign is asynchronous and error needs to outlive this scope
-        auto resignHandler = [this, originalError = error](Error resignError) {
+        // Store error in a local variable to ensure proper lifetime for async callback
+        const Error originalError = error;
+        auto resignHandler = [this, originalError](Error resignError) {
             if (resignError != ErrorCode::kNone)
             {
                 LOG_WARN(LOG_REGION_MESHCOP, "failed to resign commissioner: {}", resignError.ToString());

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1383,7 +1383,7 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
     auto          state = (aKeepAlive ? tlv::kStateAccept : tlv::kStateReject);
 
     auto onResponse = [this, aKeepAlive](const coap::Response *aResponse, Error aError) {
-        Error error            = HandleStateResponse(aResponse, aError, aKeepAlive);
+        Error error            = HandleStateResponse(aResponse, aError);
         bool  shouldDisconnect = false;
 
         if (!aKeepAlive)

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1383,7 +1383,7 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
     auto          state = (aKeepAlive ? tlv::kStateAccept : tlv::kStateReject);
 
     auto onResponse = [this, aKeepAlive](const coap::Response *aResponse, Error aError) {
-        Error error = HandleStateResponse(aResponse, aError);
+        Error error = HandleStateResponse(aResponse, aError, aKeepAlive);
 
         if (!aKeepAlive)
         {

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1383,7 +1383,7 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
     auto          state = (aKeepAlive ? tlv::kStateAccept : tlv::kStateReject);
 
     auto onResponse = [this, aKeepAlive](const coap::Response *aResponse, Error aError) {
-        const Error error = HandleStateResponse(aResponse, aError);
+        Error error = HandleStateResponse(aResponse, aError);
 
         if (!aKeepAlive)
         {

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1385,7 +1385,7 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
     auto onResponse = [this, aKeepAlive](const coap::Response *aResponse, Error aError) {
         const Error error = HandleStateResponse(aResponse, aError);
 
-        // Handle non-keep-alive case early
+        // Handle keep-alive reject case early
         if (!aKeepAlive)
         {
             Disconnect();

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1384,7 +1384,7 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
 
     auto onResponse = [this, aKeepAlive](const coap::Response *aResponse, Error aError) {
         const Error error = HandleStateResponse(aResponse, aError);
-        
+
         // Handle non-keep-alive case early
         if (!aKeepAlive)
         {
@@ -1405,10 +1405,10 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
 
         // Handle keep-alive failure case
         LOG_WARN(LOG_REGION_MESHCOP, "keep alive message rejected: {}", error.ToString());
-        
+
         // Store error in a local variable to ensure proper lifetime for async callback
         const Error originalError = error;
-        auto resignHandler = [this, originalError](Error resignError) {
+        auto        resignHandler = [this, originalError](Error resignError) {
             if (resignError != ErrorCode::kNone)
             {
                 LOG_WARN(LOG_REGION_MESHCOP, "failed to resign commissioner: {}", resignError.ToString());
@@ -1416,7 +1416,7 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
             Disconnect();
             mCommissionerHandler.OnKeepAliveResponse(originalError);
         };
-        
+
         Resign(resignHandler);
     };
 

--- a/src/library/commissioner_impl.cpp
+++ b/src/library/commissioner_impl.cpp
@@ -1388,7 +1388,11 @@ void CommissionerImpl::SendKeepAlive(Timer &, bool aKeepAlive)
 
         if (!aKeepAlive)
         {
-            LOG_INFO(LOG_REGION_MESHCOP, "keep alive reject message sent, commissioner disconnected");
+            if (aError == ErrorCode::kNone && error.GetCode() == ErrorCode::kRejected)
+            {
+                error = ErrorCode::kNone;
+            }
+            LOG_INFO(LOG_REGION_MESHCOP, "keep alive reject message sent, disconnecting commissioner");
             shouldDisconnect = true;
         }
         else if (error == ErrorCode::kNone)


### PR DESCRIPTION
This pull request refactors the handling of commissioner resignation and keep-alive messages. The logic for disconnecting after sending a "Reject" keep-alive message is now correctly handled in the response callback.