### PR TITLE
[test] add `ba_port` to `unsecureport` list in native test

### DIFF
--- a/tests/integration/test_native_commissioner.sh
+++ b/tests/integration/test_native_commissioner.sh
@@ -86,6 +86,7 @@ test_native_commissioner()
     ot_ctl channel 11
     ot_ctl panid 0xface
     ot_ctl ifconfig up
+    ot_ctl unsecureport add "${ba_port}"
 
     start_commissioner "${NON_CCM_CONFIG}"
 


### PR DESCRIPTION
This commit updates the `test_native_commissioner` integration test to explicitly add the border agent port to the unsecure port list of the OpenThread daemon using the `ot_ctl unsecureport add` command.

In this test, the Thread interface of the daemon node is disabled so that it transmits unsecure 15.4 frames to the border agent on behalf of the commissioner. Adding the port to the `unsecureport` list ensures that the daemon can properly receive unsecure UDP traffic on this port from the border agent.