### PR TITLE
[test] enable `allwhendisabled` unsecure port in native test

### DIFF
--- a/tests/integration/test_native_commissioner.sh
+++ b/tests/integration/test_native_commissioner.sh
@@ -86,6 +86,7 @@ test_native_commissioner()
     ot_ctl channel 11
     ot_ctl panid 0xface
     ot_ctl ifconfig up
+    ot_ctl unsecureport allwhendisabled enable
 
     start_commissioner "${NON_CCM_CONFIG}"
 


### PR DESCRIPTION
This commit updates the `test_native_commissioner.sh` integration test to enable the `allwhendisabled` unsecure port feature on the OpenThread daemon.

In this test, the Thread interface of the daemon node is disabled so that it transmits unsecure 802.15.4 frames to the border agent on behalf of the commissioner. Enabling the `allwhendisabled` feature ensures that the daemon can properly receive unsecure UDP traffic from the border agent while Thread function is disabled.

----

Depends-On: openthread/openthread#13050