### PR TITLE
[mbedtls] disable MBEDTLS_HAVE_ASM for MemorySanitizer builds

### DIFF
--- a/third_party/mbedtls/mbedtls-config.h
+++ b/third_party/mbedtls/mbedtls-config.h
@@ -47,7 +47,16 @@
 #define MBEDTLS_ECP_NIST_OPTIM
 #define MBEDTLS_ENTROPY_C
 #define MBEDTLS_ERROR_C
+
+// Define __has_feature for non-Clang compilers
+#ifndef __has_feature
+#define __has_feature(x) 0
+#endif
+// Disable asm for Clang MemorySanitizer builds, since MemorySanitizer does not support assembly implementations.
+#if !__has_feature(memory_sanitizer)
 #define MBEDTLS_HAVE_ASM
+#endif
+
 #define MBEDTLS_HMAC_DRBG_C
 #define MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
 #define MBEDTLS_MD_C


### PR DESCRIPTION
- [Matter Repo](https://github.com/project-chip/connectedhomeip) uses ot-commissioner as a third-party dependency.

- Building Matter with MSan fails since MBEDTLS_HAVE_ASM is always enabled; and MbedTLS does not support Assembly with MSAN, as indicated in the following [Code Extract](https://github.com/Mbed-TLS/mbedtls/blob/c765c831e5c2a0971410692f92f7a81d6ec65ec2/include/mbedtls/check_config.h#L242-L253)

- This is part of the matter effort https://github.com/project-chip/connectedhomeip/issues/71500

- Fix: Ensure MBEDTLS_HAVE_ASM is disabled when Clang MSan is enabled
